### PR TITLE
add nodelocal endpoint

### DIFF
--- a/docs/en/configure/networking/functions/endpoint_health_checker.mdx
+++ b/docs/en/configure/networking/functions/endpoint_health_checker.mdx
@@ -1,0 +1,147 @@
+---
+weight: 400
+---
+
+# Endpoint Health Checker
+
+## Overview
+
+The Endpoint Health Checker is a cluster plugin designed to monitor and manage the health status of service endpoints. It automatically removes unhealthy endpoints from load balancers to ensure traffic is only routed to healthy instances, improving overall service reliability and availability.
+
+## Key Features
+
+- **Automatic Health Monitoring**: Continuously monitors the health status of service endpoints
+- **Load Balancer Integration**: Automatically removes unhealthy endpoints from load balancer rotation
+- **Service Availability**: Ensures traffic is only directed to healthy, available endpoints
+
+## Installation
+
+### Install via Marketplace
+
+1. Navigate to **Administrator** > **Marketplace** > **Cluster Plugins**.
+
+2. Search for "**Alauda Container Platform Endpoint Health Checker**" in the plugin list.
+
+3. Click **Install** to open the installation configuration page.
+
+4. Wait for the plugin status to change to "**Ready**".
+
+## How It Works
+
+### Health Check Mechanism
+
+The Endpoint Health Checker is a dedicated health monitoring component that ensures only healthy endpoints receive traffic. It operates by monitoring service endpoints and automatically managing their availability status.
+
+#### Core Functionality
+
+The Endpoint Health Checker works by:
+
+1. **Service Discovery**: Identifies services and pods configured for health monitoring
+2. **Pod Health Monitoring**: Monitors the readiness and liveness probe status of pods backing the service endpoints
+3. **Active Health Checks**: Performs active health assessments using configurable criteria:
+   - **TCP connectivity checks**: Establishes TCP connections to verify port accessibility
+   - **HTTP/HTTPS response validation**: Sends HTTP requests and validates response codes and content
+4. **Endpoint Management**: Automatically removes unhealthy endpoints from service endpoint lists to prevent traffic routing to failed instances
+
+#### Health Check Process
+
+The health checking process involves:
+
+- **Probe Integration**: Leverages Kubernetes readiness and liveness probe results as initial health indicators
+- **Network Connectivity**: Sends TCP or HTTP packets to target endpoint ports to verify accessibility
+- **Response Validation**: Evaluates response status, timing, and content to determine endpoint health
+- **Automatic Failover**: Removes unresponsive or failed endpoints from load balancer rotation
+
+#### Activation Methods
+
+Health checking can be activated through two methods:
+
+1. **Pod-level annotation (Recommended)**:
+
+   Add the annotation to the pod template in your Deployment:
+
+   ```yaml
+   apiVersion: apps/v1
+   kind: Deployment
+   metadata:
+     name: nginx-demo
+   spec:
+     replicas: 10
+     selector:
+       matchLabels:
+         app: nginx-demo
+     template:
+       metadata:
+         labels:
+           app: nginx-demo
+         annotations:
+           endpoint-health-checker.io/enabled: "true"
+       spec:
+         containers:
+           - name: nginx
+             image: nginx:alpine
+             ports:
+               - containerPort: 80
+             livenessProbe:
+               tcpSocket:
+                 port: 80
+               initialDelaySeconds: 15
+               periodSeconds: 10
+             readinessProbe:
+               tcpSocket:
+                 port: 80
+               initialDelaySeconds: 5
+               periodSeconds: 5
+   ```
+
+2. **Pod-level readinessGates (Legacy)**:
+
+   Configure readinessGates in the pod spec for older versions:
+
+   ```yaml
+   apiVersion: apps/v1
+   kind: Deployment
+   metadata:
+     name: nginx-demo-legacy
+   spec:
+     replicas: 5
+     selector:
+       matchLabels:
+         app: nginx-demo-legacy
+     template:
+       metadata:
+         labels:
+           app: nginx-demo-legacy
+       spec:
+         readinessGates:
+           - conditionType: "endpointHealthCheckSuccess"
+         containers:
+           - name: nginx
+             image: nginx:alpine
+             ports:
+               - containerPort: 80
+             livenessProbe:
+               tcpSocket:
+                 port: 80
+               initialDelaySeconds: 15
+               periodSeconds: 10
+             readinessProbe:
+               tcpSocket:
+                 port: 80
+               initialDelaySeconds: 5
+               periodSeconds: 5
+   ```
+   
+   > **Note**: The readinessGates configuration is from an older version. It's recommended to use the pod annotation `endpoint-health-checker.io/enabled: "true"` for new deployments.
+
+## Uninstallation
+
+To uninstall the Endpoint Health Checker:
+
+1. Navigate to **Administrator** > **Marketplace** > **Cluster Plugins**.
+
+2. Find the installed "**Endpoint Health Checker**" plugin.
+
+3. Click the options menu and select **Uninstall**.
+
+4. Confirm the uninstallation when prompted.

