### PR TITLE
change default channel for vm ha operators

### DIFF
--- a/docs/en/virtualization/virtualization/virtual_machine/how_to/vm_availability.mdx
+++ b/docs/en/virtualization/virtualization/virtual_machine/how_to/vm_availability.mdx
@@ -66,7 +66,7 @@ G --> H[Workload Rescheduling]
     Configuration Parameters:
     | **Parameter**   | **Recommended Configuration**                          |
     | :-------------- | :----------------------------------------------------- |
-    | **Channel**   | The default channel is `alpha`.                        |
+    | **Channel**   | The default channel is `stable`.                        |
     | **Installation Mode** | `Cluster`: All namespaces in the cluster share a single Operator instance for creation and management, resulting in lower resource usage. |
     | **Installation Place** | Select `Recommended`, Namespace only support **workload-availability**.|
     | **Upgrade Strategy** | `Manual`: When there is a new version in the Operator Hub, manual confirmation is required to upgrade the Operator to the latest version. |
@@ -181,7 +181,7 @@ Parameters
     Configuration Parameters:
     | **Parameter**   | **Recommended Configuration**                          |
     | :-------------- | :----------------------------------------------------- |
-    | **Channel**   | The default channel is `alpha`.                        |
+    | **Channel**   | The default channel is `stable`.                        |
     | **Installation Mode** | `Cluster`: All namespaces in the cluster share a single Operator instance for creation and management, resulting in lower resource usage. |
     | **Installation Place** | Select `Recommended`, Namespace only support **workload-availability**.|
     | **Upgrade Strategy** | `Manual`: When there is a new version in the Operator Hub, manual confirmation is required to upgrade the Operator to the latest version. |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to recommend the "stable" channel as the default for Self Node Remediation Operator and Node Health Check Operator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->