### PR TITLE
docs(docs): add ACP CLI token reuse guide for advanced API calls

### DIFF
--- a/docs/en/apis/overview/intro.mdx
+++ b/docs/en/apis/overview/intro.mdx
@@ -42,3 +42,9 @@ To obtain an <Term name="productShort" /> user token, follow these steps:
 4. After successful creation, the system will generate a token and display it on the page.
 
 5. Copy the token to the clipboard and save it securely for future use when calling ACP APIs.
+
+### Alternative: Use ACP CLI Sessions Without Web Console
+
+If you already use ACP CLI (`ac`) sessions, you can also reuse the token stored after `ac login` for Advanced API calls.
+
+- [Reuse ACP CLI Token for Advanced API Calls](./reuse-acp-cli-token-for-advanced-api-calls)

--- a/docs/en/apis/overview/reuse-acp-cli-token-for-advanced-api-calls.mdx
+++ b/docs/en/apis/overview/reuse-acp-cli-token-for-advanced-api-calls.mdx
@@ -1,0 +1,111 @@
+---
+weight: 30
+title: Reuse ACP CLI Token for Advanced API Calls
+---
+
+# Reuse ACP CLI Token for Advanced API Calls
+
+## Summary
+
+This guide shows how to use ACP CLI (`ac`) to log in, read the current session token from kubeconfig, and call ACP Advanced APIs with a minimal `curl` request.
+
+This is a CLI-first path to get a token and call ACP Advanced APIs without using the web console.
+
+## When This Method Is a Good Fit
+
+Use this method when all of the following are true:
+
+- The target endpoint accepts `Authorization: Bearer <token>`
+- You already use `ac login` to access the platform
+- You want a minimal and reusable API call pattern
+
+## Step 1: Log In with ACP CLI
+
+Use ACP CLI to create or refresh your platform session:
+
+```bash
+ac login https://<platform-url> --name <session-name>
+```
+
+To avoid putting secrets in shell history, prefer interactive login instead of passing `--password` on the command line.
+
+For CLI setup and login options, see:
+
+- [Getting Started with ACP CLI](../../ui/cli_tools/ac/getting-started)
+- [AC CLI Developer Command Reference](../../ui/cli_tools/ac/developer-command-reference)
+
+## Step 2: Read the Token from the Current Session
+
+```bash
+CTX="$(ac config current-context)"
+USER_NAME="$(ac config view -o jsonpath="{.contexts[?(@.name==\"$CTX\")].context.user}")"
+TOKEN="$(ac config view --raw -o jsonpath="{.users[?(@.name==\"$USER_NAME\")].user.token}")"
+```
+
+Validate that token extraction worked without printing the full token:
+
+```bash
+echo "context=$CTX"
+echo "user=$USER_NAME"
+echo "token_prefix=${TOKEN:0:16}"
+echo "token_length=${#TOKEN}"
+```
+
+If `TOKEN` is empty, run `ac login` again and retry.
+
+## Step 3: Call an Advanced API with Minimal `curl`
+
+Start with the smallest useful `GET` request:
+
+```bash
+curl -sS \
+  "https://<platform-url>/<advanced-api-path>" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/json"
+```
+
+For JSON request bodies (`POST`/`PUT`/`PATCH`), add `Content-Type: application/json`:
+
+```bash
+curl -sS -X POST \
+  "https://<platform-url>/<advanced-api-path>" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  --data '{"key":"value"}'
+```
+
+Do not add browser-only headers unless an endpoint explicitly requires them.
+
+## Step 4: Troubleshoot in a Minimal Order
+
+If the request fails, check in this order:
+
+1. `TOKEN` is not empty
+2. The token is still valid (re-login if needed)
+3. The endpoint path is correct
+4. The current user has permission for this API
+5. Add only the minimum required extra headers
+
+Optional debug pattern:
+
+```bash
+curl -sS -D /tmp/acp-api-headers.txt -o /tmp/acp-api-response.json \
+  "https://<platform-url>/<advanced-api-path>" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/json"
+```
+
+## Security Notes
+
+- Never share full tokens in chat, tickets, or screenshots
+- Do not commit kubeconfig files containing active credentials
+- If a token is exposed, rotate it immediately
+
+## Related Documentation
+
+- [API Introduction](./intro)
+- [Advanced APIs](../advanced_apis/)
+- [Kubernetes API Usage Guide](./kubernetes_api_usage)
+- [Getting Started with ACP CLI](../../ui/cli_tools/ac/getting-started)
+- [Configuring ACP CLI](../../ui/cli_tools/ac/configuration)


### PR DESCRIPTION
- Add a new overview guide for reusing ACP CLI session tokens in Advanced API requests
- Document login, token extraction, minimal curl usage, troubleshooting, and security notes
- Link the new guide from the API introduction as an alternative CLI-first workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section on using ACP CLI sessions for API authentication without the web console, providing an alternative method for obtaining and reusing user tokens.
  * Added a comprehensive guide for extracting and reusing ACP CLI tokens for advanced API calls, including token extraction methods, validation techniques, troubleshooting steps, and security best practices to prevent token leakage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->