### PR TITLE
feat: add Alauda Distributed Tracing subsite docs

### DIFF
--- a/docs/en/observability/tracing/index.mdx
+++ b/docs/en/observability/tracing/index.mdx
@@ -5,4 +5,10 @@ sourceSHA: 8ba3620ee53ce38d65fc162d00e3c4f895940b15dc2179b1f2b7dcbed587b56d
 
 # Distributed Tracing
 
+:::danger Deprecation Notice
+The Distributed Tracing documentation in this section is deprecated and will be removed in ACP 4.4. ACP 4.3 is the last version that includes this documentation.
+
+Please use <ExternalSiteLink name="distributed-tracing" href="/" children="Alauda Distributed Tracing" /> for all new deployments and migrations.
+:::
+
 <Overview />

--- a/sites.yaml
+++ b/sites.yaml
@@ -19,6 +19,13 @@
   base: /opentelemetry
   version: "2.0"
   repo: https://github.com/alauda/opentelemetry-docs
+- name: distributed-tracing
+  displayName:
+    en: Alauda Distributed Tracing
+    zh: Alauda Distributed Tracing
+  base: /distributed-tracing
+  version: "2.0"
+  repo: https://github.com/alauda/distributed-tracing-docs
 - name: ai
   displayName:
     en: Alauda AI


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notice for the existing Distributed Tracing documentation (scheduled for removal in ACP 4.4; last supported version: ACP 4.3).
  * Introduced new Alauda Distributed Tracing documentation resource for new deployments and migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->