### PR TITLE
[codex] add x86-64-v2 guidance for user-provided OS

### DIFF
--- a/docs/en/install/prepare/node_preprocessing.mdx
+++ b/docs/en/install/prepare/node_preprocessing.mdx
@@ -20,6 +20,12 @@ The platform enforces strict version matching policies for official support:
 - Kylin V10, V10-SP1, and V10-SP2 have known kernel issues that may cause **NodePort network access failures**, it is recommended to upgrade to **Kylin V10-SP3**.
 :::
 
+:::info
+`x86-64-v2` is a CPU instruction set baseline used by some operating systems, platform images, or optional components. For user-provided operating systems, ACP does not impose a universal `x86-64-v2` requirement on all x86 nodes. If you use older CPUs, verify CPU compatibility according to the selected operating system and the components you plan to deploy.
+
+For ACP-provided immutable operating system images or platform images, follow the CPU baseline requirements documented for those images.
+:::
+
 ### x86
 
 <Tabs>


### PR DESCRIPTION
## Summary
- add an x86-64-v2 guidance note to the node preprocessing page for user-provided operating systems
- clarify that ACP does not impose a universal x86-64-v2 requirement on all x86 nodes in the user-provided OS scenario
- point readers to ACP-provided immutable OS or platform image documentation for image-specific CPU baseline requirements

## Why
ACP supports multiple user-provided operating systems such as Ubuntu, RHEL, CentOS, and Kylin. In that model, ACP cannot declare x86-64-v2 as a universal hard requirement for every x86 node, because CPU baseline requirements can depend on the selected operating system, platform image, or optional component.

This change documents the platform-level guidance without trying to infer feature-specific requirements. Feature owners should continue to document any stricter CPU requirements in their own feature documentation.

## Why not change virtualization docs
This PR intentionally does not update virtualization documentation. The goal here is to provide platform-level guidance that applies before users decide which optional components to deploy. Feature-level requirements should remain with the corresponding feature owners and docs.

## Validation
- `git diff --check`
- `yarn lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation documentation with guidance on CPU instruction set baseline requirements and compatibility verification for different system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->