### PR TITLE
docs: get install-ic-server.sh from kube-ovn-controller pod

### DIFF
--- a/docs/en/configure/networking/how_to/kube_ovn/configure_ovn_interconnection.mdx
+++ b/docs/en/configure/networking/how_to/kube_ovn/configure_ovn_interconnection.mdx
@@ -26,12 +26,10 @@ There are three deployment methods available: Deploy deployment (supported in pl
 
 **Operation Steps**
 
-1. Execute the following command on the cluster Master node to obtain the `install-ic-server.sh` installation script.
-   Map the version to branch as follows: `v1.14.x -> release-1.14`, `v1.15.x -> release-1.15`, and so on.
+1. Execute the following command on the cluster Master node to obtain the `install-ic-server.sh` installation script from the kube-ovn-controller Pod.
 
    ```sh
-   KUBE_OVN_BRANCH="$(kubectl -n kube-system get deployment kube-ovn-controller -o jsonpath='{.spec.template.spec.containers[0].image}' | sed -E 's#.*:v?([0-9]+)\.([0-9]+).*#release-\1.\2#')"
-   wget "https://raw.githubusercontent.com/kubeovn/kube-ovn/${KUBE_OVN_BRANCH}/dist/images/install-ic-server.sh" -O install-ic-server.sh
+   kubectl -n kube-system cp $(kubectl get pods -n kube-system -l app=kube-ovn-controller -o custom-columns=NAME:.metadata.name --no-headers | head -1):/kube-ovn/install-ic-server.sh ./install-ic-server.sh
    ```
 
 2. Open the script file in the current directory and modify the parameters as follows.


### PR DESCRIPTION
## Summary
- 将获取 install-ic-server.sh 的方式从 wget 下载改为从 kube-ovn-controller Pod 中直接拷贝
- 解决离线环境下无法访问 GitHub 下载脚本的问题

## Test plan
- [ ] 确认 kube-ovn-controller Pod 中存在 /kube-ovn/install-ic-server.sh 文件
- [ ] 确认 kubectl cp 命令能正确拷贝脚本

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * **Simplified OVN Interconnection configuration guide** - Updated kube-ovn setup documentation with streamlined instructions for obtaining required deployment scripts. New process is more direct and efficient, reducing installation complexity and improving the user experience for operators configuring multi-cluster OVN interconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->