### PR TITLE
nfs and snapshot plugin install via yaml

### DIFF
--- a/docs/en/configure/storage/functions/nfs_storageclass.mdx
+++ b/docs/en/configure/storage/functions/nfs_storageclass.mdx
@@ -13,19 +13,26 @@ Unlike the traditional client-server model of NFS access, NFS shared storage uti
 
 - An NFS server must be configured, and its access methods must be obtained. Currently, the platform supports three NFS protocol versions: `v3`, `v4.0`, and `v4.1`. You can execute `nfsstat -s` on the server side to check the version information.
 
-## Deploying the NFS Shared Storage Plugin
+## Deploying the Alauda Container Platform NFS CSI plugin
 
+### Deploying via Web Console
 1. Enter **Administrator**.
 
-2. In the left navigation bar, click **Storage Management** > **Storage Classes**.
+2. In the left navigation bar, click **Storage** > **StorageClasses**.
 
-3. Click **Create Storage Class**.
+3. Click **Create StorageClass**.
 
-4. On the right side of **NFS Shared Storage**, click Deploy to navigate to the **Plugins** page.
+4. On the right side of **NFS CSI**, click Deploy to navigate to the **Plugins** page.
 
-5. On the right side of the **NFS** plugin, click ⋮ > **Deploy**.
+5. On the right side of the `Alauda Container Platform NFS CSI` plugin, click ⋮ > **Install**.
 
 6. Wait for the deployment status to indicate **Deployment Successful** before completing the deployment.
+
+### Deploying via YAML
+
+Refs to [Installing via YAML](../../../extend/cluster_plugin.mdx#installing-via-yaml)
+
+`Alauda Container Platform NFS CSI` is a **Non-config plugin**, and the module-name is `nfs`
 
 ## Creating an NFS Shared Storage Class
 
@@ -33,7 +40,7 @@ Unlike the traditional client-server model of NFS access, NFS shared storage uti
 
    **Note**: The following content is presented in a form, but you may also choose to complete the operation using YAML.
 
-2. Select **NFS Shared Storage** and click **Next**.
+2. Select **NFS CSI** and click **Next**.
 
 3. Refer to the following instructions to configure the relevant parameters.
 

--- a/docs/en/configure/storage/functions/snapshot_con.mdx
+++ b/docs/en/configure/storage/functions/snapshot_con.mdx
@@ -17,12 +17,16 @@ Currently, the platform only supports creating volume snapshots for PVCs that ar
 | **CephRBD Block Storage**                     | Supported                    | Not Supported              | Not Supported               |
 | **CephFS File Storage**                       | Supported                    | **Supported**              | Supported                   |
 
-## Procedure
+## Deploying via Web Console
 
 1. Go to **Administrator**.
 
-2. In the left navigation bar, click on **Storage Management** > **Volume Snapshots**.
+2. Click **Marketplace** > **Cluster Plugins** to access the **Cluster Plugins** list page.
 
-3. Click on **Quick Deployment**, which will redirect you to the cluster plugin.
+3. Locate the `Alauda Container Platform Snapshot Management` cluster plugin, click **Install**, and wait for a moment until the deployment is successful.
 
-4. Click on the ⋮ > **Deploy** next to **Snapshot Controller**, and wait for a moment until the deployment is successful.
+## Deploying via YAML
+
+Refs to [Installing via YAML](../../../extend/cluster_plugin.mdx#installing-via-yaml)
+
+`Alauda Container Platform Snapshot Management` is a **Non-config plugin**, and the module-name is `snapshot`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rebranded NFS plugin references to “Alauda Container Platform NFS CSI,” updated Web Console navigation (Storage > StorageClasses), changed action label to Install, and aligned selection labels. Added “Deploying via YAML” with note that it’s a Non-config plugin (module: nfs).
  * Updated snapshot docs: renamed section to “Deploying via Web Console,” revised path to Marketplace > Cluster Plugins to install “Alauda Container Platform Snapshot Management,” and added “Deploying via YAML” noting Non-config plugin (module: snapshot).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->