### PR TITLE
[codex] Add kubeconfig access guide

### DIFF
--- a/docs/en/configure/clusters/how-to/access-cluster-with-kubeconfig.mdx
+++ b/docs/en/configure/clusters/how-to/access-cluster-with-kubeconfig.mdx
@@ -1,0 +1,210 @@
+---
+title: Access a Cluster with KubeConfig
+weight: 30
+author: dev@alauda.io
+category: howto
+queries:
+  - access cluster with KubeConfig
+  - download KubeConfig from acp
+  - create KubeConfig with acp api token
+  - use ac with KubeConfig
+---
+
+# Access a Cluster with KubeConfig
+
+## Introduction
+
+This topic explains the currently supported ways to use KubeConfig to access a cluster in <Term name="productShort" />. Use it when you need local access from ACP CLI (`ac`), `kubectl`, `helm`, `client-go`, or similar Kubernetes clients.
+
+A KubeConfig file is a YAML client configuration file. It is not a Kubernetes resource. A KubeConfig file typically defines the target cluster endpoint, the client credential, and the context that combines them.
+
+ACP CLI (`ac`) uses standard kubeconfig and provides a kubectl-like experience. It is compatible with `kubectl` workflows and also adds ACP-specific context, cluster, and session operations. If you already use `ac login`, ACP CLI can configure kubeconfig and create contexts automatically. This topic focuses on the KubeConfig access paths themselves, including downloaded KubeConfig files and manually assembled token-based KubeConfig files.
+
+## Scenarios
+
+This topic applies to the following scenarios:
+
+- A cluster administrator needs a ready-to-use KubeConfig for cluster administration, troubleshooting, or inspection.
+- A developer or project user needs a KubeConfig that matches their own ACP identity and RBAC permissions.
+- A pipeline or connector needs an independent credential that is separate from a personal day-to-day account.
+
+## Choose the Access Path
+
+Use the following table to choose the appropriate access path:
+
+| Access path | Credential source | Effective permissions | Lifetime control | Best fit |
+| :--- | :--- | :--- | :--- | :--- |
+| Platform-downloaded KubeConfig | Credential embedded in the KubeConfig file downloaded from ACP | Determined by the credential embedded in the downloaded file | Controlled by the current platform behavior for the downloaded file | Cluster administrators and template preparation |
+| Token-based KubeConfig | ACP API token created for a user account | Limited to the identity and RBAC scope of the token owner | Controlled by the token expiration or revocation state | Developers, project users, and automation accounts |
+
+<Directive type="warning" title="Current behavior">
+Currently, the KubeConfig file downloaded from ACP defaults to a 10-year validity period. ACP does not currently provide CA replacement for this path and does not support user-defined cluster CA for this path.
+</Directive>
+
+If you need stricter identity isolation or shorter lifecycle control, use a token-based KubeConfig instead of long-term reuse of the downloaded file.
+
+## Prerequisites
+
+Before you begin, ensure the following conditions are met:
+
+- You can sign in to <Term name="productShort" /> and access the target cluster.
+- You have ACP CLI (`ac`) or `kubectl` installed on the local machine where you will use the KubeConfig file.
+- If you want to use a token-based KubeConfig, you can create an ACP API token from **Profile** > **API Tokens**. For details, see [Introduction](../../../apis/overview/intro.mdx).
+- If you want to use KubeConfig for a pipeline or connector, prepare a dedicated account and grant only the required permissions before creating its token.
+
+## Procedure
+
+### Download and Use the Platform-Provided KubeConfig
+
+Use this path when you need direct cluster access from the platform-provided KubeConfig file.
+
+<Steps>
+### Download the KubeConfig file
+
+In the **Administrator** view, go to **Clusters** > **Clusters**, select the target cluster, open the cluster details page, click **Actions**, and select **Download Kubeconfig**.
+
+Save the downloaded file to a local path such as `~/.kube/<cluster-name>.yaml`.
+
+### Select the KubeConfig file
+
+Point ACP CLI (`ac`) or `kubectl` to the downloaded file:
+
+```shell
+export KUBECONFIG="$HOME/.kube/<cluster-name>.yaml"
+kubectl config get-contexts
+kubectl config current-context
+ac config current-context
+```
+
+If you manage multiple clusters, use `kubectl config use-context <context-name>` or `ac config use-context <context-name>` to switch to the correct context before running commands. If you use ACP CLI sessions, you can also use `ac config use-cluster <cluster-name>` to switch clusters within the current ACP session.
+
+### Validate cluster access
+
+Run read-only commands to confirm that the KubeConfig file works as expected:
+
+```shell
+kubectl get nodes
+kubectl get pods -A
+ac get nodes
+ac get pods -A
+```
+
+If the commands return the expected cluster resources, the KubeConfig file is valid for direct use.
+</Steps>
+
+Use this downloaded file directly when you need cluster administration. You can also use it as a template for a token-based KubeConfig that works with both `ac` and `kubectl`.
+
+## Build a Token-Based KubeConfig with Your Own ACP API Token
+
+Use this path when you want the KubeConfig permissions to match a specific ACP user or automation account.
+
+This path does not elevate permissions. The KubeConfig file only carries the connection and authentication settings. The effective access boundary still depends on the token owner and that identity's RBAC assignments.
+
+<Steps>
+### Create an ACP API token
+
+Open **Profile** > **API Tokens**, create a new token, and set an expiration time that matches your use case.
+
+Store the token securely. If you plan to use it for automation, avoid using a personal daily account.
+
+### Prepare a KubeConfig template
+
+Use one of the following methods:
+
+- Download the platform-provided KubeConfig file and save a separate copy for token-based access.
+- Create a standard KubeConfig file manually.
+
+If you create the file manually, use the target cluster endpoint in the following format:
+
+```text
+https://<platform-access-address>/kubernetes/<cluster-name>
+```
+
+If you do not want to build the cluster section from scratch, download the platform-provided KubeConfig first and reuse its cluster and CA fields as the template.
+
+### Set the ACP API token in the KubeConfig file
+
+Replace the `users[].user.token` value with the ACP API token that you created for the target user or automation account.
+
+The following example shows a token-based KubeConfig:
+
+```yaml title="KubeConfig.yaml"
+apiVersion: v1
+kind: Config
+clusters:
+  - name: <cluster-name>
+    cluster:
+      server: https://<platform-access-address>/kubernetes/<cluster-name>
+      certificate-authority-data: <base64-encoded-ca-data>
+users:
+  - name: <user-name>
+    user:
+      token: <acp-api-token>
+contexts:
+  - name: <context-name>
+    context:
+      cluster: <cluster-name>
+      user: <user-name>
+      namespace: <namespace>
+current-context: <context-name>
+```
+
+`namespace` is optional. It sets the default namespace for commands, but it does not increase the permission scope of the token.
+
+### Validate the effective permissions
+
+Use the new KubeConfig file and verify that the returned permissions match the intended role:
+
+```shell
+export KUBECONFIG="$HOME/.kube/<user-or-automation>.yaml"
+kubectl auth can-i get pods -n <namespace>
+kubectl get pods -n <namespace>
+ac config current-context
+ac get pods -n <namespace>
+```
+
+If the command returns `no` for `kubectl auth can-i`, grant the required role or use a different account. Do not treat KubeConfig changes as a substitute for RBAC changes.
+</Steps>
+
+## Use a Dedicated Account for Pipeline or Connector Access
+
+For pipeline or connector access, use a dedicated account instead of a personal user account:
+
+1. Create a dedicated account for the pipeline or connector.
+2. Grant only the required project-level or tenant-level permissions to that account.
+3. Create an ACP API token for that account.
+4. Build a token-based KubeConfig by using that token.
+5. Store the token or KubeConfig file in the secret management system of the automation platform.
+6. Rotate the credential by creating a new token, updating the secret, and revoking the old token.
+
+This pattern provides an independent credential for automation, but it is not a native project-level KubeConfig object in ACP.
+
+## Lifecycle and Revocation
+
+The lifetime behavior depends on which access path you use:
+
+| Access path | What controls validity | Current behavior |
+| :--- | :--- | :--- |
+| Platform-downloaded KubeConfig | The current platform behavior for the downloaded file | The downloaded KubeConfig currently defaults to a 10-year validity period. ACP does not currently provide CA replacement or user-defined cluster CA for this path. |
+| Token-based KubeConfig | The ACP API token in `users[].user.token` | The KubeConfig remains usable only while the token is valid. When the token expires or is revoked, the KubeConfig also stops working. |
+
+If you need a shorter validity period or easier revocation, prefer the token-based path.
+
+## Verification
+
+After you prepare the KubeConfig file, perform the following checks:
+
+1. Run `kubectl config get-contexts` and confirm that the expected context exists.
+2. Run a read-only command such as `kubectl get pods -A` or `kubectl get pods -n <namespace>` and confirm that the response matches the intended access scope.
+3. For a token-based KubeConfig, run `kubectl auth can-i <verb> <resource> -n <namespace>` and confirm that the result matches the token owner's role.
+4. If you use ACP CLI, run `ac config current-context` or `ac namespace` and confirm that the active context matches the intended cluster and namespace.
+5. If you use ACP CLI, run `ac get pods -n <namespace>` or `ac get nodes` and confirm that the response matches the intended access scope.
+
+## Next Steps
+
+- For ACP API token management, see [Introduction](../../../apis/overview/intro.mdx).
+- For ACP CLI basics, see [Getting Started with ACP CLI](../../../ui/cli_tools/ac/getting-started.md).
+- For ACP CLI context and session management, see [Managing CLI Profiles](../../../ui/cli_tools/ac/managing-cli-profiles.md).
+- For ACP CLI and kubectl compatibility, see [Usage of ac and kubectl Commands](../../../ui/cli_tools/ac/ac-and-kubectl-usage.md).
+- For imported cluster onboarding, see [Fetch import cluster information](../managed/how-to/fetch-kubeconfig.mdx).
+- For control-plane certificate rotation, see [Automated Kubernetes Certificate Rotation](../../../security/cert/k8s-cert-rotator.mdx).

