### PR TITLE
cleanhouse: provide detailed usage instructions of violet (#215)

### DIFF
--- a/docs/en/extend/upload_package.mdx
+++ b/docs/en/extend/upload_package.mdx
@@ -87,11 +87,9 @@ mv -f violet_darwin_arm64 /usr/bin/violet && chmod +x /usr/bin/violet
 
 > **Note:** If the role property of your account is set to `Custom`, you cannot use this tool.
 
-## Using the Tool
+## Usage
 
-The following examples illustrate common usage scenarios.
-
-### View Package Information
+### violet show
 
 Before uploading a package, use the `violet show` command to preview its details.
 
@@ -111,59 +109,99 @@ Artifact: harbor.demo.io/acp/topolvm-operator-bundle:v3.11.0
 RelateImages: [harbor.demo.io/acp/topolvm-operator:v3.11.0 harbor.demo.io/acp/topolvm:v3.11.0 harbor.demo.io/3rdparty/k8scsi/csi-provisioner:v3.00 ...]
 ```
 
-### Upload an Operator to Multiple Clusters
+### violet push \{#violet_push_usage}
 
-Use the `--clusters` parameter to specify the target clusters.
+The following examples illustrate common usage scenarios.  
+Before digging into the examples, here are some common OPTIONAL parameters used in the commands:
+
+```
+--platform-address <platform access URL>     # The access URL of the platform, e.g., "https://example.com"
+--platform-username <platform user>          # The username of the platform user
+--platform-password <platform password>      # The password of the platform user
+--clusters <cluster names>                   # Specify target clusters, separated by commas (e.g., region1,region2)
+
+--dest-repo <image repository URL>           # Specify the destination image repository URL. MUST be specified when uploading extensions to a standby cluster.
+                                                 When `--dest-repo` is specified, either the authentication info of the image registry or `--no-auth` MUST be provided.
+--username <registry user>                   # The username of the specified image registry.
+--password <registry password>               # The password of the specified image registry.
+--no-auth                                    # Specify if the image registry does not require authentication.
+--plain                                      # Specify if the image registry uses HTTP instead of HTTPS.
+
+--skip-crs                                   # Skip creating `Artifact` and `ArtifactVersion` resources, only push images.
+                                                 This prevents Operators or Cluster Plugins from being updated prematurely during the <Term name="productShort" /> upgrade process.
+--skip-push                                  # Only create `Artifact` and `ArtifactVersion` resources, while images are not pushed.
+```
+
+#### Upload an Operator to Multiple Clusters
 
 ```bash
 violet push opensearch-operator.v3.14.2.tgz \
-  --platform-address https://192.168.0.1 \
-  --platform-username <user> \
-  --platform-password <password> \
+  --platform-address "https://example.com" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>" \
   --clusters region1,region2
 ```
 
-> **Note:** If `--clusters` is not specified, the Operator is uploaded to the **global cluster** by default.
+:::info
+* If `--clusters` is not specified, the Operator is uploaded to the **global cluster** by default.  
+:::
 
-### Upload a Cluster Plugin
+#### Upload an Operator to a Standby Global Cluster
+```bash
+violet push opensearch-operator.v3.14.2.tgz \
+  --platform-address "https://example.com" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>" \
+  --dest-repo "<standby-cluster-VIP>:11443" --username "<registry-username>" --password "<registry-password>"
+```
+
+#### Upload a Cluster Plugin
 
 ```bash
 violet push plugins-cloudedge-v0.3.16-hybrid.tgz \
-  --platform-address https://192.168.0.1 \
-  --platform-username <user> \
-  --platform-password <password>
+  --platform-address "https://example.com" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>"
 ```
 
-> **Note:** You do not need to specify the `--clusters` parameter when uploading a Cluster Plugin, as the platform will automatically distribute it based on its affinity configuration. If you specify `--clusters`, the parameter will be ignored.
+:::info
+* You do not need to specify the `--clusters` parameter when uploading a Cluster Plugin, as the platform will automatically distribute it based on its affinity configuration.
+If you specify `--clusters`, the parameter will be ignored.  
+:::
 
-### Upload All Packages in a Directory \{#upload_all_packages}
+#### Upload a Helm Chart to the chart repository
+
+```bash
+violet push plugins-cloudedge-v0.3.16-hybrid.tgz \
+  --platform-address "https://example.com" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>"
+```
+
+:::info
+* Helm Charts can only be uploaded to the default **`public-charts`** repository provided by the platform.  
+:::
+
+#### Push only images from all packages in a directory \{#only_push_images}
 
 When multiple packages are downloaded from the Marketplace, you can place them in the same directory and upload them all at once:
 
 ```bash
 violet push <packages_dir_name> \
-  --platform-address https://192.168.0.1 \
-  --platform-username <user> \
-  --platform-password <password>
+  --skip-crs \
+  --platform-address "https://example.com" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>"
 ```
 
-The tool automatically detects the package types in the directory.
+#### Create only CRs from all packages in a directory \{#only_create_cr}
 
-
-### Upload a Helm Chart
-
-Upload a Helm Chart to the chart repository:
-```bash
-violet push plugins-cloudedge-v0.3.16-hybrid.tgz \
-  --platform-address https://192.168.0.1 \
-  --platform-username <user> \
-  --platform-password <password>
-```
-
-> **Note:** Helm Charts can only be uploaded to the default **`public-charts`** repository provided by the platform.
-
-For more details, run:
+When multiple packages are downloaded from the Marketplace, you can place them in the same directory and upload them all at once:
 
 ```bash
-violet --help
+violet push <packages_dir_name> \
+  --skip-push \
+  --platform-address "https://example.com" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>"
 ```

--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -258,104 +258,11 @@ If any keys are missing or surplus, follow the instructions in the output to res
 
 ## Uploading Packages \{#upload_dr_packages}
 
-When using **`violet`** to upload packages to a standby cluster, you must specify the `--dest-repo` parameter with the VIP of the standby cluster.
-If this parameter is omitted, the package will be uploaded to the image repository of the primary cluster, preventing the standby cluster from installing or upgrading the corresponding extension.
+:::warning
+When using `violet` to upload packages to a standby cluster, the parameter `--dest-repo <VIP addr of standby cluster>` must be specified.  
+Otherwise, the packages will be uploaded to the image repository of the **primary cluster**, preventing the standby cluster from installing or upgrading extensions.  
 
-## FAQ
+Also be awared that either authentication info of the standby cluster's image registry or `--no-auth` parameter MUST be provided.
+:::
 
-* Here are the instructions in case that the ETCD encryption key of the standby cluster has not synced with the one of **primary cluster** before Installing the standby cluster.
-
-1. Get the ETCD encryption key on any of the standby cluster's control plane nodes:
-
-    ```bash
-    ssh <user>@<STANDBY cluster control plane node> sudo cat /etc/kubernetes/encryption-provider.conf
-    ```
-
-It should look like:
-
-    ```yaml
-    apiVersion: apiserver.config.k8s.io/v1
-    kind: EncryptionConfiguration
-    resources:
-      - resources:
-        - secrets
-        providers:
-        - aescbc:
-            keys:
-            - name: key1
-              secret: MTE0NTE0MTkxOTgxMA==
-    ```
-
-2. Back up the ETCD encryption key on any primary control plane node (e.g., 1.1.1.1):
-
-    ```bash
-    # login into the primary cluster's control plane nodes 1.1.1.1
-    ssh "<user>@1.1.1.1"
-    sudo install -o root -g root -m 600 /etc/kubernetes/encryption-provider.conf /etc/kubernetes/encryption-provider.conf.bak
-    ```
-
-3. Merge the ETCD encryption key of the standby cluster into the `/etc/kubernetes/encryption-provider.conf` file on node `1.1.1.1`, ensuring the key names are unique.
-For example, if the primary cluster's key is `key1`, rename the standby's key to `key2`:
-
-    ```yaml
-    apiVersion: apiserver.config.k8s.io/v1
-    kind: EncryptionConfiguration
-    resources:
-      - resources:
-        - secrets
-        providers:
-        - aescbc:
-            keys:
-            - name: key1
-              secret: My4xNDE1OTI2NTM1ODk3
-            - name: key2
-              secret: MTE0NTE0MTkxOTgxMA==
-    ```
-
-4. Make sure the new `/etc/kubernetes/encryption-provider.conf` file overwrites EVERY replicas on the control plane nodes of both clusters:
-
-    ```bash
-    # Assume the control plane nodes of the primary cluster are 1.1.1.1, 2.2.2.2 & 3.3.3.3
-    # the control plane nodes of the standby cluster are 4.4.4.4, 5.5.5.5 & 6.6.6.6
-
-    # Since the 1.1.1.1 has already been configured to use both of the ETCD encryption keys,
-    # login into the node 1.1.1.1, and issue the following commands:
-    for i in \
-        2.2.2.2 3.3.3.3 \
-        4.4.4.4 5.5.5.5 6.6.6.6 \
-    ; do
-        scp /etc/kubernetes/encryption-provider.conf "<user>@${i}:/tmp/encryption-provider.conf"
-        ssh "<user>@${i}" '
-    #!/bin/bash
-    set -euo pipefail
-    
-    sudo install -o root -g root -m 600 \
-        /etc/kubernetes/encryption-provider.conf /etc/kubernetes/encryption-provider.conf.bak
-    sudo install -o root -g root -m 600 \
-        /tmp/encryption-provider.conf            /etc/kubernetes/encryption-provider.conf
-    sudo rm -f /tmp/encryption-provider.conf
-    
-    _pod_name="kube-apiserver"
-    _pod_id=$(sudo crictl ps --name "${_pod_name}" --no-trunc --quiet)
-    if [[ -z "${_pod_id}" ]]; then
-        echo "FATAL: could not find pod `kube-apiserver` on node $(hostname)"
-        exit 1
-    fi
-    sudo crictl rm --force "${_pod_id}"
-    sudo systemctl restart kubelet.service
-    '
-    done
-    ```
-
-4. Restart the kube-apiserver on node 1.1.1.1
-
-    ```bash
-    _pod_name="kube-apiserver"
-    _pod_id=$(sudo crictl ps --name "${_pod_name}" --no-trunc --quiet)
-    if [[ -z "${_pod_id}" ]]; then
-        echo "FATAL: could not find pod `kube-apiserver` on node $(hostname)"
-        exit 1
-    fi
-    sudo crictl rm --force "${_pod_id}"
-    sudo systemctl restart kubelet.service
-    ```
+For details of the `violet push` subcommand, please refer to [Upload Packages](../extend/upload_package.mdx#violet_push_usage).

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -38,6 +38,15 @@ Copy the upgrade package to **any control plane node** of the global cluster. Ex
   maintenance window accordingly.
 </Directive>
 
+:::warning
+When using `violet` to upload packages to a standby cluster, the parameter `--dest-repo <VIP addr of standby cluster>` must be specified.  
+Otherwise, the packages will be uploaded to the image repository of the **primary cluster**, preventing the standby cluster from installing or upgrading extensions.  
+
+Also be awared that either authentication info of the standby cluster's image registry or `--no-auth` parameter MUST be provided.
+:::
+
+For details of the `violet push` subcommand, please refer to [Upload Packages](../extend/upload_package.mdx#violet_push_usage).
+
 ### Trigger the upgrade
 
 After the image upload is complete, run the following command to start the upgrade process:


### PR DESCRIPTION
* revert: instructions in the FAQ section is not reliable

* cleanhouse: provide detailed usage instructions of violet

* chore: refine the upload_dr_packages section

* fix: simplify the doc

by omitting the optional parameters
in usage instructions of `violet push`

* chore: example of uploading an operator to a standby global cluster

* chore