### PR TITLE
Restructure and expand certificate documentation

### DIFF
--- a/docs/en/security/cert/index.mdx
+++ b/docs/en/security/cert/index.mdx
@@ -1,0 +1,8 @@
+---
+weight: 70
+title: Certificates
+---
+
+# Certificates
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/security/cert/k8s-cert-rotator.mdx
+++ b/docs/en/security/cert/k8s-cert-rotator.mdx
@@ -1,9 +1,9 @@
 ---
 weight: 10
-title: Automated Rotate
+title: Automated Kubernetes Certificate Rotation
 ---
 
-# Automated Rotate Kuberentes Certificates
+# Automated Kubernetes Certificate Rotation
 
 This guide helps you install, understand, and operate the Kubernetes Certificate Rotator in <Term name="productShort" textCase="upper" /> to automate the rotation of Kubernetes certificates within your clusters.
 
@@ -89,7 +89,7 @@ cert-renew --ca-cert <ca-cert-path> --ca-key <ca-key-path> --days <days> <certif
 For example to renew the `kubelet.crt`:
 
 ```bash
-cert-renew --ca-cert /etc/kubernetes/pki/ca.crt --ca-key /etc/kubernetes/pki/ca.key --days 91 /etc/kubenetes/pki/kubelet.crt
+cert-renew --ca-cert /etc/kubernetes/pki/ca.crt --ca-key /etc/kubernetes/pki/ca.key --days 91 /etc/kubernetes/pki/kubelet.crt
 ```
 
 To download and prepare the `cert-renew` tool, run:

--- a/docs/en/security/cert/k8s-cert-rotator.mdx
+++ b/docs/en/security/cert/k8s-cert-rotator.mdx
@@ -1,6 +1,6 @@
 ---
-weight: 91
-title: Automated Rotate Kuberentes Certificates
+weight: 10
+title: Automated Rotate
 ---
 
 # Automated Rotate Kuberentes Certificates

--- a/docs/en/security/cert/olm.mdx
+++ b/docs/en/security/cert/olm.mdx
@@ -1,0 +1,10 @@
+---
+weight: 20
+title: OLM Certificates
+---
+
+# OLM Certificates
+
+All certificates for **Operator Lifecycle Manager (OLM)** components — including `olm-operator`, `catalog-operator`, `packageserver`, and `marketplace-operator` — are automatically managed by the system.
+
+When installing Operators that define **webhooks** or **API services** in their **ClusterServiceVersion (CSV)** object, OLM automatically generates and rotates the required certificates.


### PR DESCRIPTION
Moved Kubernetes certificate rotator docs to the security/cert section, added an index page for certificates, and introduced new documentation for OLM certificate management. This improves organization and clarity of certificate-related documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Certificates" overview page.
  * Added an "OLM Certificates" page describing automatic certificate management and rotation for OLM components and Operator webhooks/API services.
  * Updated Kubernetes certificate rotator doc: lowered navigation weight, shortened/clarified title, and corrected wording and command example.
  * No product or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->