--- a/docs/en/configure/clusters/how-to/access-cluster-with-kubeconfig.mdx
+++ b/docs/en/configure/clusters/how-to/access-cluster-with-kubeconfig.mdx
@@ -206,5 +206,3 @@ After you prepare the KubeConfig file, perform the following checks:
 - For ACP CLI basics, see [Getting Started with ACP CLI](../../../ui/cli_tools/ac/getting-started.md).
 - For ACP CLI context and session management, see [Managing CLI Profiles](../../../ui/cli_tools/ac/managing-cli-profiles.md).
 - For ACP CLI and kubectl compatibility, see [Usage of ac and kubectl Commands](../../../ui/cli_tools/ac/ac-and-kubectl-usage.md).
-- For imported cluster onboarding, see [Fetch import cluster information](../managed/how-to/fetch-kubeconfig.mdx).
-- For control-plane certificate rotation, see [Automated Kubernetes Certificate Rotation](../../../security/cert/k8s-cert-rotator.mdx).


### PR DESCRIPTION
## Summary
- add a new guide for accessing ACP clusters with kubeconfig
- document both platform-downloaded and token-based kubeconfig flows
- trim two unrelated next-step links to keep the page focused

## Why
Users need a single English-first reference that explains the supported kubeconfig access paths, token usage, and ACP CLI context handling.

## Impact
This adds operator-facing documentation under the cluster how-to section and clarifies how ACP CLI and kubectl share kubeconfig-based access in ACP.

## Validation
- `git diff --check HEAD`
- `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for accessing Kubernetes clusters with kubeconfig, covering two supported access methods, prerequisites, step-by-step procedures, validation steps, and token lifecycle information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->