### PR TITLE
docs: add known issue note for rds-updater upgrade failure

### DIFF
--- a/docs/en/appservice/upgrade.mdx
+++ b/docs/en/appservice/upgrade.mdx
@@ -16,3 +16,6 @@ When upgrading ACP from v3 to v4, it is recommended to promptly upgrade both the
 If only the global cluster is upgraded to v4 while workload clusters remain on v3, please contact the technical team during this period to obtain mitigation steps for view display issues in unupgraded workload clusters.
 :::
 
+:::note
+**Known Issue**: In rare cases, automatic upgrades might fail due to a bug that causes the update-manager to crash repeatedly during the upgrade of the `rds-updater` component. If this occurs, manually uninstall the `rds-operator`. The system will automatically reinstall the `rds-operator` and resume the upgrade process.
+:::


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a Known Issue to the upgrade guide describing a rare case where the update manager may crash during the rds-updater step. The note includes clear remediation: manually uninstall the rds-operator; it will be reinstalled automatically and the upgrade will resume. This update improves transparency during upgrades and provides users with a quick recovery path if encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->