### PR TITLE
docs: add critical note about LB service IP prohibition for internal pod access

### DIFF
--- a/docs/en/configure/networking/how_to/kube_ovn/config_metallb_underlay.mdx
+++ b/docs/en/configure/networking/how_to/kube_ovn/config_metallb_underlay.mdx
@@ -9,6 +9,8 @@ weight: 14
 This solution addresses the integration of MetalLB L2 mode with Kube-OVN Underlay networking. It allows users to utilize Underlay subnet IPs as MetalLB LoadBalancer Service VIPs, directly forwarding traffic to backend business Pods.
 
 > ⚠️ **Critical**: The LoadBalancer VIP and the backend Pod IPs **must be in the same Underlay subnet**.
+> 
+> ⚠️ **Critical**: The LoadBalancer Service IP is prohibited from being accessed by internal Pods. This IP is intended for external client access only.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Add a critical warning in `config_metallb_underlay.mdx` that the MetalLB LoadBalancer Service IP must not be accessed by internal Pods

## Changes
- `docs/en/configure/networking/how_to/kube_ovn/config_metallb_underlay.mdx`: Added critical note below the existing VIP-subnet constraint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a critical warning to the MetalLB underlay configuration guide clarifying that LoadBalancer Service IPs are not reachable from internal Pods and are intended only for external client traffic.
  * Documentation-only change; no configuration steps, examples, or code were modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/acp-docs/pull/707)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->