### PR TITLE
docs: add platform security configurations for ClientSecret and PKCE

### DIFF
--- a/docs/en/security/platform_security_configurations/change_client_secret.mdx
+++ b/docs/en/security/platform_security_configurations/change_client_secret.mdx
@@ -13,6 +13,12 @@ ACP uses an OIDC Client Secret for authentication between platform components. Y
 ## Prerequisites \{#prerequisites}
 
 - `kubectl` access to the **global cluster** with cluster-admin privileges.
+- All clusters managed by the platform have been upgraded to ACP v4.3.
+- The following plugins with the `Agnostic` life cycle have been upgraded to versions compatible with ACP v4.3:
+  - `Alauda Container Platform Gitops`
+  - `Alauda Build of Kiali`
+  - `Kubeflow Base`
+  - `Alauda AI`
 - A new client secret value prepared. It is recommended to use a cryptographically random string of at least 32 characters.
 
 :::warning
@@ -49,6 +55,14 @@ kubectl get secret cpaas-oidc-secret -n cpaas-system -o yaml > cpaas-oidc-secret
 The backup file contains sensitive credential data. Store it in a secure location and delete it after the operation is complete.
 :::
 
+Record the current `client-secret` hash for non-plaintext verification after the update:
+
+```bash
+OLD_SECRET_SHA256="$(kubectl get secret cpaas-oidc-secret -n cpaas-system \
+  -o jsonpath='{.data.client-secret}' | base64 -d | openssl dgst -sha256 -r | awk '{print $1}')"
+echo "Current client-secret SHA256: ${OLD_SECRET_SHA256}"
+```
+
 ### Update the Client Secret \{#update_secret}
 
 :::danger
@@ -59,12 +73,15 @@ Use one of the following methods to update only the `client-secret` data field.
 
 **Method 1: Using `kubectl patch` (recommended)**
 
-Replace `<NEW_CLIENT_SECRET>` with your new secret value.
+Read the new secret from secure interactive input:
 
 ```bash
+read -rs NEW_CLIENT_SECRET
+echo
 kubectl patch secret cpaas-oidc-secret -n cpaas-system \
   --type merge \
-  -p "{\"data\":{\"client-secret\":\"$(echo -n '<NEW_CLIENT_SECRET>' | base64 | tr -d '\n')\"}}"
+  -p "{\"data\":{\"client-secret\":\"$(printf %s "$NEW_CLIENT_SECRET" | base64 | tr -d '\n')\"}}"
+unset NEW_CLIENT_SECRET
 ```
 
 **Method 2: Using `kubectl edit`**
@@ -79,15 +96,22 @@ kubectl edit secret cpaas-oidc-secret -n cpaas-system
 You can generate the base64-encoded value in advance:
 
 ```bash
-echo -n '<NEW_CLIENT_SECRET>' | base64
+read -rs NEW_CLIENT_SECRET
+echo
+printf %s "$NEW_CLIENT_SECRET" | base64
+unset NEW_CLIENT_SECRET
 ```
 :::
 
-Verify that the Secret has been updated on the global cluster:
+Verify that the Secret has been updated on the global cluster without exposing plaintext:
 
 ```bash
-kubectl get secret cpaas-oidc-secret -n cpaas-system \
-  -o jsonpath='{.data.client-secret}' | base64 -d
+NEW_SECRET_SHA256="$(kubectl get secret cpaas-oidc-secret -n cpaas-system \
+  -o jsonpath='{.data.client-secret}' | base64 -d | openssl dgst -sha256 -r | awk '{print $1}')"
+echo "Updated client-secret SHA256: ${NEW_SECRET_SHA256}"
+test "${OLD_SECRET_SHA256}" != "${NEW_SECRET_SHA256}" && \
+  echo "Verification passed: client-secret has changed."
+unset OLD_SECRET_SHA256 NEW_SECRET_SHA256
 ```
 
 ### Verify component health \{#verify_components}
