### PR TITLE
[codex] update 4.3 release notes

### DIFF
--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -133,31 +133,31 @@ This release introduces the **Alauda Container Platform Project Application Esse
 - **Project isolation**: All operations scoped to the project boundary, ensuring natural isolation between projects.
 - **Permission-aware**: Strictly enforces RBAC permissions, displaying only resources the user is authorized to access.
 
-#### Egress Gateway High Availability and Resource Protection
+#### Underlay and Egress Gateway Enhancements
 
-ACP 4.3 improves the operational resilience of the egress gateway.
+ACP 4.3 expands core CNI networking capabilities around underlay access and egress gateway operations.
 
 Key enhancements include:
 
 * Better high-availability and fast-switching design for egress gateway workloads, reducing service impact during node maintenance or failover.
 * Resource protection guidance and platform support for egress gateway Pods, helping reduce the risk of node resource contention under traffic spikes or replica growth.
 * Support for configuring taints for egress gateway workloads, allowing better placement isolation on dedicated nodes.
-* Support for custom VIP addresses for `EgressGatewayAPI`, helping keep outbound addresses stable across rebuilds or lifecycle changes.
-
-#### Underlay and Gateway Networking Enhancements
-
-ACP 4.3 expands the networking capabilities around underlay access and gateway-based traffic exposure.
-
-Key enhancements include:
-
 * Support for managing VLAN sub-interfaces for underlay NICs.
-* Support for host-network-based gateway deployment scenarios.
-* Support for exposing services through `metalLB + ALB + underlay`, so business traffic can avoid the management network.
 * Added YAML editing support for subnet resources.
 * Added support for node selector settings for centralized gateways.
 * Added subnet CRD support for centralized gateway scenarios.
 
 These enhancements make ACP more adaptable to complex enterprise networking environments and simplify migration from earlier exposure models to underlay-based designs.
+
+#### Gateway API Enhancements
+
+ACP 4.3 strengthens **Gateway API** as a key Layer 7 load balancing capability in the platform.
+
+Key enhancements include:
+
+* Support for host-network-based gateway deployment scenarios.
+* Support for exposing services through `metalLB + Envoy Gateway proxy + underlay`, so business traffic can avoid the management network.
+* Support for custom VIP addresses for Gateway API, helping keep service exposure addresses stable across rebuilds or lifecycle changes.
 
 #### Stateful Application Disaster Recovery with PVC-Based Protection
 

--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -173,7 +173,6 @@ Key enhancements include:
 
 * Added support for placing disks into different Ceph pools from the UI.
 * Improved operational support for Ceph disk replacement scenarios.
-* Added MicroOS compatibility support for Ceph-related deployments.
 
 These changes improve day-2 storage operations and make Ceph-based environments easier to manage in production.
 

--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -133,6 +133,62 @@ This release introduces the **Alauda Container Platform Project Application Esse
 - **Project isolation**: All operations scoped to the project boundary, ensuring natural isolation between projects.
 - **Permission-aware**: Strictly enforces RBAC permissions, displaying only resources the user is authorized to access.
 
+#### Egress Gateway High Availability and Resource Protection
+
+ACP 4.3 improves the operational resilience of the egress gateway.
+
+Key enhancements include:
+
+* Better high-availability and fast-switching design for egress gateway workloads, reducing service impact during node maintenance or failover.
+* Resource protection guidance and platform support for egress gateway Pods, helping reduce the risk of node resource contention under traffic spikes or replica growth.
+* Support for configuring taints for egress gateway workloads, allowing better placement isolation on dedicated nodes.
+* Support for custom VIP addresses for `EgressGatewayAPI`, helping keep outbound addresses stable across rebuilds or lifecycle changes.
+
+#### Underlay and Gateway Networking Enhancements
+
+ACP 4.3 expands the networking capabilities around underlay access and gateway-based traffic exposure.
+
+Key enhancements include:
+
+* Support for managing VLAN sub-interfaces for underlay NICs.
+* Support for host-network-based gateway deployment scenarios.
+* Support for exposing services through `metalLB + ALB + underlay`, so business traffic can avoid the management network.
+* Added YAML editing support for subnet resources.
+* Added support for node selector settings for centralized gateways.
+* Added subnet CRD support for centralized gateway scenarios.
+
+These enhancements make ACP more adaptable to complex enterprise networking environments and simplify migration from earlier exposure models to underlay-based designs.
+
+#### Stateful Application Disaster Recovery with PVC-Based Protection
+
+ACP 4.3 introduces stronger disaster recovery capabilities for stateful workloads, including **PVC-based disaster recovery** and support for **VolSync-based backup and restore workflows** for storage-backed applications such as MinIO.
+
+This enhancement improves cross-cluster recovery readiness for stateful applications and provides a more practical protection path for storage-heavy production environments.
+
+#### Ceph Storage Management Enhancements
+
+ACP 4.3 improves storage operations and Ceph-based workload support.
+
+Key enhancements include:
+
+* Added support for placing disks into different Ceph pools from the UI.
+* Improved operational support for Ceph disk replacement scenarios.
+* Added MicroOS compatibility support for Ceph-related deployments.
+
+These changes improve day-2 storage operations and make Ceph-based environments easier to manage in production.
+
+#### Virtualization Platform Enhancements
+
+ACP 4.3 delivers several important virtualization-related improvements.
+
+Key enhancements include:
+
+* Improved VM creation and display workflows.
+* Added support for Astra Linux in virtualization-related scenarios.
+* Added support for multi-NIC and NIC hot-plug capabilities for virtual machines.
+
+These enhancements improve virtualization usability and expand guest workload compatibility in enterprise environments.
+
 ### Deprecated and Removed Features
 
 #### Decommissioning of Operation Statistics


### PR DESCRIPTION
## What changed

- added release notes entries for major completed `net` and `storage` epics in ACP 4.3
- covered egress gateway resilience, underlay and gateway networking, stateful application DR, Ceph storage enhancements, and virtualization improvements
- excluded smaller improvements, research items, documentation-only items, and validation tasks

## Why

The 4.3 release notes were missing a concise summary of several user-visible platform capabilities that were already tracked as completed work in Jira.

## Impact

Documentation readers get a clearer release summary for ACP 4.3, focused on larger platform changes that matter operationally.

## Validation

- `./node_modules/.bin/doom lint`
