### PR TITLE
Upgrade/violet push

### DIFF
--- a/docs/en/extend/upload_package.mdx
+++ b/docs/en/extend/upload_package.mdx
@@ -136,20 +136,6 @@ violet push plugins-cloudedge-v0.3.16-hybrid.tgz \
 
 > **Note:** You do not need to specify the `--clusters` parameter when uploading a Cluster Plugin, as the platform will automatically distribute it based on its affinity configuration. If you specify `--clusters`, the parameter will be ignored.
 
-### Upload All Packages in a Directory \{#upload_all_packages}
-
-When multiple packages are downloaded from the Marketplace, you can place them in the same directory and upload them all at once:
-
-```bash
-violet push <packages_dir_name> \
-  --platform-address https://192.168.0.1 \
-  --platform-username <user> \
-  --platform-password <password>
-```
-
-The tool automatically detects the package types in the directory.
-
-
 ### Upload a Helm Chart
 
 Upload a Helm Chart to the chart repository:
@@ -167,3 +153,32 @@ For more details, run:
 ```bash
 violet --help
 ```
+
+### Push only images from all packages in a directory \{#only_push_images}
+
+When multiple packages are downloaded from the Marketplace, you can place them in the same directory and upload them all at once:
+
+```bash
+violet push <packages_dir_name> \
+  --skip-crs \
+  --platform-address https://192.168.0.1 \
+  --platform-username <user> \
+  --platform-password <password>
+```
+
+With the `--skip-crs` flag, **only images are pushed**, while the creation of `Artifact` and `ArtifactVersion` resources is skipped.
+This prevents Operators or Cluster Plugins from being updated prematurely during the <Term name="productShort" /> upgrade process.
+
+### Create only CRs from all packages in a directory \{#only_create_cr}
+
+When multiple packages are downloaded from the Marketplace, you can place them in the same directory and upload them all at once:
+
+```bash
+violet push <packages_dir_name> \
+  --skip-push \
+  --platform-address https://192.168.0.1 \
+  --platform-username <user> \
+  --platform-password <password>
+```
+
+With the `--skip-push` flag, **only `Artifact` and `ArtifactVersion` resources are created**, while images are not pushed.

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -18,29 +18,28 @@ If the global cluster is configured with the **global DR (Disaster Recovery)** s
 
 Copy the core package to **any control plane node** of the global cluster. Extract the package and `cd` into the extracted directory.
 
-- If the global cluster uses the **built-in registry**, run:
+* If the global cluster uses the **built-in registry**, run:
 
   ```bash
   bash upgrade.sh --only-sync-image=true
   ```
 
-- If the global cluster uses an **external registry**, you also need to provide the registry address:
+* If the global cluster uses an **external registry**, you also need to provide the registry address:
 
   ```bash
   bash upgrade.sh --only-sync-image=true --registry <registry-address> --username <username> --password <password>
   ```
 
