### PR TITLE
Feat/registry limit support

### DIFF
--- a/docs/en/developer/registry/how_to/common_cli_command.mdx
+++ b/docs/en/developer/registry/how_to/common_cli_command.mdx
@@ -12,7 +12,8 @@ Use the `ac` CLI for platform login, namespace permission management, and Regist
 
 The examples below assume:
 
-- Registry address: `registry.cluster.local`
+- Registry client address: `<REGISTRY_CLIENT_HOSTPORT>`
+- Registry API URL: `<REGISTRY_API_URL>`
 - Current namespace: `my-ns`
 
 ## Before You Begin
@@ -45,6 +46,12 @@ If you run `ac` inside a Pod, Job, or CronJob:
 - `ac` uses the current ACP login session for Registry-related API access.
 - If `ac` runs inside a Pod and no ACP session is available, it can fall back to the mounted ServiceAccount token.
 - `nerdctl` authenticates directly to the Registry, typically by using the same ACP account credentials that already have access to the target namespace.
+
+Address usage in this document:
+
+- `<REGISTRY_CLIENT_HOSTPORT>` is the Registry address used by OCI clients such as `nerdctl`.
+- `<REGISTRY_API_URL>` is the Registry API endpoint used by `ac get images` and `ac delete images`.
+- In external access scenarios, `ac` should typically use an explicitly specified `--registry-url` instead of relying on the default in-cluster Registry address.
 
 ## Authenticate to ACP
 
@@ -91,7 +98,15 @@ ac create rolebinding <binding-name> --clusterrole=system:image-pusher --service
 For image push and pull, use the same ACP account credentials that have access to the target namespace:
 
 ```bash
-nerdctl login registry.cluster.local -u <ACP-USERNAME> -p <ACP-PASSWORD>
+nerdctl login <REGISTRY_CLIENT_HOSTPORT> -u <ACP-USERNAME> -p <ACP-PASSWORD>
+```
+
+If the Registry uses a self-signed certificate or plain HTTP, add the global flag `--insecure-registry`.
+
+Example:
+
+```bash
+nerdctl --insecure-registry login <REGISTRY_CLIENT_HOSTPORT> -u <ACP-USERNAME> -p <ACP-PASSWORD>
 ```
 
 ## List Images
@@ -99,19 +114,21 @@ nerdctl login registry.cluster.local -u <ACP-USERNAME> -p <ACP-PASSWORD>
 List images from namespaces that the current user is allowed to access:
 
 ```bash
-ac get images
+ac get images --registry-url=<REGISTRY_API_URL>
 
 # List images from a specific namespace
-ac get images -n my-ns
+ac get images -n my-ns --registry-url=<REGISTRY_API_URL>
 
 # Use structured output
-ac get images -o yaml
+ac get images -o yaml --registry-url=<REGISTRY_API_URL>
 ```
 
-If `ac` cannot automatically detect the correct Registry endpoint in your environment, specify it explicitly:
+When `ac` runs outside the cluster, explicitly specifying `--registry-url` is recommended. Otherwise, the CLI may fall back to the default in-cluster Registry address, which is often unreachable from a local workstation.
+
+Example:
 
 ```bash
-ac get images --registry-url=http://image-registry.cpaas-system
+ac get images --registry-url=<REGISTRY_API_URL>
 ```
 
 ## Pull Images
@@ -120,10 +137,10 @@ Pull an image from the Registry with `nerdctl`:
 
 ```bash
 # Pull an image from the current namespace
-nerdctl pull registry.cluster.local/my-ns/my-app:latest
+nerdctl pull <REGISTRY_CLIENT_HOSTPORT>/my-ns/my-app:latest
 
 # Pull an image from another namespace when you already have permission
-nerdctl pull registry.cluster.local/shared-ns/base-image:latest
+nerdctl pull <REGISTRY_CLIENT_HOSTPORT>/shared-ns/base-image:latest
 ```
 
 ## Push Images
@@ -132,10 +149,10 @@ Push a local image to the current namespace:
 
 ```bash
 # Tag the local image with the target repository
-nerdctl tag my-app:latest registry.cluster.local/my-ns/my-app:v1
+nerdctl tag my-app:latest <REGISTRY_CLIENT_HOSTPORT>/my-ns/my-app:v1
 
 # Push it to the Registry
-nerdctl push registry.cluster.local/my-ns/my-app:v1
+nerdctl push <REGISTRY_CLIENT_HOSTPORT>/my-ns/my-app:v1
 ```
 
 Copy an image from another registry into ACP Registry:
