### PR TITLE
docs: add critical warning for MTU increase scenarios

### DIFF
--- a/docs/en/configure/networking/how_to/kube_ovn/configure_mtu.mdx
+++ b/docs/en/configure/networking/how_to/kube_ovn/configure_mtu.mdx
@@ -60,6 +60,25 @@ MTU settings can be customized globally for overlay networks or on a per-subnet 
   with your underlying network infrastructure before making changes.
 :::
 
+:::warning Critical Consideration When Increasing MTU
+  **When increasing MTU from a smaller to a larger value, you must restart all Pods**
+  to ensure the new MTU takes effect uniformly across the cluster.
+
+  **Why is this necessary?**
+
+  OVS internal ports (such as `ovn0`) automatically adopt the **smallest MTU** among
+  all interfaces connected to the `br-int` bridge as their own MTU. This behavior
+  creates a potential issue in the following scenario:
+
+  1. You configure a larger MTU value for new Pods
+  2. Some existing Pods still use the original smaller MTU
+  3. The `ovn0` interface retains the smaller MTU due to the minimum MTU rule
+  4. Traffic from Pods with the larger MTU gets dropped when packets exceed the `ovn0` MTU
+
+  **Solution:** After increasing MTU settings, recreate all Pods to ensure consistent
+  MTU configuration across the entire network path.
+:::
+
 :::note
   MTU configuration changes will only take effect for newly created Pods.
   Existing Pods will retain their original MTU settings until they are recreated.


### PR DESCRIPTION
Add a warning block explaining why all Pods must be restarted when increasing MTU from smaller to larger values.

OVS internal ports adopt the smallest MTU among all interfaces on br-int, which can cause packet drops when some Pods use larger MTU while ovn0 retains the smaller MTU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added critical guidance on increasing MTU, including the necessity to restart Pods and explanation of OVS port MTU behavior.
  * Added reminders about planning Pod restarts when modifying MTU configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->