### PR TITLE
[upgrade-doc]:least k8s version before upgrading

### DIFF
--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -8,7 +8,7 @@ weight: 20
 * Supported platform versions for upgrade: `3.18.0`, `3.18.1`, `3.18.2`, `4.0.0`, `4.0.1`, `4.0.2`, `4.0.3`.
   Ensure your current platform version is within this supported range before upgrading.
 
-* The **Kubernetes version** of all clusters in the platform must be **at least 1.28**.
+* The **Kubernetes version** of all clusters in the platform must be **at least 1.30**.
   If any cluster is below this version, upgrade its Kubernetes version first.
 
 * If the platform has a cluster with a **service mesh** provided by the platform, ensure that its **Istio version is 1.20 or higher**. Otherwise, upgrade the service mesh before proceeding.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the minimum required Kubernetes version for clusters before upgrading from 1.28 to 1.30.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->