### PR TITLE
chore: backup the original ETCD encryption keys

### DIFF
--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -286,7 +286,16 @@ It should look like:
               secret: MTE0NTE0MTkxOTgxMA==
     ```
 
-2. Merge that ETCD encryption key into the primary cluster's `/etc/kubernetes/encryption-provider.conf` file, ensuring the key names are unique. For example, if the primary cluster's key is `key1`, rename the standby's key to `key2`:
+2. Backup the ETCD encryption key of the primary cluster on any of its control plane nodes (assuming the node is 1.1.1.1):
+
+    ```bash
+    # login into the primary cluster's control plane nodes 1.1.1.1
+    ssh "<user>@1.1.1.1"
+    sudo /bin/cp -f /etc/kubernetes/encryption-provider.conf /etc/kubernetes/encryption-provider.conf.bak
+    ```
+
+3. Merge the ETCD encryption key of the standby cluster into the `/etc/kubernetes/encryption-provider.conf` file on node `1.1.1.1`, ensuring the key names are unique.
+For example, if the primary cluster's key is `key1`, rename the standby's key to `key2`:
 
     ```yaml
     apiVersion: apiserver.config.k8s.io/v1
@@ -303,13 +312,13 @@ It should look like:
               secret: MTE0NTE0MTkxOTgxMA==
     ```
 
-3. Make sure the new `/etc/kubernetes/encryption-provider.conf` file overwrites EVERY replicas on the control plane nodes of both clusters:
+4. Make sure the new `/etc/kubernetes/encryption-provider.conf` file overwrites EVERY replicas on the control plane nodes of both clusters:
 
     ```bash
-    # Let the control plane nodes of the primary cluster are 1.1.1.1, 2.2.2.2 & 3.3.3.3
+    # Assume the control plane nodes of the primary cluster are 1.1.1.1, 2.2.2.2 & 3.3.3.3
     # the control plane nodes of the standby cluster are 4.4.4.4, 5.5.5.5 & 6.6.6.6
 
-    # assume the 1.1.1.1 has already been configured to use both of the ETCD encryption keys,
+    # Since the 1.1.1.1 has already been configured to use both of the ETCD encryption keys,
     # login into the node 1.1.1.1, and issue the following commands:
     for i in \
         2.2.2.2 3.3.3.3 \
@@ -320,7 +329,9 @@ It should look like:
     #!/bin/bash
     set -euo pipefail
     
-    sudo install -o root -g root -m 600 /tmp/encryption-provider.conf /etc/kubernetes/encryption-provider.conf && rm -f /tmp/encryption-provider.conf
+    sudo /bin/cp -f /etc/kubernetes/encryption-provider.conf /etc/kubernetes/encryption-provider.conf.bak
+    sudo install -o root -g root -m 600 /tmp/encryption-provider.conf /etc/kubernetes/encryption-provider.conf
+    sudo rm -f /tmp/encryption-provider.conf
     _pod_name="kube-apiserver"
     _pod_id=$(sudo crictl ps --name "${_pod_name}" --no-trunc --quiet)
     if [[ -z "${_pod_id}" ]]; then

--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -286,12 +286,12 @@ It should look like:
               secret: MTE0NTE0MTkxOTgxMA==
     ```
 
-2. Backup the ETCD encryption key of the primary cluster on any of its control plane nodes (assuming the node is 1.1.1.1):
+2. Back up the ETCD encryption key on any primary control plane node (e.g., 1.1.1.1):
 
     ```bash
     # login into the primary cluster's control plane nodes 1.1.1.1
     ssh "<user>@1.1.1.1"
-    sudo /bin/cp -f /etc/kubernetes/encryption-provider.conf /etc/kubernetes/encryption-provider.conf.bak
+    sudo install -o root -g root -m 600 /etc/kubernetes/encryption-provider.conf /etc/kubernetes/encryption-provider.conf.bak
     ```
 
 3. Merge the ETCD encryption key of the standby cluster into the `/etc/kubernetes/encryption-provider.conf` file on node `1.1.1.1`, ensuring the key names are unique.
@@ -329,9 +329,12 @@ For example, if the primary cluster's key is `key1`, rename the standby's key to
     #!/bin/bash
     set -euo pipefail
     
-    sudo /bin/cp -f /etc/kubernetes/encryption-provider.conf /etc/kubernetes/encryption-provider.conf.bak
-    sudo install -o root -g root -m 600 /tmp/encryption-provider.conf /etc/kubernetes/encryption-provider.conf
+    sudo install -o root -g root -m 600 \
+        /etc/kubernetes/encryption-provider.conf /etc/kubernetes/encryption-provider.conf.bak
+    sudo install -o root -g root -m 600 \
+        /tmp/encryption-provider.conf            /etc/kubernetes/encryption-provider.conf
     sudo rm -f /tmp/encryption-provider.conf
+    
     _pod_name="kube-apiserver"
     _pod_id=$(sudo crictl ps --name "${_pod_name}" --no-trunc --quiet)
     if [[ -z "${_pod_id}" ]]; then

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -16,7 +16,7 @@ Before upgrading, ensure that your current platform version is within this suppo
 
 | Condition | Requirement | If Not Met |
 | --------- | ----------- | ---------- |
-| **Service mesh (Istio)** | All clusters running **1.22 or later** | Upgrade Istio and its instances BEFORE upgrading `Kubernetes` |
+| **Service mesh (Istio)** | All clusters running **1.22 or later** | Upgrade `Istio` and its instances BEFORE upgrading `Kubernetes` or <Term name="productShort" /> |
 | **Kubernetes** | All clusters running **1.30 or later** | Upgrade Kubernetes BEFORE upgrading <Term name="productShort" />; be aware to upgrade `Istio` FIRST |
 | **Elasticsearch logging** | Must comply with the fix described in *How to Correct the Issue of Node Role Settings in Big Cluster Elasticsearch* (see Custom Portal > Knowledge) | Apply the fix before upgrade |
 | **Disk space on `/cpaas/minio` (global cluster control plane)** | At least **120 GB free** | Expand storage |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a backup step for the primary control plane’s encryption configuration before merging the standby key.
  - Introduced a new step to merge the standby key; example now shows two keys with updated secrets.
  - Renumbered and reordered steps and clarified that the updated file should overwrite replicas.
  - Limited the apply/push loop to primary cluster nodes only.
  - Updated remote update procedure: backup current config, apply new config, remove temporary artifacts, and restart affected services.
  - Improved phrasing for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->