### PR TITLE
docs: avoid hardcoded kube-ovn release branch in IC script download

### DIFF
--- a/docs/en/configure/networking/how_to/kube_ovn/configure_ovn_interconnection.mdx
+++ b/docs/en/configure/networking/how_to/kube_ovn/configure_ovn_interconnection.mdx
@@ -26,10 +26,12 @@ There are three deployment methods available: Deploy deployment (supported in pl
 
 **Operation Steps**
 
-1. Execute the following command on the cluster Master node to obtain the install-ic-server.sh installation script.
+1. Execute the following command on the cluster Master node to obtain the `install-ic-server.sh` installation script.
+   Map the version to branch as follows: `v1.14.x -> release-1.14`, `v1.15.x -> release-1.15`, and so on.
 
    ```sh
-   wget https://github.com/kubeovn/kube-ovn/blob/release-1.14/dist/images/install-ic-server.sh
+   KUBE_OVN_BRANCH="$(kubectl -n kube-system get deployment kube-ovn-controller -o jsonpath='{.spec.template.spec.containers[0].image}' | sed -E 's#.*:v?([0-9]+)\.([0-9]+).*#release-\1.\2#')"
+   wget "https://raw.githubusercontent.com/kubeovn/kube-ovn/${KUBE_OVN_BRANCH}/dist/images/install-ic-server.sh" -O install-ic-server.sh
    ```
 
 2. Open the script file in the current directory and modify the parameters as follows.


### PR DESCRIPTION
## Summary
- remove hardcoded `release-1.14` from OVN interconnection doc
- add explicit mapping rule: `v1.14.x -> release-1.14`, `v1.15.x -> release-1.15`, and so on
- derive `release-x.y` from the current kube-ovn-controller image tag before downloading `install-ic-server.sh`

## Why
Customers may not know which fixed release branch to use. This change makes the workflow deterministic and aligned with the deployed kube-ovn version.
