### PR TITLE
fix keda docs of startingCSV version

### DIFF
--- a/docs/en/developer/building_application/operation_maintaining/keda_autoscaler/install_keda_operator.mdx
+++ b/docs/en/developer/building_application/operation_maintaining/keda_autoscaler/install_keda_operator.mdx
@@ -52,7 +52,7 @@ spec:
   name: keda
   source: custom
   sourceNamespace: cpaas-system
-  startingCSV: keda.v2.16.0
+  startingCSV: keda.v2.17.2
 EOF
 ```
 Configuration Parameters:
@@ -66,7 +66,7 @@ Configuration Parameters:
 | **spec.name** | `keda`: The operator package name, must be **keda**.  |
 | **spec.source** | `custom`: The catalog source of keda operator, must be **custom**.   |
 | **spec.sourceNamespace** | `cpaas-system`: The namespace of catalog source, must be **cpaas-system**.   |
-| **spec.startingCSV** | `keda.v2.16.0`: The starting CSV name of keda operator.   |
+| **spec.startingCSV** | `keda.v2.17.2`: The starting CSV name of keda operator.   |
 
 ### Creating the KedaController instance
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to reference the latest KEDA operator version (v2.17.2) and revised related configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->