@@ -145,29 +162,34 @@ Copy an image from another registry into ACP Registry:
 nerdctl pull remote.registry.io/demo/my-app:latest
 
 # Retag it for ACP Registry
-nerdctl tag remote.registry.io/demo/my-app:latest registry.cluster.local/my-ns/my-app:latest
+nerdctl tag remote.registry.io/demo/my-app:latest <REGISTRY_CLIENT_HOSTPORT>/my-ns/my-app:latest
 
 # Push it to ACP Registry
-nerdctl push registry.cluster.local/my-ns/my-app:latest
+nerdctl push <REGISTRY_CLIENT_HOSTPORT>/my-ns/my-app:latest
 ```
 
 ## Delete Images
 
-Use `ac delete images` to remove image tags from the Registry. This operation removes the image manifest reference from the Registry, but it does not guarantee that the underlying image data is reclaimed immediately:
+Use `ac delete images` to remove image tags from the Registry:
 
 ```bash
 # Preview the deletion result without removing anything
-ac delete images --repo=my-ns/my-app:v1
+ac delete images --repo=my-ns/my-app:v1 --registry-url=<REGISTRY_API_URL>
 
 # Confirm the deletion
-ac delete images --repo=my-ns/my-app:v1 --confirm
+ac delete images --repo=my-ns/my-app:v1 --registry-url=<REGISTRY_API_URL> --confirm
 ```
 
-If needed, specify the Registry endpoint explicitly:
+Notes:
+
+- This operation removes the image manifest reference from the Registry, but it does not guarantee that the underlying image data is reclaimed immediately.
+- In the current implementation, if multiple tags point to the same manifest digest, deleting one tag may also remove the sibling tags that reference the same manifest.
+
+Example:
 
 ```bash
 ac delete images \
   --repo=my-ns/my-app:v1 \
-  --registry-url=http://image-registry.cpaas-system \
+  --registry-url=<REGISTRY_API_URL> \
   --confirm
 ```

--- a/docs/en/developer/registry/how_to/common_cli_command.mdx
+++ b/docs/en/developer/registry/how_to/common_cli_command.mdx
@@ -8,80 +8,166 @@ i18n:
 
 # Common CLI Command Operations
 
-The Alauda Container Platform provides command line tools for users to interact with the Alauda Container Platform Registry. The following are some examples of common operations and commands:
+Use the `ac` CLI for platform login, namespace permission management, and Registry metadata operations. Use a standard OCI client such as `nerdctl` for image transfer operations such as push and pull.
 
-Let's assume that Alauda Container Platform Registry for the cluster has a service address of registry.cluster.local and the namespace you are currently working on is my-ns.
+The examples below assume:
 
-> Contact technical services to acquire the kubectl-acp plugin and ensure it is properly installed in your environment.
+- Registry address: `registry.cluster.local`
+- Current namespace: `my-ns`
 
-## Logging in Registry
+## Before You Begin
 
-Log in to the cluster's Registry by logging in to the ACP.
+Before running the commands in this document, make sure:
+
+- `ac` is installed.
+- `nerdctl` is installed if you need to push or pull images.
+- You can reach the ACP API endpoint and the Registry address from your current environment.
+- You have logged in to ACP and selected the target cluster.
+- Your current ACP account, or the ServiceAccount used in a Pod or Job, has the required namespace permissions.
+
+Typical permission requirements:
+
+- Pull images: `system:image-puller`
+- Push images: `system:image-pusher`
+- List images with `ac get images`: access to the target namespaces
+- Delete images with `ac delete images`: permission to delete images in the target namespaces
+
+If you run `ac` inside a Pod, Job, or CronJob:
+
+- The Pod must use a valid `serviceAccountName`.
+- The mounted ServiceAccount token must be available.
+- The ServiceAccount must have permissions to access the target cluster and Registry-related APIs.
+
+## How Authentication Works
+
+`ac` and `nerdctl` use different authentication paths:
+
+- `ac` uses the current ACP login session for Registry-related API access.
+- If `ac` runs inside a Pod and no ACP session is available, it can fall back to the mounted ServiceAccount token.
+- `nerdctl` authenticates directly to the Registry, typically by using the same ACP account credentials that already have access to the target namespace.
+
+## Authenticate to ACP
+
+Before using Registry-related commands in `ac`, log in and select the target cluster:
 
 ```bash
-kubectl acp login <ACP-endpoint>
+ac login <acp-url>
+ac config get-clusters
+ac config use-cluster <cluster-name>
 ```
 
-## Add namespace permissions for users
+After login, `ac` can use the current session to access Registry-related APIs such as `ac get images` and `ac delete images`.
+
+## Grant namespace permissions to a user
 
 Add namespace pull permission for a user.
 
 ```bash