--- a/docs/en/configure/networking/functions/node_local_dns.mdx
+++ b/docs/en/configure/networking/functions/node_local_dns.mdx
@@ -1,0 +1,99 @@
+---
+weight: 500
+---
+
+# NodeLocal DNSCache
+
+## Overview
+
+NodeLocal DNSCache is a cluster plugin that improves cluster DNS performance by running a DNS caching proxy on cluster nodes. This plugin reduces DNS query latency and improves cluster stability by caching DNS responses locally on each node, minimizing the load on the central DNS service.
+
+## Key Features
+
+- **Local DNS Caching**: Caches DNS responses locally on each node to reduce query latency
+- **Improved Performance**: Significantly reduces DNS lookup times for applications
+
+## Important Notes
+
+:::warning
+**Deployment Considerations:**
+
+1. **Kube-OVN Underlay Mode**: The plugin does not support deployment in Kube-OVN Underlay mode. If deployed, it may cause DNS query failures.
+
+2. **Kubelet Restart**: Deploying this plugin will cause the kubelet to restart.
+
+3. **Pod Restart Required**: After the plugin is successfully deployed, it will not affect running Pods, but will only take effect on newly created Pods. When the CNI is Kube-OVN, you need to manually add the parameter "--node-local-dns-ip=(IP address of the local DNS cache server)" to the kube-ovn-controller.
+
+4. **NetworkPolicy Configuration**: If NetworkPolicy is configured in the cluster, you need to additionally allow both from and to directions for the node CIDR and nodeLocalDNSIP in the networkPolicy to ensure proper communication.
+:::
+
+## Installation
+
+### Install via Marketplace
+
+1. Navigate to **Administrator** > **Marketplace** > **Cluster Plugins**.
+
+2. Search for "**Alauda Build of NodeLocal DNSCache**" in the plugin list.
+
+3. Click **Install** to open the installation configuration page.
+
+4. Configure the required parameters:
+
+   | Parameter | Description | Example Value |
+   |-----------|-------------|---------------|
+   | **IP** | The IP address of the node local DNS cache server. For IPv4, it is recommended to use an address within the 169.254.0.0/16 range, preferably 169.254.20.10. For IPv6, it is recommended to use an address within the fd00::/8 range, preferably fd00::10. | 169.254.20.10 |
+
+5. Review the deployment notes and ensure your environment meets the requirements.
+
+6. Click **Install** to complete the installation.
+
+7. Wait for the plugin status to change to "**Ready**".
+
+## How It Works
+
+### Architecture
+
+```
+Pod → NodeLocal DNSCache → [Cache Hit] → Pod
+           ↓
+    [Cache Miss] → CoreDNS → Response → Cache & Pod
+```
+
+## Configuration
+
+### Network Policy Configuration
+
+> **Important**: If your cluster has NetworkPolicy enabled, you must configure proper rules to allow DNS traffic to the NodeLocal DNSCache. Without these rules, pods may not be able to resolve DNS queries.
+
+When using NetworkPolicy, ensure the following DNS traffic is allowed:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-cache
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 169.254.20.10/32 # NodeLocal DNS IP address
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 169.254.20.10/32 # NodeLocal DNS IP address
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+```
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a page for the Endpoint Health Checker plugin: overview, features (automatic health monitoring, load balancer integration), installation/uninstallation via Marketplace, activation options (pod annotation or readiness gates), and health check behavior (TCP/HTTP(S), probe integration, automatic endpoint removal).
  - Added a page for NodeLocal DNSCache: purpose and benefits, deployment notes/limitations, installation with configurable NodeLocal DNS IP (IPv4/IPv6), architecture diagram, and required NetworkPolicy examples to permit DNS traffic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->