### PR TITLE
Add uid/gid assignment

### DIFF
--- a/docs/en/developer/building_application/namespace/uid_gid_assign.mdx
+++ b/docs/en/developer/building_application/namespace/uid_gid_assign.mdx
@@ -1,0 +1,93 @@
+---
+weight: 50
+---
+
+# UID/GID Assignment
+
+In Kubernetes, each Pod runs with a specific User ID (UID) and Group ID (GID) to ensure security and proper access control. By default, Pods may run as the root user (UID 0), which can pose security risks. To enhance security, it's recommended to assign non-root UIDs and GIDs to Pods.
+
+ACP allows to auto assign a namespace with specific UID and GID ranges to ensure that all Pods within the namespace run with the designated user and group IDs.
+
+## Enable UID/GID Assignment
+
+To enable UID/GID assignment for a namespace, follow these steps:
+
+1. Enter **Project Management**.
+2. In the left navigation bar, click **Namespace**.
+3. Click on the target namespace.
+4. Click **Actions** > **Upate Pod Security Policy**.
+5. Change the **Enforce** option value to **Restricted**, click **Update**.
+6. Click edit icon next to **Labels**, add a label with key `security.cpaas.io/enabled` and value `true`, click **Update**. (To disable, remove this label or set the value to `false`.)
+8. Click **Save**.
+
+## Verify UID/GID Assignment
+
+### The UID/GID Range
+
+In the namespace details page, you can view the assigned UID and GID ranges in the **Annotations**.
+
+The **security.cpaas.io/uid-range** annotation specifies the range of UID/GIDs that can be assigned to Pods in the namespace, e.g. **security.cpaas.io/uid-range=1000002000-1000011999**, means the uid/gid range is between 1000002000 to 1000011999.
+
+### Verify the Pod UID/GID
+
+If the pod does not specify `runAsUser` and `fsGroup` in the `securityContext`, the platform will automatically assign the first value from the assigned uid range.
+
+1. Create a Pod in the namespace with the following YAML configuration:
+
+    ```yaml
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: uid-gid-test-pod
+    spec:
+      containers:
+      - name: test-container
+        image: busybox
+        command: ["sleep", "3600"]
+    ```
+
+2. After the Pod is created, get the Pod yaml to check the assigned UID and GID:
+
+    ```bash
+    kubectl get pod uid-gid-test-pod -n <namespace-name> -o yaml
+    ```
+
+the Pod YAML will show the assigned UID and GID in the `securityContext` section:
+
+  ```yaml
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: uid-gid-test-pod
+  spec:
+    containers:
+    - name: test-container
+      image: busybox
+      command: ["sleep", "3600"]
+      securityContext:
+        runAsUser: 1000000
+    securityContext:
+      fsGroup: 1000000
+  ```
+
+If the pod specifies runAsUser and fsGroup in the securityContext, the platform will validate if the specified UID/GID are within the assigned range. If they are not, the Pod creation will fail.
+
+1. Create a Pod in the namespace with the following YAML configuration:
+
+   ```yaml
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: uid-gid-test-pod-invalid
+   spec:
+     containers:
+     - name: test-container
+       image: busybox
+       command: ["sleep", "3600"]
+       securityContext:
+         runAsUser: 2000000  # Invalid UID, outside the assigned range
+     securityContext:
+       fsGroup: 2000000  # Invalid GID, outside the assigned range
+   ```
+
+2. After applying the YAML, the Pod creation will fail with an error message indicating that the specified UID/GID are outside the assigned range.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New guide on configuring UID/GID assignment for Kubernetes namespaces in ACP.
  * Explains enabling via security settings and a namespace label.
  * Describes defining an allowed UID/GID range with a namespace annotation.
  * Clarifies pod behavior: automatic assignment when not specified and validation when specified.
  * Includes example Pod manifests for success and failure cases and verification via kubectl.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->