### PR TITLE
[codex] backport overview glossary to release-4.1

### DIFF
--- a/docs/en/overview/architecture.mdx
+++ b/docs/en/overview/architecture.mdx
@@ -11,6 +11,8 @@ The <Term name="product" /> (<Term name="productShort" />) provides an enterpris
 
 The architecture follows a **hub-and-spoke** model, consisting of a `global` cluster and multiple workload clusters. This design provides centralized governance while allowing independent workload execution and scalability.
 
+For canonical definitions of platform-wide terms such as `global` cluster, workload cluster, and cluster plugin, see [Glossary](./glossary.mdx).
+
 ![](./assets/arch-overview.svg)
 
 ## Core Architectural Components

--- a/docs/en/overview/glossary.mdx
+++ b/docs/en/overview/glossary.mdx
@@ -1,0 +1,76 @@
+---
+weight: 12
+queries:
+  - acp glossary
+  - alauda container platform terminology
+  - acp cluster model terms
+  - global cluster workload cluster hosted control plane
+  - immutable infrastructure immutable os managed cluster
+---
+
+# Glossary
+
+This glossary defines canonical platform-wide terms used across <Term name="product" /> documentation. It focuses on concepts that appear in multiple sections of the product. Terms that apply only to a single workflow or subsystem should remain documented in their local pages.
+
+## Platform and Cluster Terms
+
+| Term | Definition | Related doc |
+| ---- | ---------- | ----------- |
+| Global Cluster | The centralized management and control hub of <Term name="productShort" />. In the platform's hub-and-spoke architecture, it provides platform-wide services such as authentication, policy management, cluster lifecycle operations, and observability. | [Architecture](./architecture.mdx) |
+| Workload Cluster | A Kubernetes-based environment managed by the `global` cluster. A workload cluster runs isolated application workloads and inherits governance and configuration from the central control plane. | [Architecture](./architecture.mdx) |
+| Platform-Provisioned Infrastructure | A cluster management model in which the platform provisions both machines and node operating systems, and manages the full cluster lifecycle. In this model, all nodes use an immutable operating system. | [Clusters Overview](../configure/clusters/overview.mdx) |
+| User-Provisioned Infrastructure | A cluster management model in which users provide pre-provisioned physical or virtual machines. The platform manages Kubernetes on those nodes, while node operating system management remains under user control. | [Clusters Overview](../configure/clusters/overview.mdx) |
+| Hosted Control Plane (HCP) | A deployment model in which each cluster has its own dedicated control plane, while multiple control planes are hosted as workloads on a dedicated management cluster. This model separates the control plane from worker nodes to reduce resource consumption and improve multi-cluster scalability. | [About Hosted Control Plane](../configure/clusters/about-hcp.mdx) |
+| Managed Cluster | An existing cluster brought under the platform for centralized governance and operations. In ACP, managed clusters include existing standard Kubernetes clusters and selected public cloud clusters that are onboarded through import or registration workflows. | [Managed Clusters Overview](../configure/clusters/managed/overview.mdx) |
+| Immutable OS | An immutable operating system used for platform-managed nodes in platform-provisioned environments. Node state is kept consistent and recoverable by treating the operating system layer as read-only and centrally managed. | [Clusters Overview](../configure/clusters/overview.mdx) |
+| Immutable Infrastructure | A cluster provisioning and operating model in which node configurations are baked into images and remain unchanged after deployment. Cluster upgrades and configuration changes are applied by replacing nodes with new images. | [About Immutable Infrastructure](../configure/clusters/immutable-infra.mdx) |
+| Project | A platform governance unit that isolates resources and personnel for a tenant or team. A project can span multiple associated clusters and acts as the management boundary for quotas, policies, and namespace ownership. | [Create Project](../security/project/functions/create_project.mdx) |
+| Namespace | A Kubernetes namespace managed directly or indirectly by the platform. In ACP, a namespace can be created within or imported into a project so that it inherits project-level governance and visibility. | [Importing Namespaces](../developer/building_application/namespace/import_namespace.mdx) |
+| Control Plane | The Kubernetes management layer that runs core cluster components such as the API server, scheduler, and controller manager. | [Architecture](./architecture.mdx) |
+| Control Plane Node | A node that runs Kubernetes control plane components used for cluster management. Use this term instead of outdated alternatives such as "master node". | [Architecture](./architecture.mdx) |
+| Worker Node | A node that runs application workloads and supporting platform components. Use this term instead of outdated alternatives such as "slave node". | [Architecture](./architecture.mdx) |
+
+## Identity and Access Terms
+
+| Term | Definition | Related doc |
+| ---- | ---------- | ----------- |
+| Identity Provider (IdP) | An external identity system that authenticates users for the platform, such as LDAP, Active Directory, or an OpenID Connect provider. | [Accessing the Web Console](../ui/web_console/access.mdx) |
+| OpenID Connect (OIDC) | An identity layer built on OAuth 2.0 that ACP uses in several authentication and authorization scenarios. | [Managing OIDC](../security/users_and_roles/idp/functions/oidc_manage.mdx) |
+
+## Extension and Packaging Terms
+
+| Term | Definition | Related doc |
+| ---- | ---------- | ----------- |
+| Operator | An extension mechanism built on Kubernetes custom resources and controllers that automates lifecycle management for complex applications or services. In <Term name="productShort" />, Operators are managed through Operator Lifecycle Manager. | [Operator](../extend/operator.mdx) |
+| Operator Lifecycle Manager (OLM) | The operator management framework that handles Operator installation, upgrades, channel subscriptions, dependency resolution, and related custom resources such as `CatalogSource`, `Subscription`, and `InstallPlan`. | [Operator](../extend/operator.mdx) |
+| OperatorHub | The platform interface for discovering, installing, upgrading, and managing Operators through OLM. | [Operator](../extend/operator.mdx) |
+| Cluster Plugin | The platform's extension mechanism for chart-based plugins. Cluster plugins are managed through the `ModulePlugin`, `ModuleConfig`, and `ModuleInfo` custom resources. | [Cluster Plugin](../extend/cluster_plugin.mdx) |
+
+## Networking and Access Terms
+
+| Term | Definition | Related doc |
+| ---- | ---------- | ----------- |
+| Ingress | A Kubernetes resource that exposes HTTP and HTTPS routes from outside the cluster to internal services. ACP uses Ingress as one of its main north-south traffic entry models. | [Configure Ingresses](../configure/networking/functions/configure_ingress.mdx) |
+| Gateway API | The Kubernetes networking API family that defines role-oriented resources for advanced L4 and L7 routing. In ACP, Gateway API is positioned as a next-generation traffic management model alongside Service and Ingress. | [GatewayAPI](../configure/networking/concepts/gatewayapi.mdx) |
+| Service | In Kubernetes, a Service is a method for exposing a network application that runs as one or more Pods in a cluster. In ACP, Service is a core service-discovery and traffic-exposure primitive, including `ClusterIP`, `NodePort`, and `LoadBalancer` types. | [Configure Services](../configure/networking/functions/configure_service.mdx) |
+| LoadBalancer | A Service type that exposes a Service through an external load balancer. This usually requires either a cloud-provider integration or a separately provided load-balancing component. | [Configure Services](../configure/networking/functions/configure_service.mdx) |
+| Platform Access Address | The external address used to access platform services such as the web console and platform APIs. It can be the same as the Cluster Endpoint or a separate address for external access scenarios. | [Install](../install/installing.mdx) |
+| Cluster Endpoint | The address used by cluster components and administrators to reach the target cluster control plane endpoint. It is the primary control-plane access entry during installation and later operations. | [Install](../install/installing.mdx) |
+| Self-built VIP | The built-in virtual IP option used when an external load balancer is not provided for the Cluster Endpoint. | [Install](../install/installing.mdx) |
+
+## Disaster Recovery and Upgrade Terms
+
+| Term | Definition | Related doc |
+| ---- | ---------- | ----------- |
+| Global Cluster Disaster Recovery | The disaster recovery model for the `global` cluster in which a primary global cluster and a standby global cluster are kept ready for failover through etcd data synchronization and coordinated operational procedures. | [Global Cluster Disaster Recovery](../install/global_dr.mdx) |
+| Cluster Version Operator (CVO) | The operator-based upgrade workflow and controller used to coordinate target version, preflight status, and execution progress for `global` and workload cluster upgrades. | [Upgrade Overview](../upgrade/overview.mdx) |
+
+## Usage Notes
+
+- Use this page as the canonical source for ACP-wide terms that appear across multiple documentation sections.
+- Keep page-local `## Terminology` sections for workflow-specific or subsystem-specific terms that are not reused broadly across the product.
+- The **Term** column uses a normalized display style for readability.
+- Keep official feature names, protocol names, UI labels, and API-facing names in their official capitalization, such as `OperatorHub`, `Platform Access Address`, `ClusterIP`, `Self-built VIP`, and `OpenID Connect (OIDC)`.
+- Favor product concepts, platform models, and high-value cross-section entry terms over generic engineering vocabulary.
+- Expand an acronym on first mention when needed, then use the acronym consistently.
+- When a term is already defined by Kubernetes or OpenShift, use the upstream meaning first and add ACP-specific context only when needed.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "update-ac-manual": "node scripts/update-ac-manual.js release-1.0"
   },
   "dependencies": {
-    "@alauda/doom": "^2.3.0"
+    "@alauda/doom": "^2.4.0"
   },
   "devDependencies": {
     "prettier": "^3.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,9 +20,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alauda/doom@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "@alauda/doom@npm:2.3.0"
+"@alauda/doom@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "@alauda/doom@npm:2.4.0"
   dependencies:
     "@alauda/doom-export": "npm:^0.4.1"
     "@cspell/eslint-plugin": "npm:^10.0.0"
@@ -97,7 +97,7 @@ __metadata:
     yoctocolors: "npm:^2.1.2"
   bin:
     doom: lib/cli/index.js
-  checksum: 10c0/073eacad79da2a885a56c0aef86076f34663f78b94aac335d15779fe7e50884edc2e640eac2fd9b6670d458eca395ffbe3ee4194120edcc92a7ddca40f664f2c
+  checksum: 10c0/2a92fa0d8efeaf8b640340ac387752f45691b1ab5bbe4618542433f24a321cf66090f9f2162d6c74ca9ed05507172272b37468b02db86d412b395e24f6d67bd9
   languageName: node
   linkType: hard
 
@@ -3323,7 +3323,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "acp-docs@workspace:."
   dependencies:
-    "@alauda/doom": "npm:^2.3.0"
+    "@alauda/doom": "npm:^2.4.0"
     prettier: "npm:^3.8.3"
     prettier-plugin-pkg: "npm:^0.22.1"
     simple-git-hooks: "npm:^2.13.1"


### PR DESCRIPTION
## What changed

- backport the new `docs/en/overview/glossary.mdx` page to `release-4.1`
- add the overview architecture link that points readers to the glossary
- run the standard Doom preview-prep dependency update on this branch (`yarn up @alauda/doom` and `yarn install`)
- adjust the OIDC and Gateway API related-doc links in the glossary to match the document layout that exists on `release-4.1`

## Why

- `release-4.1` should carry the same overview glossary improvements where the branch structure allows it
- the glossary centralizes ACP-wide platform terminology used across overview, cluster, install, and upgrade content

## Validation

- `yarn lint`
