### PR TITLE
fix: typo of gpu

### DIFF
--- a/docs/en/hardware_accelerator/hami.mdx
+++ b/docs/en/hardware_accelerator/hami.mdx
@@ -1,5 +1,5 @@
 
-# About Alauda build of Hami
+# About Alauda Build of Hami
 
 Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k8s-vGPU-scheduler, is an "all-in-one" chart designed to manage Heterogeneous AI Computing Devices in a k8s cluster. It can provide the ability to share Heterogeneous AI devices among tasks.
 

--- a/docs/en/hardware_accelerator/pgpu.mdx
+++ b/docs/en/hardware_accelerator/pgpu.mdx
@@ -1,5 +1,5 @@
 
-# About Alauda build of NVIDIA GPU Device Plugin
+# About Alauda Build of NVIDIA GPU Device Plugin
 
 The NVIDIA device plugin for Kubernetes is a Daemonset that allows you to automatically:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized capitalization of H1 titles to “Alauda Build” in hardware accelerator docs:
    - HAMI documentation
    - NVIDIA GPU Device Plugin (pGPU) documentation
  * Improves consistency and readability across docs.
  * No content, behavior, or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->