### PR TITLE
docs(appservice): backport manual upgrade instructions to release-4.3

### DIFF
--- a/docs/en/appservice/upgrade.mdx
+++ b/docs/en/appservice/upgrade.mdx
@@ -5,7 +5,12 @@ en: Upgrade
 
 # Upgrade
 
-Alauda Container Platform Data Services Essentials are designed to upgrade automatically during platform upgrades, requiring no manual intervention. The system handles all necessary migrations and updates seamlessly in the background.
+Alauda Container Platform Data Services Essentials requires a manual upgrade. After upgrading the platform, follow the steps below to upgrade the plugin:
+
+1. Log in to the platform and navigate to **Marketplace** > **Cluster Plugins**.
+2. Locate **Alauda Container Platform Data Services Essentials** and click into its detail page.
+3. Click **Actions** and select **Upgrade**.
+4. In the upgrade dialog, select the **Target Version** and click **Upgrade** to confirm.
 
 Alauda Container Platform Data Services RDS Framework will execute upgrades based on the configured upgrade strategy:
 * **Automatic**: Auto-upgrades are triggered immediately upon detecting new component versions.


### PR DESCRIPTION
## Summary
- Backport the Data Services Essentials manual plugin upgrade instructions from PR #674 / commit 769152297c938f8682e1fceacfb51ce5fbf278cc to release-4.3.

## Verification
- node .yarn/releases/yarn-4.14.1.cjs lint
- node .yarn/releases/yarn-4.14.1.cjs build *(fails locally: missing JIRA_USERNAME/JIRA_PASSWORD, then SSG localStorage.getItem is not a function)*