-kubectl create rolebinding <binding-name> --clusterrole=system:image-puller --user=<username> -n <namespace>
+ac create rolebinding <binding-name> --clusterrole=system:image-puller --user=<username> -n <namespace>
 ```
 
 Add namespace push permissions to a user.
 
 ```bash
-kubectl create rolebinding <binding-name> --clusterrole=system:image-pusher --user=<username> -n <namespace>
+ac create rolebinding <binding-name> --clusterrole=system:image-pusher --user=<username> -n <namespace>
 ```
 
-## Add namespace permissions for a service account
+## Grant namespace permissions to a ServiceAccount
 
 Add namespace pull permission for a service account.
 
 ```bash
-kubectl create rolebinding <binding-name> --clusterrole=system:image-puller --serviceaccount=<namespace>:<serviceaccount-name> -n <namespace>
+ac create rolebinding <binding-name> --clusterrole=system:image-puller --serviceaccount=<namespace>:<serviceaccount-name> -n <namespace>
 ```
 
 Add namespace push permission for a service account.
 
 ```bash
-kubectl create rolebinding <binding-name> --clusterrole=system:image-pusher --serviceaccount=<namespace>:<serviceaccount-name> -n <namespace>
+ac create rolebinding <binding-name> --clusterrole=system:image-pusher --serviceaccount=<namespace>:<serviceaccount-name> -n <namespace>
 ```
 
-## Pulling Images
-Pulls an image from the registry to inside the cluster (e.g., for Pod deployment).
+## Authenticate an OCI Client
+
+For image push and pull, use the same ACP account credentials that have access to the target namespace:
 
 ```bash
-# Pull the image named my-app, labeled latest, from the Registry of the current namespace (my-ns)
-kubectl acp pull registry.cluster.local/my-ns/my-app:latest
-
-# Pull images from other namespaces (e.g. shared-ns) (requires permission to pull from the shared-ns namespace)
-kubectl acp pull registry.cluster.local/shared-ns/base-image:latest
+nerdctl login registry.cluster.local -u <ACP-USERNAME> -p <ACP-PASSWORD>
 ```
 
-This command verifies your identity and pull permissions in the target namespace, and then pulls the image from the Registry.
+## List Images
 
-## Pushing Images
-Pushes locally built images or images pulled from elsewhere to a specific namespace in the registry.
-
-You need to first tag (tag) the local image with the address and namespace format of the target Registry using a standard container command line tool such as podman.
+List images from namespaces that the current user is allowed to access:
 
 ```bash
-# Tag it with the target address:
-podman tag my-app:latest registry.cluster.local/my-ns/my-app:v1
+ac get images
 
-# Use the kubectl command to push it to the Registry for the current namespace (my-ns)
-kubectl acp push registry.cluster.local/my-ns/my-app:v1
+# List images from a specific namespace
+ac get images -n my-ns
+
+# Use structured output
+ac get images -o yaml
 ```
 
-Pushes an image from a remote image repository to a specific namespace in the Alauda Container Platform Registry.
+If `ac` cannot automatically detect the correct Registry endpoint in your environment, specify it explicitly:
 
 ```bash
-# If your remote image repository has an image remote.registry.io/demo/my-app:latest
-# Use the kubectl command to push it to the namespace(my-ns) of the registry
-kubectl acp push remote.registry.io/demo/my-app:latest registry.cluster.local/my-ns/my-app:latest
+ac get images --registry-url=http://image-registry.cpaas-system
 ```
 
-This command verifies your identity and push permissions within the my-ns namespace, and then uploads the locally tagged image to Registry.
+## Pull Images
+
+Pull an image from the Registry with `nerdctl`:
+
+```bash
+# Pull an image from the current namespace
+nerdctl pull registry.cluster.local/my-ns/my-app:latest
+
+# Pull an image from another namespace when you already have permission
+nerdctl pull registry.cluster.local/shared-ns/base-image:latest
+```
+
+## Push Images
+
+Push a local image to the current namespace:
+
+```bash
+# Tag the local image with the target repository
+nerdctl tag my-app:latest registry.cluster.local/my-ns/my-app:v1
+
+# Push it to the Registry
+nerdctl push registry.cluster.local/my-ns/my-app:v1
+```
+
+Copy an image from another registry into ACP Registry:
+
+```bash
+# Pull the source image
+nerdctl pull remote.registry.io/demo/my-app:latest
+
+# Retag it for ACP Registry
+nerdctl tag remote.registry.io/demo/my-app:latest registry.cluster.local/my-ns/my-app:latest
+
+# Push it to ACP Registry
+nerdctl push registry.cluster.local/my-ns/my-app:latest
+```
+
+## Delete Images
+
+Use `ac delete images` to remove image tags from the Registry. This operation removes the image manifest reference from the Registry, but it does not guarantee that the underlying image data is reclaimed immediately:
+
+```bash
+# Preview the deletion result without removing anything
+ac delete images --repo=my-ns/my-app:v1
+
+# Confirm the deletion
+ac delete images --repo=my-ns/my-app:v1 --confirm
+```
+
+If needed, specify the Registry endpoint explicitly:
+
+```bash
+ac delete images \
+  --repo=my-ns/my-app:v1 \
+  --registry-url=http://image-registry.cpaas-system \
+  --confirm
+```

--- a/docs/en/developer/registry/how_to/configure_registry_push_limits.mdx
+++ b/docs/en/developer/registry/how_to/configure_registry_push_limits.mdx
@@ -176,9 +176,11 @@ Allow a short propagation delay before the new limits take effect.
 Example:
 
 ```bash