-If you want to upgrade Operators and Cluster Plugins together with the cluster upgrade, you must upload the Extensions to the platform **before upgrading ACP Core** using **violet**.
+If you plan to upgrade the **Operator** and **Cluster Plugin** together during the global cluster upgrade, you can pre-push their images to the global cluster’s registry in advance.
+For bulk upload instructions, see [Push only images from all packages in a directory](../extend/upload_package.mdx#only_push_images).
 
-For bulk upload instructions, see [Upload All Packages in a Directory](../extend/upload_package.mdx#upload_all_packages).
-
-When using **`violet push`** on a **standby global cluster**, you must specify the `--dest-repo` parameter with the VIP of the standby cluster.
+When using **`violet push`** on a **standby global cluster**, you must specify the `--dest-repo` parameter with the standby cluster VIP.
 For details, see [Upload Packages in a Global DR Environment](../install/global_dr.mdx#upload_dr_packages).
 
 <Directive type="info" title="INFO">
 Uploading images typically takes about 2 hours, depending on your network and disk performance.
 
-If your platform uses the global DR, remember that the **standby global cluster also requires image upload**, and plan your maintenance window accordingly.
+If your platform is configured for global disaster recovery (DR), remember that the **standby global cluster also requires image upload**. Be sure to plan your maintenance window accordingly. 
 </Directive>
 
 ### Trigger the upgrade
@@ -53,25 +52,28 @@ bash upgrade.sh --skip-sync-image
 
 Wait for the script to finish before proceeding.
 
+If you have already pre-pushed the Operator and Cluster Plugin images to the global cluster’s registry, you can then follow [Create only CRs from all packages in a directory](../extend/upload_package.mdx#only_create_cr). After running this command, wait about **10–15 minutes** until upgrade notifications appear for functional components. You will then be able to upgrade the Operator and Cluster Plugin together as part of the subsequent upgrade steps.
+
 ### Upgrade the global cluster
 
 <Directive type="warning" title="WARNING">
-If the platform has **Data Services** installed, you must also upgrade the related extensions when upgrading clusters.
+If the platform has **Data Services** installed, you must also upgrade the related extensions when upgrading clusters.  
 For details, see [Upgrade Data Services](../appservice/upgrade.mdx).
 </Directive>
 
-1. Log into the Web Console of the global cluster and switch to **Administrator** view.
+1. Log in to the Web Console of the global cluster and switch to **Administrator** view.
 2. Navigate to **Clusters > Clusters**.
 3. Click on the `global` cluster to open its detail view.
 4. Go to the **Functional Components** tab.
 5. Click the **Upgrade** button.
 
-Review the available component updates shown in the dialog, and confirm to continue.
+Review the available component updates in the dialog, and confirm to proceed.
 
 <Directive type="info" title="INFO">
-- Upgrading the Kubernetes version is optional. However, since service disruptions may occur regardless, we recommend including the Kubernetes upgrade to avoid multiple maintenance windows.
+- Upgrading the Kubernetes version is optional. However, since service disruptions may occur regardless, we recommend including the Kubernetes upgrade to avoid multiple maintenance windows.  
 
-- If the **Alauda Container Platform GitOps** is installed in the global cluster, and after the upgrading, the pods of the plugin is running abnormally.Please refer to [Upgrading Alauda Container Platform GitOps](/gitops/upgrade/upgrade_gitops_plugin.html#procedure).
+* If the **Alauda Container Platform GitOps** plugin is installed in the global cluster and its pods are running abnormally after the upgrade, refer to [Upgrading Alauda Container Platform GitOps](/gitops/upgrade/upgrade_gitops_plugin.html#procedure).
+
 </Directive>
 
 </Steps>

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -30,7 +30,7 @@ Copy the core package to **any control plane node** of the global cluster. Extra
   bash upgrade.sh --only-sync-image=true --registry <registry-address> --username <username> --password <password>
   ```
 
-If you plan to upgrade the **Operator** and **Cluster Plugin** together during the global cluster upgrade, you can pre-push their images to the global cluster’s registry in advance.
+If you plan to upgrade the **Operator** and **Cluster Plugin** together during the global cluster upgrade, you can pre-push their images to the global cluster's registry in advance.
 For bulk upload instructions, see [Push only images from all packages in a directory](../extend/upload_package.mdx#only_push_images).
 
 When using **`violet push`** on a **standby global cluster**, you must specify the `--dest-repo` parameter with the standby cluster VIP.
@@ -52,7 +52,7 @@ bash upgrade.sh --skip-sync-image
 
 Wait for the script to finish before proceeding.
 
-If you have already pre-pushed the Operator and Cluster Plugin images to the global cluster’s registry, you can then follow [Create only CRs from all packages in a directory](../extend/upload_package.mdx#only_create_cr). After running this command, wait about **10–15 minutes** until upgrade notifications appear for functional components. You will then be able to upgrade the Operator and Cluster Plugin together as part of the subsequent upgrade steps.
+If you have already pre-pushed the Operator and Cluster Plugin images to the global cluster's registry, you can then follow [Create only CRs from all packages in a directory](../extend/upload_package.mdx#only_create_cr). After running this command, wait about **10–15 minutes** until upgrade notifications appear for functional components. You will then be able to upgrade the Operator and Cluster Plugin together as part of the subsequent upgrade steps.
 
 ### Upgrade the global cluster
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured “Upload Package” guide with clearer flows: upload a Helm chart, push only images from a directory, or create only CRs from a directory; added examples and clarified default chart repository; linked to in-tool help.
  * Updated global cluster upgrade guide to support pre-pushing images and a create-only-CRs path; removed bulk upload requirement.
  * Refined DR terminology and guidance; standardized “standby cluster” phrasing.
  * Added note for GitOps plugin behavior post-upgrade.
  * Minor editorial and wording improvements for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->