### PR TITLE
[upgrade doc]: prerequisite of ACP v4.1

### DIFF
--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -5,7 +5,7 @@ weight: 20
 
 ## Important notes before upgrade
 
-* Supported platform versions for upgrade: `3.16.0`, `3.16.1`, `3.16.2`, `3.18.0`, `3.18.1`, `3.18.2`, `4.0.0`, `4.0.1`.
+* Supported platform versions for upgrade: `3.18.0`, `3.18.1`, `3.18.2`, `4.0.0`, `4.0.1`, `4.0.2`, `4.0.3`.
   Ensure your current platform version is within this supported range before upgrading.
 
 * The **Kubernetes version** of all clusters in the platform must be **at least 1.28**.
@@ -37,7 +37,7 @@ Contact technical support to obtain the **checklist script** and run it against 
 
 ### Download the upgrade package
 
-For platforms upgrading from version `3.16` or `3.18` to `4.0`, the **upgrade package is the same as the installation package**.
+For platforms upgrading from version `3.18` to `4.1`, the **upgrade package is the same as the installation package**.
 Refer to [Download Installation Package](../install/prepare/download.mdx) for instructions.
 
 </Steps>

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -97,22 +97,6 @@ If any such nodes exist, contact technical support to resolve them before contin
   4. Select `global` from the cluster dropdown.
   5. Find the **EtcdSync** plugin and click **Uninstall**. Wait for the uninstallation to complete.
   </Tab>
-
-  <Tab label="Upgrading from 3.16">
-  Log into any **control plane node** of the **primary global cluster**, then run:
-
-```bash
-helm3 del etcd-sync -n default 2> /dev/null
-helm3 del etcd-sync -n cpaas-system 2> /dev/null
-
-kubectl delete configmaps,secret -n kube-system   etcd-master-mirror-cert etcd-slave-mirror-cert etcd-sync-env   etcd-sync-ignore-text &> /dev/null
-
-kubectl delete deploy -n kube-system etcd-mirror-etcd-mirror &> /dev/  null
-
-kubectl get pod -n kube-system | grep etcd-mirror  # Ensure no   etcd-mirror pods remain
-```
-
-  </Tab>
 </Tabs>
 
 ### Upgrade the standby global cluster


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the list of supported platform versions for upgrade, now covering versions from 3.18.0 to 4.0.3.
  * Revised the upgrade package description to reflect the new supported upgrade paths.
  * Removed manual command-line instructions for uninstalling the etcd sync plugin when upgrading from version 3.16 in the global cluster upgrade procedure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->