@@ -117,9 +141,12 @@ kubectl apply -f cpaas-oidc-secret-backup.yaml
 Alternatively, if you know the previous secret value:
 
 ```bash
+read -rs PREVIOUS_CLIENT_SECRET
+echo
 kubectl patch secret cpaas-oidc-secret -n cpaas-system \
   --type merge \
-  -p "{\"data\":{\"client-secret\":\"$(echo -n '<PREVIOUS_CLIENT_SECRET>' | base64 | tr -d '\n')\"}}"
+  -p "{\"data\":{\"client-secret\":\"$(printf %s "$PREVIOUS_CLIENT_SECRET" | base64 | tr -d '\n')\"}}"
+unset PREVIOUS_CLIENT_SECRET
 ```
 
 After rolling back, repeat the [verification steps](#verify_components) to confirm that all components are healthy.

--- a/docs/en/security/platform_security_configurations/change_client_secret.mdx
+++ b/docs/en/security/platform_security_configurations/change_client_secret.mdx
@@ -1,0 +1,125 @@
+---
+weight: 10
+queries:
+  - how to change OIDC client secret
+  - how to rotate platform authentication client secret in ACP
+  - platform client secret rotation
+---
+
+# Changing the Platform OIDC Client Secret \{#change_client_secret}
+
+ACP uses an OIDC Client Secret for authentication between platform components. You may need to rotate this secret for security compliance, periodic credential rotation, or after a potential credential leak. After updating the secret on the global cluster, the platform automatically synchronizes it to all member clusters.
+
+## Prerequisites \{#prerequisites}
+
+- `kubectl` access to the **global cluster** with cluster-admin privileges.
+- A new client secret value prepared. It is recommended to use a cryptographically random string of at least 32 characters.
+
+:::warning
+Changing the Client Secret causes affected components to restart, resulting in temporary authentication disruptions. Plan this operation during a maintenance window.
+:::
+
+## OIDC Secret Overview \{#oidc_secret_overview}
+
+The platform OIDC credential is stored in a Kubernetes Secret with the following details:
+
+| Property    | Value                |
+| :---------- | :------------------- |
+| Secret Name | `cpaas-oidc-secret`  |
+| Namespace   | `cpaas-system`       |
+
+The Secret contains two data keys:
+
+- `client-id` — The OIDC client identifier, with the default value `alauda-auth`. **Do not modify this value.**
+- `client-secret` — The OIDC client secret. This is the value you will rotate.
+
+## Procedure \{#procedure}
+
+<Steps>
+
+### Back up the current secret \{#backup_secret}
+
+Before making changes, back up the current Secret manifest so you can roll back if needed.
+
+```bash
+kubectl get secret cpaas-oidc-secret -n cpaas-system -o yaml > cpaas-oidc-secret-backup.yaml
+```
+
+:::warning
+The backup file contains sensitive credential data. Store it in a secure location and delete it after the operation is complete.
+:::
+
+### Update the Client Secret \{#update_secret}
+
+:::danger
+Do not modify the `client-id` value, and do not delete and recreate the Secret. Doing so may cause cascading authentication failures across the platform.
+:::
+
+Use one of the following methods to update only the `client-secret` data field.
+
+**Method 1: Using `kubectl patch` (recommended)**
+
+Replace `<NEW_CLIENT_SECRET>` with your new secret value.
+
+```bash
+kubectl patch secret cpaas-oidc-secret -n cpaas-system \
+  --type merge \
+  -p "{\"data\":{\"client-secret\":\"$(echo -n '<NEW_CLIENT_SECRET>' | base64 | tr -d '\n')\"}}"
+```
+
+**Method 2: Using `kubectl edit`**
+
+Open the Secret in your default editor and replace the `client-secret` value with the new base64-encoded value.
+
+```bash
+kubectl edit secret cpaas-oidc-secret -n cpaas-system
+```
+
+:::tip
+You can generate the base64-encoded value in advance:
+
+```bash
+echo -n '<NEW_CLIENT_SECRET>' | base64
+```
+:::
+
+Verify that the Secret has been updated on the global cluster:
+
+```bash
+kubectl get secret cpaas-oidc-secret -n cpaas-system \
+  -o jsonpath='{.data.client-secret}' | base64 -d
+```
+
+### Verify component health \{#verify_components}
+
+After the Secret is updated, the `base-operator` automatically synchronizes it to all member clusters. Some components that depend on the OIDC credential will restart to load the new value. In particular, verify that the `frontend` and `apollo` deployments are running normally:
+
+```bash
+kubectl get deploy -n cpaas-system frontend apollo
+```
+
+Verify that all Pods are `READY` and `UP-TO-DATE`. It may take several minutes for the restart to complete.
+
+:::info
+If a component fails to start, verify that the `cpaas-oidc-secret` Secret exists in the `cpaas-system` namespace and contains valid `client-id` and `client-secret` values.
+:::
+
+</Steps>
+
+## Rollback \{#rollback}
+
+If issues occur after the Secret change, restore the previous value from the backup created in [Step 1](#backup_secret):
+
+```bash
+kubectl apply -f cpaas-oidc-secret-backup.yaml
+```
+
+Alternatively, if you know the previous secret value:
+
+```bash
+kubectl patch secret cpaas-oidc-secret -n cpaas-system \
+  --type merge \
+  -p "{\"data\":{\"client-secret\":\"$(echo -n '<PREVIOUS_CLIENT_SECRET>' | base64 | tr -d '\n')\"}}"
+```
+
+After rolling back, repeat the [verification steps](#verify_components) to confirm that all components are healthy.

--- a/docs/en/security/platform_security_configurations/disable_pkce_plain_method.mdx
+++ b/docs/en/security/platform_security_configurations/disable_pkce_plain_method.mdx
@@ -1,0 +1,72 @@
+---
+weight: 20
+queries:
+  - how to disable PKCE plain method
+  - how to remove plain code challenge method from OIDC
+  - PKCE security hardening after ACP upgrade
+---
+
+# Disabling the PKCE Plain Method \{#disable_pkce_plain_method}
+
+Starting from ACP v4.3.0, PKCE (Proof Key for Code Exchange) verification is enabled by default for login authorization. To maintain backward compatibility with L5 plugins that have not yet been upgraded, the platform retains the `plain` code challenge method alongside the secure `S256` method after upgrade.
+
+Once all plugins have been upgraded to versions compatible with ACP v4.3.0, you should remove the `plain` method to enforce `S256`-only PKCE verification.
+
+## Prerequisites \{#prerequisites}
+
+- `kubectl` access to the **global cluster** with cluster-admin privileges.
+- All L5 plugins have been upgraded to versions compatible with ACP v4.3.0.
+
+:::warning
+Removing the `plain` method before all plugins are upgraded will cause authentication failures for plugins that do not support `S256` PKCE verification.
+:::
+
+## Procedure \{#procedure}
+
+The OIDC client configuration is stored as an `OAuth2Client` custom resource in the `cpaas-system` namespace. The resource name `mfwgc5lemewwc5lundf7fhheqqrcgji` is a hash of the client ID `alauda-auth`.
+
+Edit the `OAuth2Client` resource:
+
+```bash
+kubectl edit oauth2client mfwgc5lemewwc5lundf7fhheqqrcgji -n cpaas-system
+```
+
+Locate the `codeChallengeMethods` field and remove the `plain` entry, keeping only `S256`:
+
+```yaml
+# Before
+codeChallengeMethods:
+- S256
+- plain
+
+# After
+codeChallengeMethods:
+- S256
+```
+
+Save and exit the editor. The change takes effect immediately.
+
+## Verification \{#verification}
+
+Confirm that the `plain` method has been removed:
+
+```bash
+kubectl get oauth2client mfwgc5lemewwc5lundf7fhheqqrcgji -n cpaas-system \
+  -o jsonpath='{.codeChallengeMethods}'
+```
+
+The output should be:
+
+```
+["S256"]
+```
+
+## Rollback \{#rollback}
+
+If authentication issues occur after removing the `plain` method, add it back:
+
+```bash
+kubectl patch oauth2client mfwgc5lemewwc5lundf7fhheqqrcgji -n cpaas-system \
+  --type merge \
+  -p '{"codeChallengeMethods":["S256","plain"]}'
+```

--- a/docs/en/security/platform_security_configurations/disable_pkce_plain_method.mdx
+++ b/docs/en/security/platform_security_configurations/disable_pkce_plain_method.mdx
@@ -8,27 +8,39 @@ queries:
 
 # Disabling the PKCE Plain Method \{#disable_pkce_plain_method}
 
-Starting from ACP v4.3.0, PKCE (Proof Key for Code Exchange) verification is enabled by default for login authorization. To maintain backward compatibility with L5 plugins that have not yet been upgraded, the platform retains the `plain` code challenge method alongside the secure `S256` method after upgrade.
+Starting from ACP v4.3.0, PKCE (Proof Key for Code Exchange) verification is enabled by default for login authorization. To maintain backward compatibility with affected plugins that use the `Agnostic` life cycle and are not yet upgraded, the platform retains the `plain` code challenge method alongside the secure `S256` method after upgrade.
 
-Once all plugins have been upgraded to versions compatible with ACP v4.3.0, you should remove the `plain` method to enforce `S256`-only PKCE verification.
+Once all affected `Agnostic` plugins have been upgraded to versions compatible with ACP v4.3.0, you should remove the `plain` method to enforce `S256`-only PKCE verification.
 
 ## Prerequisites \{#prerequisites}
 
 - `kubectl` access to the **global cluster** with cluster-admin privileges.
-- All L5 plugins have been upgraded to versions compatible with ACP v4.3.0.
+- All clusters managed by the platform have been upgraded to ACP v4.3.
+- The following affected plugins with the `Agnostic` life cycle have been upgraded to versions compatible with ACP v4.3:
+  - `Alauda Container Platform Gitops`
+  - `Alauda Build of Kiali`
+  - `Kubeflow Base`
+  - `Alauda AI`
 
 :::warning
-Removing the `plain` method before all plugins are upgraded will cause authentication failures for plugins that do not support `S256` PKCE verification.
+In this context, affected plugins are the listed `Agnostic` plugins that use the platform OIDC authorization flow; removing `plain` before all of them are upgraded to ACP v4.3-compatible versions will cause authentication failures.
 :::
 
 ## Procedure \{#procedure}
 
-The OIDC client configuration is stored as an `OAuth2Client` custom resource in the `cpaas-system` namespace. The resource name `mfwgc5lemewwc5lundf7fhheqqrcgji` is a hash of the client ID `alauda-auth`.
+The OIDC client configuration is stored as an `OAuth2Client` custom resource in the `cpaas-system` namespace. Determine the target resource name by client ID:
+
+```bash
+OIDC_CLIENT_NAME="$(kubectl get oauth2client -n cpaas-system \
+  -o jsonpath='{range .items[?(@.id=="alauda-auth")]}{.metadata.name}{"\n"}{end}' | head -n 1)"
+test -n "${OIDC_CLIENT_NAME}" || { echo "Failed to find OAuth2Client for id=alauda-auth"; exit 1; }
+echo "Target OAuth2Client: ${OIDC_CLIENT_NAME}"
+```
 
 Edit the `OAuth2Client` resource:
 
 ```bash
-kubectl edit oauth2client mfwgc5lemewwc5lundf7fhheqqrcgji -n cpaas-system
+kubectl edit oauth2client "${OIDC_CLIENT_NAME}" -n cpaas-system
 ```
 
 Locate the `codeChallengeMethods` field and remove the `plain` entry, keeping only `S256`:
@@ -51,7 +63,7 @@ Save and exit the editor. The change takes effect immediately.
 Confirm that the `plain` method has been removed:
 
 ```bash
-kubectl get oauth2client mfwgc5lemewwc5lundf7fhheqqrcgji -n cpaas-system \
+kubectl get oauth2client "${OIDC_CLIENT_NAME}" -n cpaas-system \
   -o jsonpath='{.codeChallengeMethods}'
 ```
 
@@ -61,12 +73,16 @@ The output should be:
 ["S256"]
 ```
 
+Run at least one login/authorization verification for each affected plugin (`Alauda Container Platform Gitops`, `Alauda Build of Kiali`, `Kubeflow Base`, and `Alauda AI`) to confirm there are no PKCE-related authentication failures.
+
 ## Rollback \{#rollback}
 
-If authentication issues occur after removing the `plain` method, add it back:
+If authentication issues occur after removing the `plain` method (for example, any affected plugin login or authorization fails), add it back:
 
 ```bash
-kubectl patch oauth2client mfwgc5lemewwc5lundf7fhheqqrcgji -n cpaas-system \
+kubectl patch oauth2client "${OIDC_CLIENT_NAME}" -n cpaas-system \
   --type merge \
   -p '{"codeChallengeMethods":["S256","plain"]}'
 ```
+
+After rollback, verify affected plugin logins again and then `unset OIDC_CLIENT_NAME`.

--- a/docs/en/security/platform_security_configurations/index.mdx
+++ b/docs/en/security/platform_security_configurations/index.mdx
@@ -1,0 +1,7 @@
+---
+weight: 25
+---
+
+# Platform Security Configurations
+
+<Overview />


### PR DESCRIPTION
Add new section 'Platform Security Configurations' under Security:
- Changing the Platform OIDC Client Secret guide
- Disabling the PKCE Plain Method guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for rotating the Platform OIDC client secret with step-by-step procedures and rollback instructions.
  * Added guide for enforcing PKCE security by disabling the plain code challenge method.
  * Established new platform security configurations documentation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->