### PR TITLE
Builds Operator 拆分成独立 L5 插件

### DIFF
--- a/docs/en/developer/s2i/functions/s2i_application_management.mdx
+++ b/docs/en/developer/s2i/functions/s2i_application_management.mdx
@@ -21,7 +21,7 @@ i18n:
 
 ## Prerequisites
 
-- [Installing Alauda Container Platform Builds](../install_builds/install_builds_operator.mdx) is completed.
+- [Installing Alauda Container Platform Builds](./../install_builds/install_builds_operator.mdx) is completed.
 - Access to a image repository is required; if unavailable, contact the Administrator to [Installing Alauda Container Platform Registry](/developer/registry/install/index.mdx)
 
 ## Procedure

--- a/docs/en/developer/s2i/overview/architecture.mdx
+++ b/docs/en/developer/s2i/overview/architecture.mdx
@@ -9,7 +9,7 @@ title: Architecture
 
 # Architecture
 
-![Source to Image Architecture](./assets/s2i-archtecture.png "Source to Image Architecture")
+![Source to Image Architecture](./../assets/s2i-archtecture.png "Source to Image Architecture")
 
 Source to Image (S2I) capability is implemented through the **Alauda Container Platform Builds** operator,
 enabling automated container image builds from Git repository source code and subsequent pushes to a designated image registry. 

--- a/docs/en/developer/s2i/overview/index.mdx
+++ b/docs/en/developer/s2i/overview/index.mdx
@@ -1,0 +1,10 @@
+---
+weight: 10
+i18n:
+  title:
+    en: Overview
+---
+
+# Overview
+
+<Overview />

--- a/docs/en/developer/s2i/overview/intro.mdx
+++ b/docs/en/developer/s2i/overview/intro.mdx
@@ -47,5 +47,5 @@ The main application scenarios for S2I are as follows:
 > The current version only supports Java, Go, Python, and Node.js languages.
 
 :::warning
-Prerequisites: Tekton Operator is now available in the cluster OperatorHub.
+Prerequisites: [Alauda DevOps Pipelines operator](https://docs.alauda.io/alauda-devops-pipelines) is now available in the cluster OperatorHub.
 :::

--- a/docs/en/developer/s2i/overview/lifecycle_policy.mdx
+++ b/docs/en/developer/s2i/overview/lifecycle_policy.mdx
@@ -1,0 +1,19 @@
+---
+weight: 40
+i18n:
+  title:
+    en: Lifecycle Policy
+---
+
+# Lifecycle Policy
+
+# Version Lifecycle Timeline  
+
+Below is the lifecycle schedule for released versions of the Alauda Container Platform Builds Operator:
+
+
+| **Version** | **Release Date** | **End of Life** |
+|:-----------:|:----------------:|:---------------:|
+| v1.1.0      | 2025-08-15       | 2027-08-15      |
+
+

--- a/docs/en/developer/s2i/overview/releasenote.mdx
+++ b/docs/en/developer/s2i/overview/releasenote.mdx
@@ -1,0 +1,34 @@
+---
+weight: 30
+i18n:
+  title:
+    en: Release Notes
+---
+
+# Release Notes
+
+## Alauda Container Platform Builds Release Notes
+
+The release notes for the **Alauda Container Platform Builds** operator describe new features and enhancements, deprecated features, and known issues.
+
+:::info
+The **Alauda Container Platform Builds** operator is provided as an installable component, with a distinct release cycle from the core <Term name="product"/>. The [Alauda Container Platform Builds operator Lifecycle Policy](./lifecycle_policy.mdx) outlines release compatibility.
+:::
+
+## Supported Versions
+
+| **Version** | **<Term name="product"/> Version** | **Alauda DevOps Pipelines Version** |
+|:-----------:|:-----------------------------------:|:-----------------------------------:| 
+| **v1.1.0**  | **v4.1**                            | **v4.1**                            |
+
+## v1.1 Release Notes
+### v1.1.0
+
+1. Security Vulnerability Remediation.
+2. Independently Releasable.
+
+
+
+
+
+

--- a/docs/en/developer/s2i/upgrade/index.mdx
+++ b/docs/en/developer/s2i/upgrade/index.mdx
@@ -2,10 +2,10 @@
 weight: 12
 i18n:
   title:
-    en: Upgrading
+    en: Upgrade
     zh: 升级
 ---
 
-# Upgrading
+# Upgrade
 
 <Overview />

--- a/docs/en/developer/s2i/upgrade/upgrade_builds_operator.mdx
+++ b/docs/en/developer/s2i/upgrade/upgrade_builds_operator.mdx
@@ -22,8 +22,9 @@ i18n:
 
 <Directive type="info" title="INFO">
 If you are upgrading from version v4.0 and earlier, first migrate the **Alauda DevOps Tekton v3** to **Alauda DevOps Pipelines**.
-For details, see the <ExternalSiteLink name="devops" href="devops-initialization/cicd/migrating-tekton-v3-to-v4.md" children="migration guide" />.
+For details, see the <ExternalSiteLink name="devops" href="4.0/upgrade/migrating-tekton-v3-to-v4.md" children="migration guide" />.
 </Directive>
+
 
 1. Log in, and navigate to the **Administrator** page.
 2. Click **Marketplace** > **OperatorHub**.


### PR DESCRIPTION
Builds Operator 拆分成独立 L5 插件，调整文档结构以及更新 DevOps 升级引用相关内容