### PR TITLE
docs(application): add guide about adding imagePullSecrets to SA

### DIFF
--- a/docs/en/developer/building_application/create_applications/image_app.mdx
+++ b/docs/en/developer/building_application/create_applications/image_app.mdx
@@ -28,6 +28,8 @@ Obtain the image address. The source of the images can be from the image reposit
 
 :::info
 **Note**: When using images from the image repository integrated into web console, you can filter images by **Already Integrated**. The **Integration Project Name**, for example, images (docker-registry-projectname), which includes the project name projectname in this web console and the project name containers in the image repository.
+
+When using images from a private registry, you need to configure the corresponding image pull secret. For more information, see [Add ImagePullSecrets to ServiceAccount](../how_to/sa_imagepullsecret.mdx).
 :::
 
 6. Refer to the following instructions to configure the related parameters.

--- a/docs/en/developer/building_application/how_to/sa_imagepullsecret.mdx
+++ b/docs/en/developer/building_application/how_to/sa_imagepullsecret.mdx
@@ -1,0 +1,56 @@
+---
+weight: 10
+i18n:
+  title:
+    en: Add ImagePullSecrets to ServiceAccount
+    zh: 添加ImagePullSecrets到ServiceAccount
+---
+
+# Add ImagePullSecrets to ServiceAccount
+
+If the image repository requires authentication, you need to add the corresponding `ImagePullSecrets` to the `ServiceAccount` used by the application. This ensures that the application can successfully pull images from the private repository.
+
+## Create an ImagePullSecret
+
+To create an ImagePullSecret, please refer to [Creating a Secret](../configuration/add_secret.mdx) for detailed steps on creating an ImagePullSecret.
+
+## Add an ImagePullSecret to a ServiceAccount
+
+If the Pod of your application uses the `ServiceAccount` `example`, you can add the `ImagePullSecret` to the `example` `ServiceAccount` in the namespace where your application is located.
+
+Edit the `ServiceAccount` `example` with patch command:
+
+```bash
+kubectl patch serviceaccount example -p '{"imagePullSecrets": [{"name": "my-docker-creds"}]}' -n <namespace>
+```
+
+Replace `<namespace>` with the namespace where your application is located, and `my-docker-creds` with the name of the `ImagePullSecret` you created.
+
+You can verify the addition of the `ImagePullSecret` by describing the `ServiceAccount`:
+
+```bash
+kubectl describe serviceaccount example -n <namespace>
+Name:                example
+Namespace:           <namespace>
+Labels:              <none>
+Annotations:         <none>
+Image pull secrets:  my-docker-creds
+Mountable secrets:   <none>
+Tokens:              <none>
+Events:              <none>
+```
+You should see the `Image pull secrets` section showing the added secret.
+
+:::note
+**Note**: If your Pod does not specify a `ServiceAccount`, it will use the `default` `ServiceAccount` in the namespace by default. You can add the `ImagePullSecret` to the `default` `ServiceAccount` in the same way.
+:::
+
+## Verify that imagePullSecrets are set for new Pods
+
+When you create a new Pod that uses the `ServiceAccount` `example`, the Pod will automatically use the `ImagePullSecrets` specified in the `ServiceAccount`.
+
+You can verify this by run the command:
+
+```bash
+kubectl get pod <pod-name> -n <namespace> -o=jsonpath='{.spec.imagePullSecrets}'
+```


### PR DESCRIPTION

- Add note about image pull secret requirement for private registry
- Add new document explaining how to add imagePullSecrets to ServiceAccount
- Include examples and verification steps for ServiceAccount configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a bilingual step-by-step guide for attaching ImagePullSecrets to a ServiceAccount to enable pulling images from private registries; includes patching commands, verification methods, and guidance on default ServiceAccounts.
  * Updated image application docs to highlight when ImagePullSecrets are required for private registries and added a reference link for further configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->