### PR TITLE
Restructure and update certificate documentation

### DIFF
--- a/docs/en/security/cert/index.mdx
+++ b/docs/en/security/cert/index.mdx
@@ -1,0 +1,8 @@
+---
+weight: 70
+title: Certificates
+---
+
+# Certificates
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/security/cert/k8s-cert-rotator.mdx
+++ b/docs/en/security/cert/k8s-cert-rotator.mdx
@@ -1,9 +1,9 @@
 ---
-weight: 91
-title: Automated Rotate Kuberentes Certificates
+weight: 10
+title: Automated Kubernetes Certificate Rotation
 ---
 
-# Automated Rotate Kuberentes Certificates
+# Automated Kubernetes Certificate Rotation
 
 This guide helps you install, understand, and operate the Kubernetes Certificate Rotator in <Term name="productShort" textCase="upper" /> to automate the rotation of Kubernetes certificates within your clusters.
 
@@ -89,7 +89,7 @@ cert-renew --ca-cert <ca-cert-path> --ca-key <ca-key-path> --days <days> <certif
 For example to renew the `kubelet.crt`:
 
 ```bash
-cert-renew --ca-cert /etc/kubernetes/pki/ca.crt --ca-key /etc/kubernetes/pki/ca.key --days 91 /etc/kubenetes/pki/kubelet.crt
+cert-renew --ca-cert /etc/kubernetes/pki/ca.crt --ca-key /etc/kubernetes/pki/ca.key --days 91 /etc/kubernetes/pki/kubelet.crt
 ```
 
 To download and prepare the `cert-renew` tool, run:

--- a/docs/en/security/cert/olm.mdx
+++ b/docs/en/security/cert/olm.mdx
@@ -1,0 +1,10 @@
+---
+weight: 20
+title: OLM Certificates
+---
+
+# OLM Certificates
+
+All certificates for **Operator Lifecycle Manager (OLM)** components — including `olm-operator`, `catalog-operator`, `packageserver`, and `marketplace-operator` — are automatically managed by the system.
+
+When installing Operators that define **webhooks** or **API services** in their **ClusterServiceVersion (CSV)** object, OLM automatically generates and rotates the required certificates.


### PR DESCRIPTION
Moved Kubernetes certificate rotator documentation to the security/cert section, created an index page for certificate docs, and added a new page for OLM certificate management. Updated titles, weights, and minor text corrections for clarity and organization.