### PR TITLE
Bump gitops docs to 4.3

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -143,7 +143,7 @@
     en: Alauda Container Platform GitOps
     zh: Alauda Container Platform GitOps
   base: /gitops
-  version: "4.2"
+  version: "4.3"
   repo: https://github.com/alauda/gitops-docs
 - name: hosted-control-plane
   displayName:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the gitops site to version 4.3.
  * No other site entries or visible settings were modified.
  * Low-risk change; no UI or behavior changes expected from this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->