### PR TITLE
fix:external link in upgrade

### DIFF
--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -78,11 +78,11 @@ Review the available component updates shown in the dialog, and confirm to conti
 
 ### Post-upgrade
 
-- <ExternalSiteLink name="ai" href="1.3/upgrade/upgrade-from-aml-1.2.html" children="Upgrade Alauda AI" />
+- <ExternalSiteLink name="ai" href="/upgrade/upgrade-from-aml-1.2.html" children="Upgrade Alauda AI" />
 
-- <ExternalSiteLink name="devops" href="4.0/upgrade/index.html" children="Upgrade Alauda DevOps" />
+- <ExternalSiteLink name="devops" href="/upgrade/index.html" children="Upgrade Alauda DevOps" />
 
-- <ExternalSiteLink name="servicemesh" href="4.0/upgrade.html" children="Upgrade Alauda Service Mesh" />
+- <ExternalSiteLink name="servicemesh" href="/upgrade.html" children="Upgrade Alauda Service Mesh" />
 
 ## global DR procedure \{#global_dr}
 

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -43,8 +43,8 @@ However, since service disruptions may still occur during other component update
 
 ## Post-upgrade
 
-- <ExternalSiteLink name="ai" href="1.3/upgrade/upgrade-from-aml-1.2.html" children="Upgrade Alauda AI" />
+- <ExternalSiteLink name="ai" href="/upgrade/upgrade-from-aml-1.2.html" children="Upgrade Alauda AI" />
 
-- <ExternalSiteLink name="devops" href="4.0/upgrade/index.html" children="Upgrade Alauda DevOps" />
+- <ExternalSiteLink name="devops" href="/upgrade/index.html" children="Upgrade Alauda DevOps" />
 
-- <ExternalSiteLink name="servicemesh" href="4.0/upgrade.html" children="Upgrade Alauda Service Mesh" />
+- <ExternalSiteLink name="servicemesh" href="/upgrade.html" children="Upgrade Alauda Service Mesh" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Post-upgrade links in global and workload cluster upgrade guides to use root-relative paths for AI, DevOps, and Service Mesh sections, replacing versioned relative URLs.
  * This improves link consistency and reduces the chance of navigating to outdated version-specific pages.
  * Minor formatting cleanup (added trailing newline) with no content or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->