-nerdctl login <REGISTRY-ADDRESS> -u <ACP-USERNAME> -p <ACP-PASSWORD>
-nerdctl push <REGISTRY-ADDRESS>/team-a/demo:v1
+nerdctl login <REGISTRY_CLIENT_HOSTPORT> -u <ACP-USERNAME> -p <ACP-PASSWORD>
+nerdctl push <REGISTRY_CLIENT_HOSTPORT>/team-a/demo:v1
 ```
+
+If the Registry uses a self-signed certificate or plain HTTP, add the global flag `--insecure-registry`.
 
 Expected behavior:
 

--- a/docs/en/developer/registry/how_to/configure_registry_push_limits.mdx
+++ b/docs/en/developer/registry/how_to/configure_registry_push_limits.mdx
@@ -7,7 +7,7 @@ i18n:
 
 # Configure Registry Push Limits
 
-The Alauda Container Platform Registry includes a built-in proxy that can enforce image push limits for Docker Registry API requests.
+The Alauda Container Platform Registry includes a built-in proxy that can enforce image push limits for OCI registry API requests.
 
 You can use this capability to:
 
@@ -176,8 +176,8 @@ Allow a short propagation delay before the new limits take effect.
 Example:
 
 ```bash
-podman login <REGISTRY-ADDRESS>
-podman push <REGISTRY-ADDRESS>/team-a/demo:v1
+nerdctl login <REGISTRY-ADDRESS> -u <ACP-USERNAME> -p <ACP-PASSWORD>
+nerdctl push <REGISTRY-ADDRESS>/team-a/demo:v1
 ```
 
 Expected behavior:

--- a/docs/en/developer/registry/how_to/configure_registry_push_limits.mdx
+++ b/docs/en/developer/registry/how_to/configure_registry_push_limits.mdx
@@ -1,0 +1,216 @@
+---
+weight: 14
+i18n:
+  title:
+    zh: 配置镜像推送限制
+---
+
+# Configure Registry Push Limits
+
+The Alauda Container Platform Registry includes a built-in proxy that can enforce image push limits for Docker Registry API requests.
+
+You can use this capability to:
+
+- Limit the maximum size of pushed images
+- Limit the number of tags allowed in a repository
+- Apply global limits or path-based override rules
+
+## Before You Begin
+
+- The **Alauda Container Platform Registry** cluster plugin must already be installed.
+- You must have permission to update the Registry plugin configuration.
+- You must be able to create a ConfigMap in the Registry namespace.
+- If you have not installed the Registry yet, see [Install Via YAML](/developer/registry/install/install_via_yaml.mdx).
+
+## How It Works
+
+To use this feature, enable `registryLimitConfig` in the Registry plugin configuration and create a ConfigMap that defines the limits.
+
+## Enable Registry Push Limits
+
+When installing or updating the Registry plugin, enable `registryLimitConfig` and point it to a ConfigMap name.
+
+Example:
+
+```yaml
+spec:
+  config:
+    registryLimitConfig:
+      enabled: true
+      configMapName: image-registry-limit-config
+```
+
+Notes:
+
+- `enabled: true` mounts the limit configuration into the Registry proxy container.
+- `configMapName` must reference a ConfigMap that you create manually.
+- For new deployments, the recommended ConfigMap name is `image-registry-limit-config`.
+- The runtime also accepts the legacy ConfigMap name `registry-gateway-config` for backward compatibility.
+
+## Create the Limit ConfigMap
+
+Create a ConfigMap in the same namespace as the Registry deployment.
+
+Example:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: image-registry-limit-config
+  namespace: cpaas-system
+data:
+  max_image_size: "1GB"
+  tag_count_limit: "1000"
+  rules: |
+    - path: ^team-a/.+
+      limit:
+        max_image_size: "100MB"
+        tag_count_limit: "3"
+    - path: ^team-b/.+
+      limit:
+        max_image_size: "5GB"
+        tag_count_limit: "20"
+```
+
+Apply it:
+
+```bash
+kubectl apply -f image-registry-limit-config.yaml
+```
+
+## Configuration Keys
+
+### Global Keys
+
+| Key | Description | Example |
+| --- | --- | --- |
+| `max_image_size` | Maximum size allowed for a pushed image. Supported units: `GB`, `MB`, `KB`, `B`. | `1GB` |
+| `tag_count_limit` | Maximum number of tags allowed in a repository | `1000` |
+
+### Optional Rule Key
+
+| Key | Description |
+| --- | --- |
+| `rules` | Optional path-based override rules |
+
+Each rule contains:
+
+- `path`: A regular expression used to match a repository path
+- `limit.max_image_size`: The size limit applied when the rule matches
+- `limit.tag_count_limit`: The tag count limit applied when the rule matches
+
+Rules are evaluated in order, and the first matching rule takes effect.
+
+For each rule, set both `limit.max_image_size` and `limit.tag_count_limit`.
+
+## Configuration Examples
+
+### Example 1: Global Limits Only
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: image-registry-limit-config
+  namespace: cpaas-system
+data:
+  max_image_size: "500MB"
+  tag_count_limit: "50"
+```
+
+Effect:
+
+- All repositories use the same default size limit and tag count limit.
+
+### Example 2: Per-Repository Overrides
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: image-registry-limit-config
+  namespace: cpaas-system
+data:
+  max_image_size: "1GB"
+  tag_count_limit: "100"
+  rules: |
+    - path: ^project-a/.+
+      limit:
+        max_image_size: "100MB"
+        tag_count_limit: "3"
+    - path: ^project-b/release/.+
+      limit:
+        max_image_size: "5GB"
+        tag_count_limit: "20"
+```
+
+Effect:
+
+- `project-a/*` is limited to `100MB` and `3` tags.
+- `project-b/release/*` is limited to `5GB` and `20` tags.
+- Other repositories use the global defaults.
+
+## Apply Changes
+
+After you create or update the ConfigMap, the Registry proxy loads the new rules automatically.
+
+Allow a short propagation delay before the new limits take effect.
+
+## Verify the Configuration
+
+1. Check that the ConfigMap exists:
+
+   ```bash
+   kubectl get configmap image-registry-limit-config -n cpaas-system
+   ```
+
+2. Check that the Registry deployment is running:
+
+   ```bash
+   kubectl get pods -n cpaas-system -l app=image-registry
+   ```
+
+3. Push an image to a repository covered by the rule and verify the result.
+
+Example:
+
+```bash
+podman login <REGISTRY-ADDRESS>
+podman push <REGISTRY-ADDRESS>/team-a/demo:v1
+```
+
+Expected behavior:
+
+- When the image size exceeds the configured limit, the push is rejected.
+- When the repository already has the maximum allowed number of tags, the push is rejected.
+
+## Recommended Practices
+
+- Start with global defaults, then add path-based rules only where needed.
+- Use repository path conventions that make rule matching predictable.
+- Keep the ConfigMap name stable across updates.
+- Verify changes in a non-production environment before applying them to production.
+
+## Troubleshooting
+
+### The limits do not take effect
+
+Check the following:
+
+- `spec.config.registryLimitConfig.enabled` is set to `true`
+- The ConfigMap name matches `spec.config.registryLimitConfig.configMapName`
+- The ConfigMap exists in the Registry namespace
+- Repository paths in `rules` match the actual push target
+
+### A rule does not match the expected repository
+
+Check the regular expression in `path`.
+
+Rules are matched in order, so an earlier rule may already have taken effect.
+
+### Existing environments still use `registry-gateway-config`
+
+The runtime still supports the legacy ConfigMap name.
+
+For new environments, use `image-registry-limit-config`.

