### PR TITLE
fix: update displayname of hami

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -21,8 +21,8 @@
   repo: https://github.com/alauda/aml-docs
 - name: hami
   displayName:
-    en: Alauda Hami
-    zh: Alauda Hami
+    en: Alauda Build of Hami
+    zh: Alauda Build of Hami
   base: /hami
   version: "2.6"
   repo: https://github.com/alauda/hami-docs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the site’s display name from “Alauda Hami” to “Alauda Build of Hami” in both English and Chinese.
  * The new name appears consistently across the UI, including titles, navigation, selectors, and notifications, to align with current branding.
  * Users will see the updated name immediately with no changes to workflows or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->