### PR TITLE
feat: add doc acp-node-planning.mdx

### DIFF
--- a/docs/en/configure/clusters/acp-node-planning.mdx
+++ b/docs/en/configure/clusters/acp-node-planning.mdx
@@ -2,22 +2,22 @@
 weight: 20
 ---
 
-# ACP Node Planning
+# Cluster Node Planning
 
-ACP utilizes the Kubernetes node role labels `node-role.kubernetes.io/<role>` to assign different roles to nodes. For convenience of description, we refer to this type of label as a role label.
+A cluster utilizes the Kubernetes node role labels `node-role.kubernetes.io/<role>` to assign different roles to nodes. For convenience of description, we refer to this type of label as a role label.
 
-By default, an ACP cluster contains two types of nodes: control plane nodes and worker nodes, used to host control plane workloads and application workloads, respectively.
+By default, a cluster contains two types of nodes: control plane nodes and worker nodes, used to host control plane workloads and application workloads, respectively.
 
-In ACP:
+In a cluster:
 - The control plane nodes are labeled with the role label `node-role.kubernetes.io/control-plane`.
 
     > **Note:**
     >
-    >  Prior to Kubernetes v1.24, the community also used the label `node-role.kubernetes.io/master` to mark control plane nodes. To maintain compatibility with older versions, ACP recognizes both as valid labels for control plane nodes.
+    >  Prior to Kubernetes v1.24, the community also used the label `node-role.kubernetes.io/master` to mark control plane nodes. For backward compatibility, both labels are considered valid for identifying control plane nodes.
 
 - The worker nodes, by default, have no role labels. However, you can explicitly assign the role label `node-role.kubernetes.io/worker` to a worker node if desired.
 
-In addition to these default role labels, ACP also allows you to define custom role labels on worker nodes to further classify them into different functional types. For example:
+In addition to these default role labels, you can also define custom role labels on worker nodes to further classify them into different functional types. For example:
 
 - You can add the role label `node-role.kubernetes.io/infra` to designate a node as an infra node, intended for hosting infrastructure components.
 
@@ -25,11 +25,15 @@ In addition to these default role labels, ACP also allows you to define custom r
 
 This document will guide you through creating infra nodes and custom role nodes, and migrating workloads to those nodes.
 
-## Creating Infra Nodes
+## Creating Infra Nodes on Non-Immutable Cluster  
 
-By default, an ACP cluster only includes control plane nodes and worker nodes. If you want to designate certain worker nodes as infra nodes dedicated to hosting infrastructure components, you need to manually add the appropriate role label and taint to those nodes.
+By default, a cluster only includes control plane nodes and worker nodes. If you want to designate certain worker nodes as infra nodes dedicated to hosting infrastructure components, you need to manually add the appropriate role label and taint to those nodes.
 
-### Adding Infra Nodes in a Standard Cluster
+> **Note:**
+>
+> The operations in this section are only applicable to non-immutable clusters. That is, the following operations are not supported on cloud clusters (such as EKS managed clusters deployed via the `Alauda Container Platform EKS Provider` Cluster Plugin), third-party clusters, or clusters where the nodes use an immutable OS.
+
+### Adding Infra Nodes
 
 #### Step 1: Add the Infra Role Label to the Node resources
 
@@ -60,9 +64,9 @@ Taints:             node-role.kubernetes.io/infra=reserved:NoSchedule
 
 The output indicates that the Node 192.168.143.133 has been configured as an infra node and has been tainted with tainted with `node-role.kubernetes.io/infra=reserved:NoSchedule`.
 
-## Migrating Workloads to Infra Nodes
+## Migrating Pods to Infra Nodes
 
-If you want to schedule specific workloads (e.g., Deployments, Jobs, DaemonSets) onto infra nodes, you need to configure the workloads with:
+If you want to schedule specific Pod onto infra nodes, you need to make the following configurations:
 
 - A nodeSelector targeting the infra role label.
 - Corresponding tolerations for the infra node's taint.
@@ -71,31 +75,30 @@ Below is an example Deployment manifest configured to run on the infra node.
 
 ```yaml
 apiVersion: apps/v1
-kind: Deployment
+kind: Pod
 metadata:
-  name: my-workload
+  name: infra-pod-demo
   namespace: default
 spec:
-  template:
-    metadata:
-      labels:
-        ...
-    spec:
-      ...
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        value: reserved
-        operator: Exists
-      ...
+  ...
+  nodeSelector:
+    node-role.kubernetes.io/infra: ""
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/infra
+    value: reserved
+    operator: Equal
+  ...
 ```
 
 The nodeSelector ensures the Pod is only scheduled on nodes with the label `node-role.kubernetes.io/infra: ""`,
-the tolerationallows the Pod to tolerate the taint node-role.kubernetes.io/infra=reserved:NoSchedule.
+the toleration allows the Pod to tolerate the taint node-role.kubernetes.io/infra=reserved:NoSchedule.
 
-With these configurations, the Deployment will be scheduled onto the infra node.
+With these configurations, the Pod will be scheduled onto the infra node.
+
+> **Note:**
+>
+> Moving pods installed via OLM Operators or Cluster Plugins to an infra node is not always possible. The capability to move these pods is depends on the configuration of each Operator or Cluster Plugin.
 
 ## Custom Node Planning
 
@@ -133,7 +136,7 @@ Ensure the Labels and Taints fields reflect your custom role configuration.
 
 If you want to create a node specifically for installing logging components, you can add the log role. In this case, create the log node as follows.
 
-### Step 1: Add the Log Role Label
+#### Step 1: Add the Log Role Label
 
 ```bash
 kubectl label nodes 192.168.143.133 node-role.kubernetes.io/log="" --overwrite
@@ -141,7 +144,7 @@ kubectl label nodes 192.168.143.133 node-role.kubernetes.io/log="" --overwrite
 
 This label indicates that the node is designated for log-related workloads.
 
-### Step 2: Add a Taint to the Node
+#### Step 2: Add a Taint to the Node
 
 ```bash
 kubectl taint nodes 192.168.143.133 node-role.kubernetes.io/log=reserved:NoSchedule
@@ -149,7 +152,7 @@ kubectl taint nodes 192.168.143.133 node-role.kubernetes.io/log=reserved:NoSched
 
 This taint prevents unscheduled workloads from being deployed to the node.
 
-### Step 3: Verify the Label and Taint
+#### Step 3: Verify the Label and Taint
 
 ```yaml
 Name:               192.168.143.133
@@ -161,5 +164,5 @@ Taints:             node-role.kubernetes.io/log=reserved:NoSchedule
 
 This confirms that the node has been successfully configured as a log node with the appropriate label and taint.
 
-By following the above practices, you can effectively partition your Kubernetes nodes within ACP based on their intended purpose, improve workload isolation, and ensure that specific components are deployed onto appropriately configured infrastructure.
+By following the above practices, you can effectively partition your Kubernetes nodes based on their intended purpose, improve workload isolation, and ensure that specific components are deployed onto appropriately configured nodes.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added an ACP Node Planning guide covering node roles, defaults, and legacy label compatibility.
  - Introduces custom roles (infra, log) and steps to create and verify infra nodes using labels and NoSchedule taints.
  - Describes migrating workloads to infra nodes with nodeSelectors and tolerations, including a sample Deployment manifest.
  - Outlines creating additional custom roles, verification steps, and guidance on partitioning nodes to isolate workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->