--- a/docs/en/developer/registry/install/install_via_web_ui.mdx
+++ b/docs/en/developer/registry/install/install_via_web_ui.mdx
@@ -47,7 +47,7 @@ The parameter descriptions are as follows:
 
 1. Navigate to **Marketplace** > **Cluster Plugins** and confirm the plugin status shows **Installed**.
 2. Click the plugin name to view its details.
-3. Copy the **Registry Address** and use a container client (e.g., Podman) to push/pull images.
+3. Copy the **Registry Address** and use an OCI client (e.g., `nerdctl`) to push or pull images.
 
 ## Updating/Uninstalling Alauda Container Platform Registry
 

--- a/docs/en/developer/registry/install/install_via_yaml.mdx
+++ b/docs/en/developer/registry/install/install_via_yaml.mdx
@@ -26,7 +26,7 @@ weight: 15
 
 ### Procedure
 
-1. **Create a YAML configuration file** named registry-plugin.yaml with the following template:
+1. **Create a ClusterPluginInstance manifest file** named `registry-plugin.yaml` with the following template:
 
    ```yaml
    apiVersion: cluster.alauda.io/v1alpha1
@@ -75,6 +75,9 @@ weight: 15
          size: <STORAGE-SIZE> # [REQUIRED] Storage size (e.g., 10Gi)
          storageClass: <STORAGE-CLASS-NAME> # [REQUIRED] StorageClass name
          type: StorageClass
+       registryLimitConfig:
+         enabled: false
+         configMapName: image-registry-limit-config
        s3storage:
          bucket: <S3-BUCKET-NAME> # [REQUIRED] S3 bucket name
          enabled: false # Set false for local storage
@@ -107,6 +110,9 @@ weight: 15
        persistence:
          size: '<STORAGE-SIZE>' # e.g., 10Gi
          storageClass: '<STORAGE-CLASS-NAME>' # e.g., cpaas-system-storage
+       registryLimitConfig:
+         enabled: true # Set true to enable registry push limits
+         configMapName: 'image-registry-limit-config' # Pre-created ConfigMap name
        s3storage:
          bucket: '<S3-BUCKET-NAME>' # e.g., prod-registry
          region: '<S3-REGION>' # e.g., us-west-1
@@ -127,7 +133,43 @@ weight: 15
 
    Replace `<S3-CREDENTIALS-SECRET>` with the name of your S3 credentials secret.
 
-4. Apply the configuration to your cluster:
+4. **Optional: enable registry push limits** for image size and tag count.
+
+   This capability is provided by the built-in Registry proxy.
+
+   To enable it:
+
+   - Set `spec.config.registryLimitConfig.enabled` to `true`.
+   - Set `spec.config.registryLimitConfig.configMapName` to the name of a ConfigMap that you create manually in the Registry namespace.
+
+   Example:
+
+   ```yaml
+   spec:
+     config:
+       registryLimitConfig:
+         enabled: true
+         configMapName: image-registry-limit-config
+   ```
+
+   Notes:
+
+   - The ConfigMap is not created by the Registry plugin.
+   - For new deployments, the recommended ConfigMap name is `image-registry-limit-config`.
+   - The runtime still accepts the legacy ConfigMap name `registry-gateway-config` for backward compatibility.
+   - For detailed ConfigMap examples, rule behavior, and verification steps, see [Configure Registry Push Limits](/developer/registry/how_to/configure_registry_push_limits.mdx).
+
+   When this feature is enabled, apply the ConfigMap before proceeding to step 5:
+
+   ```bash
+   kubectl apply -f image-registry-limit-config.yaml
+   ```
+
+5. Apply the Registry plugin manifest to your cluster.
+
+   This command creates or updates the `ClusterPluginInstance` resource named `image-registry`, which installs or updates the Registry cluster plugin.
+
+   If you enabled `registryLimitConfig`, apply the limit ConfigMap described in [Configure Registry Push Limits](/developer/registry/how_to/configure_registry_push_limits.mdx) before this step.
 
    ```bash
    kubectl apply -f registry-plugin.yaml
