### PR TITLE
add ldapID parameter to docker-registry chart

### DIFF
--- a/docs/en/developer/registry/install/install_via_yaml.mdx
+++ b/docs/en/developer/registry/install/install_via_yaml.mdx
@@ -47,6 +47,8 @@ weight: 15
           expose: false
           isIPv6: false
           replicas: 2
+          oidc:
+            ldapID: ""
           resources:
             limits:
               cpu: 500m
@@ -87,6 +89,9 @@ weight: 15
     ```yaml
     spec:
       config:
+        global:
+          oidc:
+            ldapID: "<LDAP-ID>"                   # LDAP ID
         ingress:
           hosts:
             - name: "<YOUR-DOMAIN>"                # e.g., registry.your-company.com
@@ -127,6 +132,7 @@ weight: 15
 
 | Parameter | Description | Example Value |
 |-----------|-------------|---------------|
+| `spec.config.global.oidc.ldapID` | LDAP ID for OIDC authentication | `ldap-test` |
 | `spec.config.ingress.hosts[0].name` | Custom domain for registry access | `registry.yourcompany.com` |
 | `spec.config.ingress.hosts[0].tlsCert` | TLS certificate secret reference (namespace/secret-name) | `cpaas-system/registry-tls` |
 | `spec.config.ingress.ingressClassName` | Ingress class name for the registry | `cluster-alb-1` |
@@ -152,7 +158,7 @@ weight: 15
 
 ### Update
 
-Execute the following command on the global cluster::
+Execute the following command on the global cluster and update the values in the resource according to the parameter descriptions provided above to complete the update:
 ```bash
 # <CLUSTER-NAME> is the cluster where the plugin is installed
 kubectl edit -n cpaas-system \


### PR DESCRIPTION
(cherry picked from commit 1d4637ee1d88c58d9e67dd0af9fbfa643a65282e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced OIDC LDAP ID configuration: spec.config.global.oidc.ldapID, with examples and description.
  * Updated YAML install template to use a global.oidc block and reflect the new structure.
  * Expanded customization example to include spec.config.global.oidc.ldapID with a placeholder.
  * Refreshed configuration reference with a new mandatory field entry for the LDAP ID.
  * Revised update instructions to align with the new parameters and template structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->