### PR TITLE
[codex] backport machine configuration route fix to release-4.3

### DIFF
--- a/docs/en/configure/machine_config/index.mdx
+++ b/docs/en/configure/machine_config/index.mdx
@@ -10,5 +10,5 @@ title: Machine Configuration
 Note that **Machine Configuration is only supported in Immutable Infrastructure**. In this architecture, the node operating system is immutable, and configuration updates are applied through controlled images or configuration policies, ensuring repeatability and system stability.
 
 :::info
-Because Machine Configuration releases on a different cadence from <Term name="product" />, the Machine Configuration documentation is now available as a separate documentation set at <ExternalSiteLink name="immutable-infra" href="/machine_config/index.html" children="Machine Configuration" />.
+Because Machine Configuration releases on a different cadence from <Term name="product" />, the Machine Configuration documentation is now available as a separate documentation set at <ExternalSiteLink name="immutable-infra" href="/machine-configuration/index.html" children="Machine Configuration" />.
 :::


### PR DESCRIPTION
## What changed

- moved the Machine Configuration overview page from `docs/en/configure/machine_config.mdx` to `docs/en/configure/machine_config/index.mdx`
- updated the Machine Configuration external docs link to use Doom `ExternalSiteLink` with `name="immutable-infra"` and `href="/machine-configuration/index.html"`

## Why it changed

The old page was emitted as `configure/machine_config.html`, so requests to `configure/machine_config/index.html` returned 404. This branch still used the flat-file route, which was inconsistent with the expected directory-style output path.

The Machine Configuration docs now live in the Immutable Infrastructure documentation set. Per Doom external-site conventions, this page should use `ExternalSiteLink`, with `sites.yaml` resolving the `immutable-infra` base and version.

## Impact

- `machine_config/index.html` is generated again on the ACP docs site
- the Machine Configuration page links to the Immutable Infrastructure Machine Configuration page through the standard Doom external-site component

## Validation

- manual diff review against the merged `master` fix
- local branch pre-commit `doom lint` hook is not stable in this environment on this release branch, so the commit was created with `SKIP_SIMPLE_GIT_HOOKS=1`
- `yarn build` was not run