@@ -135,22 +177,24 @@ weight: 15
 
 ### Configuration Reference
 
-#### Mandatory Fields
+#### Common Fields
 
-| Parameter                              | Description                                              | Example Value               |
-| -------------------------------------- | -------------------------------------------------------- | --------------------------- |
-| `spec.config.global.oidc.ldapID`       | LDAP ID for OIDC authentication                          | `ldap-test`                 |
-| `spec.config.ingress.hosts[0].name`    | Custom domain for registry access                        | `registry.yourcompany.com`  |
+| Parameter | Description | Example Value |
+| --- | --- | --- |
+| `spec.config.global.oidc.ldapID` | LDAP ID for OIDC authentication | `ldap-test` |
+| `spec.config.ingress.hosts[0].name` | Custom domain for registry access | `registry.yourcompany.com` |
 | `spec.config.ingress.hosts[0].tlsCert` | TLS certificate secret reference (namespace/secret-name) | `cpaas-system/registry-tls` |
-| `spec.config.ingress.ingressClassName` | Ingress class name for the registry                      | `cluster-alb-1`             |
-| `spec.config.persistence.size`         | Storage size for the registry                            | `10Gi`                      |
-| `spec.config.persistence.storageClass` | StorageClass name for the registry                       | `nfs-storage-sc`            |
-| `spec.config.s3storage.bucket`         | S3 bucket name for image storage                         | `prod-image-store`          |
-| `spec.config.s3storage.region`         | AWS region for S3 storage                                | `us-west-1`                 |
-| `spec.config.s3storage.regionEndpoint` | S3 service endpoint URL                                  | `https://s3.amazonaws.com`  |
-| `spec.config.s3storage.secretName`     | Secret containing S3 credentials                         | `s3-access-keys`            |
-| `spec.config.s3storage.env.REGISTRY_STORAGE_S3_SKIPVERIFY` | Set to `true` for self-signed certs  | `true`                      |
-| `spec.config.infra.enabled`            | Deploy components to infra nodes or all nodes            | `false`                     |
+| `spec.config.ingress.ingressClassName` | Ingress class name for the registry | `cluster-alb-1` |
+| `spec.config.persistence.size` | Storage size for the registry | `10Gi` |
+| `spec.config.persistence.storageClass` | StorageClass name for the registry | `nfs-storage-sc` |
+| `spec.config.registryLimitConfig.enabled` | Enable registry push limits for image size and tag count | `true` |
+| `spec.config.registryLimitConfig.configMapName` | Name of the manually created ConfigMap containing limit rules | `image-registry-limit-config` |
+| `spec.config.s3storage.bucket` | S3 bucket name for image storage | `prod-image-store` |
+| `spec.config.s3storage.region` | AWS region for S3 storage | `us-west-1` |
+| `spec.config.s3storage.regionEndpoint` | S3 service endpoint URL | `https://s3.amazonaws.com` |
+| `spec.config.s3storage.secretName` | Secret containing S3 credentials | `s3-access-keys` |
+| `spec.config.s3storage.env.REGISTRY_STORAGE_S3_SKIPVERIFY` | Set to `true` for self-signed certs | `true` |
+| `spec.config.infra.enabled` | Deploy components to infra nodes or all nodes | `false` |
 
 ### Verification
 

