### PR TITLE
docs:Update the devops link version in site.yaml.

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -87,7 +87,7 @@
     en: Alauda DevOps
     zh: Alauda DevOps
   base: /devops
-  version: "4.0"
+  version: "4.1"
   repo: https://github.com/alauda/devops-docs
 - name: alauda-container-security
   displayName:


### PR DESCRIPTION
Update the devops link version in site.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the DevOps site version to 4.1. All other site details remain the same. This is a routine version bump with no impact on existing features or user workflows. No visual changes are introduced, and behavior remains consistent. Deployment and navigation continue to function as before across all supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->