### PR TITLE
AIT-61302 allow specify etcd addresses for etcd-sync

### DIFF
--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -75,7 +75,7 @@ The roles of **Primary Cluster** and **Standby Cluster** are relative: the clust
 
   * Preconfigure the load balancer to route TCP traffic on ports `80`, `443`, `6443`, `2379`, and `11443` to the control-plane nodes behind the corresponding VIP.
 
-## Process
+## Procedure
 
 ### Step 1: Install the Primary Cluster
 
@@ -132,13 +132,20 @@ Refer to the following documentation to complete installation:
 
 ### Step 3: Enable etcd Synchronization \{#etcd_sync}
 
-1. Configure the load balancer to forward port `2379` to control plane nodes of the corresponding cluster. ONLY TCP mode is supported; forwarding on L7 is not supported.
+1. When applicable, configure the load balancer to forward port `2379` to control plane nodes of the corresponding cluster. ONLY TCP mode is supported; forwarding on L7 is not supported.
+
+    :::info
+    Port forwarding through a load balancer is not required.
+    If direct access from the standby cluster to the active global cluster is available, specify the etcd addresses via **Active Global Cluster ETCD Endpoints**.
+    :::
+
 2. Access the **standby global cluster** Web Console using its VIP, and switch to **Administrator** view;
 3. Navigate to **Marketplace > Cluster Plugins**, select the `global` cluster;
 4. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, configure parameters:
 
-   * Use the default sync interval;
-   * Leave log switch disabled unless troubleshooting.
+   * When not forwarding port `2379` through load balancer, its required to configure **Active Global Cluster ETCD Endpoints** correctly;
+   * Use the default value of **Data Check Interval**;
+   * Leave **Print detail logs** switch disabled unless troubleshooting.
 
 Verify the sync Pod is running on the standby cluster:
 
@@ -328,13 +335,13 @@ For example, if the primary cluster's key is `key1`, rename the standby's key to
         ssh "<user>@${i}" '
     #!/bin/bash
     set -euo pipefail
-    
+
     sudo install -o root -g root -m 600 \
         /etc/kubernetes/encryption-provider.conf /etc/kubernetes/encryption-provider.conf.bak
     sudo install -o root -g root -m 600 \
         /tmp/encryption-provider.conf            /etc/kubernetes/encryption-provider.conf
     sudo rm -f /tmp/encryption-provider.conf
-    
+
     _pod_name="kube-apiserver"
     _pod_id=$(sudo crictl ps --name "${_pod_name}" --no-trunc --quiet)
     if [[ -z "${_pod_id}" ]]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed “Process” to “Procedure” in the installation guide.
  * Updated Step 3 (etcd synchronization): clarified load balancer port-forwarding is optional when direct access is available; added guidance on using Active Global Cluster ETCD Endpoints; expanded parameter descriptions, including Data Check Interval.
  * Applied the same clarifications in the later, detailed section.
  * Performed minor formatting and whitespace cleanups in code blocks (no behavioral changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->