--- a/docs/en/developer/registry/intro.mdx
+++ b/docs/en/developer/registry/intro.mdx
@@ -22,7 +22,11 @@ One of its core design concepts is logical isolation and management based on Nam
 The authentication and authorization mechanism of Alauda Container Platform Registry is deeply integrated with ACP's platform-level authentication and authorization system, enabling access control as granular as the namespace:
 
 ### Authentication
-Users or automated processes (e.g., CI/CD pipelines on the platform, automated build tasks, etc.) do not need to maintain a separate set of account passwords for the Registry. They are authenticated through the platform's standard authentication mechanisms (e.g., using platform-provided API tokens, integrated enterprise identity systems, etc.). When accessing Alauda Container Platform Registry through the CLI or other tools, it is common to utilize existing platform login sessions or ServiceAccount tokens for transparent authentication.
+Users or automated processes (e.g., CI/CD pipelines on the platform, automated build tasks, etc.) do not need to maintain a separate set of account passwords for the Registry. They are authenticated through the platform's standard authentication mechanisms (e.g., using platform-provided API tokens, integrated enterprise identity systems, etc.).
+
+When using ACP-aware tools such as `ac`, Registry-related API access can typically reuse the current ACP login session or a mounted ServiceAccount token.
+
+When using standard OCI clients such as `nerdctl`, authentication is performed directly against the Registry endpoint, usually with ACP account credentials that already have access to the target namespace.
 
 ### Authorization
 Authorization control is implemented at the namespace level. Pull or Push permissions for an image repository in Alauda Container Platform Registry depend on the platform role and permissions that the user or ServiceAccount has in the corresponding namespace.

--- a/docs/en/developer/registry/upgrade/registry_plugin_upgrade_guide.mdx
+++ b/docs/en/developer/registry/upgrade/registry_plugin_upgrade_guide.mdx
@@ -16,6 +16,14 @@ i18n:
 ## Overview
 This document provides instructions for upgrading the `Old Plugin` to `New Plugin`. Due to the name of cluster plugin change, manual intervention is required based on **storage type**.
 
+In the commands below, replace `<LEGACY-PLUGIN-NAME>` with the registry plugin name used in ACP v4.1 and earlier.
+
+You can identify it by checking the existing registry plugin resources (Execute in Global cluster):
+
+```bash
+kubectl get moduleplugins -n cpaas-system
+```
+
 ## Upgrade Steps
 
 ### Environment Check and Preprocessing
