### PR TITLE
fix: gpu quotas

### DIFF
--- a/docs/en/developer/building_application/namespace/resource_quota.mdx
+++ b/docs/en/developer/building_application/namespace/resource_quota.mdx
@@ -73,6 +73,8 @@ kubectl create resourcequota example-resourcequota --namespace=<example> --hard=
 
 ##  Hardware accelerator Resources Quotas \{#extended-resources-quotas}
 
+When `Alauda Build of Hami` or `NVIDIA GPU Device Plugin` installed, you will be able to use extended resources quotas about hardware accelerator.
+
 Refer to [Alauda Build of Hami](../../../hardware_accelerator/hami.mdx) and [Alauda Build of NVIDIA GPU Device Plugin](../../../hardware_accelerator/pgpu.mdx).
 
 ### Other Quotas

--- a/docs/en/hardware_accelerator/pgpu.mdx
+++ b/docs/en/hardware_accelerator/pgpu.mdx
@@ -1,5 +1,5 @@
 
-# About Alauda build of NVIDIA GPU device plugin
+# About Alauda build of NVIDIA GPU Device Plugin
 
 The NVIDIA device plugin for Kubernetes is a Daemonset that allows you to automatically:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Hardware Accelerator Resource Quotas: noted that extended quotas are available when Alauda Build of Hami or the NVIDIA GPU Device Plugin is installed.
  * Updated page title to “About Alauda Build of NVIDIA GPU Device Plugin” for consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->