@@ -24,8 +32,8 @@ This document provides instructions for upgrading the `Old Plugin` to `New Plugi
 If the old plugin was never installed, you just need to clean up the old plugin from [Marketplace/Cluster Plugins]:
 ```bash
 # Execute in Global cluster
-kubectl delete moduleplugins internal-docker-registry
-kubectl get moduleconfig -l cpaas.io/module-name=internal-docker-registry -o name | xargs kubectl delete
+kubectl delete moduleplugins <LEGACY-PLUGIN-NAME>
+kubectl get moduleconfig -l cpaas.io/module-name=<LEGACY-PLUGIN-NAME> -o name | xargs kubectl delete
 ```
 #### Old Plugin Installed
 If the old plugin is installed in any cluster, follow the migration procedure based on your **storage type**.
@@ -37,23 +45,23 @@ If the old plugin is installed in any cluster, follow the migration procedure ba
 **Procedure**:
 1. Backup Old Plugin Configuration: (Execute in workload cluster where the old plugin is installed)
    ```bash
-   kubectl get clusterplugininstances internal-docker-registry -o yaml > backup-clusterplugininstances.yaml
+   kubectl get clusterplugininstances <LEGACY-PLUGIN-NAME> -o yaml > backup-clusterplugininstances.yaml
    ```
 2. Uninstall Old Plugin: (Execute in Global cluster)
    ```bash
    # Replace <CLUSTER-NAME> with actual cluster name which has the plugin installed
-   kubectl get moduleinfo -l cpaas.io/cluster-name=<CLUSTER-NAME>,cpaas.io/module-name=internal-docker-registry -o name | xargs kubectl delete
+   kubectl get moduleinfo -l cpaas.io/cluster-name=<CLUSTER-NAME>,cpaas.io/module-name=<LEGACY-PLUGIN-NAME> -o name | xargs kubectl delete
    ```
 3. Install New Plugin (Execute in workload cluster where the plugin will be installed)
-  - Edit backup file `backup-clusterplugininstances.yaml`, replace all `internal-docker-registry` with `image-registry`
+  - Edit backup file `backup-clusterplugininstances.yaml`, replace all occurrences of `<LEGACY-PLUGIN-NAME>` with `image-registry`
   - Apply new configuration:
     ```bash
     kubectl apply -f backup-clusterplugininstances.yaml
     ```
 4. Cleanup Old Plugin From [Marketplace/Cluster Plugins]: (Execute in Global cluster)
    ```bash
-   kubectl delete moduleplugins internal-docker-registry
-   kubectl get moduleconfig -l cpaas.io/module-name=internal-docker-registry -o name | xargs kubectl delete
+   kubectl delete moduleplugins <LEGACY-PLUGIN-NAME>
+   kubectl get moduleconfig -l cpaas.io/module-name=<LEGACY-PLUGIN-NAME> -o name | xargs kubectl delete
    ```
 
 ### NFS Storage Migration
@@ -62,7 +70,7 @@ If the old plugin is installed in any cluster, follow the migration procedure ba
 **Procedure**:
 1. Record PV Information: (Execute in workload cluster where the old plugin is installed)
    ```bash
-   OLD_PV=$(kubectl get pvc internal-docker-registry -n cpaas-system -o jsonpath='{.spec.volumeName}')
+   OLD_PV=$(kubectl get pvc <LEGACY-PLUGIN-NAME> -n cpaas-system -o jsonpath='{.spec.volumeName}')
    echo "Old PV Name: $OLD_PV"
    ```
 2. Modify PV Reclaim Policy: (Execute in workload cluster where the old plugin is installed)
@@ -91,6 +99,6 @@ If the old plugin is installed in any cluster, follow the migration procedure ba
 4. Data Migration:
   - ssh login to old plugin Pod node, copy data from old directory to new directory with all file permissions:
     ```bash
-    sudo cp -a /cpaas/internal-docker-registry/* /cpaas/image-registry/
+    sudo cp -a /cpaas/<LEGACY-PLUGIN-NAME>/* /cpaas/image-registry/
     ```
 5. Cleanup Old Plugin From [Marketplace/Cluster Plugins] (Same as S3 Step 4)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed guide for enforcing OCI image push limits via Registry proxy (ConfigMap-based rules, examples, verification, troubleshooting).
  * Standardized Registry CLI docs to use ac for Registry API actions and nerdctl for image transfer; added placeholders, auth model, namespace scoping, YAML output, and delete preview/confirm examples.
  * Clarified installation steps and verification tooling; improved upgrade guidance with legacy plugin placeholder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->