### PR TITLE
docs: add standard ACP API references

### DIFF
--- a/docs/en/apis/kubernetes_apis/backup/backup.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/backup.mdx
@@ -1,0 +1,12 @@
+---
+weight: 10
+queries:
+  - backup api reference
+  - backup crd
+  - backup kubernetes api
+---
+
+# Backup [velero.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="backups.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/backuprepository.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/backuprepository.mdx
@@ -1,0 +1,12 @@
+---
+weight: 20
+queries:
+  - backuprepository api reference
+  - backuprepository crd
+  - backuprepository kubernetes api
+---
+
+# BackupRepository [velero.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="backuprepositories.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/backupstoragelocation.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/backupstoragelocation.mdx
@@ -1,0 +1,12 @@
+---
+weight: 30
+queries:
+  - backupstoragelocation api reference
+  - backupstoragelocation crd
+  - backupstoragelocation kubernetes api
+---
+
+# BackupStorageLocation [velero.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="backupstoragelocations.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/datadownload.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/datadownload.mdx
@@ -1,0 +1,12 @@
+---
+weight: 40
+queries:
+  - datadownload api reference
+  - datadownload crd
+  - datadownload kubernetes api
+---
+
+# DataDownload [velero.io/v2alpha1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="datadownloads.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/dataupload.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/dataupload.mdx
@@ -1,0 +1,12 @@
+---
+weight: 50
+queries:
+  - dataupload api reference
+  - dataupload crd
+  - dataupload kubernetes api
+---
+
+# DataUpload [velero.io/v2alpha1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="datauploads.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/deletebackuprequest.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/deletebackuprequest.mdx
@@ -1,0 +1,12 @@
+---
+weight: 60
+queries:
+  - deletebackuprequest api reference
+  - deletebackuprequest crd
+  - deletebackuprequest kubernetes api
+---
+
+# DeleteBackupRequest [velero.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="deletebackuprequests.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/downloadrequest.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/downloadrequest.mdx
@@ -1,0 +1,12 @@
+---
+weight: 70
+queries:
+  - downloadrequest api reference
+  - downloadrequest crd
+  - downloadrequest kubernetes api
+---
+
+# DownloadRequest [velero.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="downloadrequests.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/index.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/index.mdx
@@ -1,0 +1,11 @@
+---
+weight: 10
+queries:
+  - backup api reference
+  - backup kubernetes api
+  - backup crd documentation
+---
+
+# Backup APIs
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/apis/kubernetes_apis/backup/podvolumebackup.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/podvolumebackup.mdx
@@ -1,0 +1,12 @@
+---
+weight: 80
+queries:
+  - podvolumebackup api reference
+  - podvolumebackup crd
+  - podvolumebackup kubernetes api
+---
+
+# PodVolumeBackup [velero.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="podvolumebackups.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/podvolumerestore.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/podvolumerestore.mdx
@@ -1,0 +1,12 @@
+---
+weight: 90
+queries:
+  - podvolumerestore api reference
+  - podvolumerestore crd
+  - podvolumerestore kubernetes api
+---
+
+# PodVolumeRestore [velero.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="podvolumerestores.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/restore.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/restore.mdx
@@ -1,0 +1,12 @@
+---
+weight: 100
+queries:
+  - restore api reference
+  - restore crd
+  - restore kubernetes api
+---
+
+# Restore [velero.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="restores.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/schedule.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/schedule.mdx
@@ -1,0 +1,12 @@
+---
+weight: 110
+queries:
+  - schedule api reference
+  - schedule crd
+  - schedule kubernetes api
+---
+
+# Schedule [velero.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="schedules.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/serverstatusrequest.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/serverstatusrequest.mdx
@@ -1,0 +1,12 @@
+---
+weight: 120
+queries:
+  - serverstatusrequest api reference
+  - serverstatusrequest crd
+  - serverstatusrequest kubernetes api
+---
+
+# ServerStatusRequest [velero.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="serverstatusrequests.velero.io" />

--- a/docs/en/apis/kubernetes_apis/backup/volumesnapshotlocation.mdx
+++ b/docs/en/apis/kubernetes_apis/backup/volumesnapshotlocation.mdx
@@ -1,0 +1,12 @@
+---
+weight: 130
+queries:
+  - volumesnapshotlocation api reference
+  - volumesnapshotlocation crd
+  - volumesnapshotlocation kubernetes api
+---
+
+# VolumeSnapshotLocation [velero.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="volumesnapshotlocations.velero.io" />

--- a/docs/en/apis/kubernetes_apis/etcd/etcdcluster.mdx
+++ b/docs/en/apis/kubernetes_apis/etcd/etcdcluster.mdx
@@ -1,0 +1,12 @@
+---
+weight: 10
+queries:
+  - etcdcluster api reference
+  - etcdcluster crd
+  - etcdcluster kubernetes api
+---
+
+# EtcdCluster [operator.etcd.io/v1alpha1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="etcdclusters.operator.etcd.io" />

--- a/docs/en/apis/kubernetes_apis/etcd/index.mdx
+++ b/docs/en/apis/kubernetes_apis/etcd/index.mdx
@@ -1,0 +1,11 @@
+---
+weight: 10
+queries:
+  - etcd api reference
+  - etcd kubernetes api
+  - etcd crd documentation
+---
+
+# Etcd APIs
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/apis/kubernetes_apis/marketplace/artifact.mdx
+++ b/docs/en/apis/kubernetes_apis/marketplace/artifact.mdx
@@ -1,0 +1,11 @@
+---
+weight: 10
+queries:
+  - artifact api reference
+  - artifact crd
+  - artifact kubernetes api
+---
+
+# Artifact [app.alauda.io/v1alpha1]
+
+<K8sAPI name="artifacts.app.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/marketplace/artifactversion.mdx
+++ b/docs/en/apis/kubernetes_apis/marketplace/artifactversion.mdx
@@ -1,0 +1,11 @@
+---
+weight: 20
+queries:
+  - artifactversion api reference
+  - artifactversion crd
+  - artifactversion kubernetes api
+---
+
+# ArtifactVersion [app.alauda.io/v1alpha1]
+
+<K8sAPI name="artifactversions.app.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/marketplace/chart.mdx
+++ b/docs/en/apis/kubernetes_apis/marketplace/chart.mdx
@@ -1,0 +1,11 @@
+---
+weight: 30
+queries:
+  - chart api reference
+  - chart crd
+  - chart kubernetes api
+---
+
+# Chart [app.alauda.io/v1alpha1]
+
+<K8sAPI name="charts.app.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/marketplace/chartrepo.mdx
+++ b/docs/en/apis/kubernetes_apis/marketplace/chartrepo.mdx
@@ -1,0 +1,11 @@
+---
+weight: 40
+queries:
+  - chartrepo api reference
+  - chartrepo crd
+  - chartrepo kubernetes api
+---
+
+# ChartRepo [app.alauda.io/v1alpha1]
+
+<K8sAPI name="chartrepos.app.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/marketplace/helmrequest.mdx
+++ b/docs/en/apis/kubernetes_apis/marketplace/helmrequest.mdx
@@ -1,0 +1,11 @@
+---
+weight: 50
+queries:
+  - helmrequest api reference
+  - helmrequest crd
+  - helmrequest kubernetes api
+---
+
+# HelmRequest [app.alauda.io/v1]
+
+<K8sAPI name="helmrequests.app.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/marketplace/imagewhitelist.mdx
+++ b/docs/en/apis/kubernetes_apis/marketplace/imagewhitelist.mdx
@@ -1,0 +1,11 @@
+---
+weight: 60
+queries:
+  - imagewhitelist api reference
+  - imagewhitelist crd
+  - imagewhitelist kubernetes api
+---
+
+# ImageWhiteList [app.alauda.io/v1alpha1]
+
+<K8sAPI name="imagewhitelists.app.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/marketplace/index.mdx
+++ b/docs/en/apis/kubernetes_apis/marketplace/index.mdx
@@ -1,0 +1,11 @@
+---
+weight: 10
+queries:
+  - marketplace api reference
+  - marketplace kubernetes api
+  - marketplace crd documentation
+---
+
+# Marketplace APIs
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/apis/kubernetes_apis/marketplace/library.mdx
+++ b/docs/en/apis/kubernetes_apis/marketplace/library.mdx
@@ -1,0 +1,11 @@
+---
+weight: 70
+queries:
+  - library api reference
+  - library crd
+  - library kubernetes api
+---
+
+# Library [app.alauda.io/v1alpha1]
+
+<K8sAPI name="libraries.app.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/operator/catalogsource.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/catalogsource.mdx
@@ -1,0 +1,11 @@
+---
+weight: 10
+queries:
+  - catalogsource api reference
+  - catalogsource crd
+  - catalogsource kubernetes api
+---
+
+# CatalogSource [operators.coreos.com/v1alpha1]
+
+<K8sAPI name="catalogsources.operators.coreos.com" />

--- a/docs/en/apis/kubernetes_apis/operator/clusterserviceversion.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/clusterserviceversion.mdx
@@ -1,0 +1,11 @@
+---
+weight: 20
+queries:
+  - clusterserviceversion api reference
+  - clusterserviceversion crd
+  - clusterserviceversion kubernetes api
+---
+
+# ClusterServiceVersion [operators.coreos.com/v1alpha1]
+
+<K8sAPI name="clusterserviceversions.operators.coreos.com" />

--- a/docs/en/apis/kubernetes_apis/operator/installplan.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/installplan.mdx
@@ -1,0 +1,11 @@
+---
+weight: 30
+queries:
+  - installplan api reference
+  - installplan crd
+  - installplan kubernetes api
+---
+
+# InstallPlan [operators.coreos.com/v1alpha1]
+
+<K8sAPI name="installplans.operators.coreos.com" />

--- a/docs/en/apis/kubernetes_apis/operator/olmconfig.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/olmconfig.mdx
@@ -1,0 +1,12 @@
+---
+weight: 40
+queries:
+  - olmconfig api reference
+  - olmconfig crd
+  - olmconfig kubernetes api
+---
+
+# OLMConfig [operators.coreos.com/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="olmconfigs.operators.coreos.com" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/operator/operatorcondition.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/operatorcondition.mdx
@@ -1,0 +1,11 @@
+---
+weight: 50
+queries:
+  - operatorcondition api reference
+  - operatorcondition crd
+  - operatorcondition kubernetes api
+---
+
+# OperatorCondition [operators.coreos.com/v1]
+
+<K8sAPI name="operatorconditions.operators.coreos.com" />

--- a/docs/en/apis/kubernetes_apis/operator/operatorgroup.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/operatorgroup.mdx
@@ -1,0 +1,11 @@
+---
+weight: 60
+queries:
+  - operatorgroup api reference
+  - operatorgroup crd
+  - operatorgroup kubernetes api
+---
+
+# OperatorGroup [operators.coreos.com/v1]
+
+<K8sAPI name="operatorgroups.operators.coreos.com" />

--- a/docs/en/apis/kubernetes_apis/operator/subscription.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/subscription.mdx
@@ -1,0 +1,11 @@
+---
+weight: 80
+queries:
+  - subscription api reference
+  - subscription crd
+  - subscription kubernetes api
+---
+
+# Subscription [operators.coreos.com/v1alpha1]
+
+<K8sAPI name="subscriptions.operators.coreos.com" />

--- a/docs/en/apis/kubernetes_apis/platform_base/clustermodule.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_base/clustermodule.mdx
@@ -1,0 +1,11 @@
+---
+weight: 10
+queries:
+  - clustermodule api reference
+  - clustermodule crd
+  - clustermodule kubernetes api
+---
+
+# ClusterModule [cluster.alauda.io/v1alpha1]
+
+<K8sAPI name="clustermodules.cluster.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_base/commonconfig.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_base/commonconfig.mdx
@@ -1,0 +1,11 @@
+---
+weight: 20
+queries:
+  - commonconfig api reference
+  - commonconfig crd
+  - commonconfig kubernetes api
+---
+
+# CommonConfig [operator.alauda.io/v1alpha1]
+
+<K8sAPI name="commonconfigs.operator.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_base/index.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_base/index.mdx
@@ -1,0 +1,11 @@
+---
+weight: 10
+queries:
+  - platform base api reference
+  - platform base kubernetes api
+  - platform base crd documentation
+---
+
+# Platform Base APIs
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/apis/kubernetes_apis/platform_base/productbase.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_base/productbase.mdx
@@ -1,0 +1,11 @@
+---
+weight: 30
+queries:
+  - productbase api reference
+  - productbase crd
+  - productbase kubernetes api
+---
+
+# ProductBase [product.alauda.io/v1alpha1]
+
+<K8sAPI name="productbases.product.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_base/productconfig.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_base/productconfig.mdx
@@ -1,0 +1,11 @@
+---
+weight: 40
+queries:
+  - productconfig api reference
+  - productconfig crd
+  - productconfig kubernetes api
+---
+
+# ProductConfig [alauda.io/v1alpha1]
+
+<K8sAPI name="productconfigs.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_base/productupgrade.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_base/productupgrade.mdx
@@ -1,0 +1,11 @@
+---
+weight: 50
+queries:
+  - productupgrade api reference
+  - productupgrade crd
+  - productupgrade kubernetes api
+---
+
+# ProductUpgrade [product.alauda.io/v1alpha1]
+
+<K8sAPI name="productupgrades.product.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/alaudafeaturegate.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/alaudafeaturegate.mdx
@@ -1,0 +1,12 @@
+---
+weight: 10
+queries:
+  - alaudafeaturegate api reference
+  - alaudafeaturegate crd
+  - alaudafeaturegate kubernetes api
+---
+
+# AlaudaFeatureGate [alauda.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="alaudafeaturegates.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/alertrule.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/alertrule.mdx
@@ -1,0 +1,11 @@
+---
+weight: 20
+queries:
+  - alertrule api reference
+  - alertrule crd
+  - alertrule kubernetes api
+---
+
+# AlertRule [ait.alauda.io/v1]
+
+<K8sAPI name="alertrules.ait.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/clusteralaudafeaturegate.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/clusteralaudafeaturegate.mdx
@@ -1,0 +1,12 @@
+---
+weight: 30
+queries:
+  - clusteralaudafeaturegate api reference
+  - clusteralaudafeaturegate crd
+  - clusteralaudafeaturegate kubernetes api
+---
+
+# ClusterAlaudaFeatureGate [alauda.io/v1]
+
+{/* cspell:disable-next-line */}
+<K8sAPI name="clusteralaudafeaturegates.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/dashboard.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/dashboard.mdx
@@ -1,0 +1,11 @@
+---
+weight: 40
+queries:
+  - dashboard api reference
+  - dashboard crd
+  - dashboard kubernetes api
+---
+
+# Dashboard [ait.alauda.io/v1alpha1]
+
+<K8sAPI name="dashboards.ait.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/disabletoken.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/disabletoken.mdx
@@ -1,0 +1,13 @@
+---
+weight: 50
+queries:
+  - disabletoken api reference
+  - disabletoken crd
+  - disabletoken kubernetes api
+---
+
+# DisableToken [auth.alauda.io/v1]
+
+This API is installed only when the chart is deployed for the global cluster. It is not available on workload clusters.
+
+<K8sAPI name="disabletokens.auth.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/disableuser.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/disableuser.mdx
@@ -1,0 +1,13 @@
+---
+weight: 60
+queries:
+  - disableuser api reference
+  - disableuser crd
+  - disableuser kubernetes api
+---
+
+# DisableUser [auth.alauda.io/v1]
+
+This API is installed only when the chart is deployed for the global cluster. It is not available on workload clusters.
+
+<K8sAPI name="disableusers.auth.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/feature.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/feature.mdx
@@ -1,0 +1,11 @@
+---
+weight: 70
+queries:
+  - feature api reference
+  - feature crd
+  - feature kubernetes api
+---
+
+# Feature [infrastructure.alauda.io/v1alpha1]
+
+<K8sAPI name="features.infrastructure.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/grafanadashboard.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/grafanadashboard.mdx
@@ -1,0 +1,11 @@
+---
+weight: 80
+queries:
+  - grafanadashboard api reference
+  - grafanadashboard crd
+  - grafanadashboard kubernetes api
+---
+
+# GrafanaDashboard [ait.alauda.io/v1beta1]
+
+<K8sAPI name="grafanadashboards.ait.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/imageversion.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/imageversion.mdx
@@ -1,0 +1,11 @@
+---
+weight: 90
+queries:
+  - imageversion api reference
+  - imageversion crd
+  - imageversion kubernetes api
+---
+
+# ImageVersion [middleware.alauda.io/v1]
+
+<K8sAPI name="imageversions.middleware.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/index.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/index.mdx
@@ -1,0 +1,11 @@
+---
+weight: 10
+queries:
+  - platform cluster api reference
+  - platform cluster kubernetes api
+  - platform cluster crd documentation
+---
+
+# Platform Cluster APIs
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/monitordashboard.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/monitordashboard.mdx
@@ -1,0 +1,13 @@
+---
+weight: 100
+queries:
+  - monitordashboard api reference
+  - monitordashboard crd
+  - monitordashboard kubernetes api
+---
+
+# MonitorDashboard [ait.alauda.io/v1alpha1]
+
+The installer creates this CRD only when it is not already present in the cluster.
+
+<K8sAPI name="monitordashboards.ait.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/productentry.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/productentry.mdx
@@ -1,0 +1,13 @@
+---
+weight: 110
+queries:
+  - productentry api reference
+  - productentry crd
+  - productentry kubernetes api
+---
+
+# ProductEntry [alauda.io/v1alpha1]
+
+This API is installed only when the chart is deployed for the global cluster. It is not available on workload clusters.
+
+<K8sAPI name="productentries.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/project.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/project.mdx
@@ -1,0 +1,13 @@
+---
+weight: 120
+queries:
+  - project api reference
+  - project crd
+  - project kubernetes api
+---
+
+# Project [auth.alauda.io/v1]
+
+This API is installed only when the chart is deployed for the global cluster. It is not available on workload clusters.
+
+<K8sAPI name="projects.auth.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/user.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/user.mdx
@@ -1,0 +1,13 @@
+---
+weight: 130
+queries:
+  - user api reference
+  - user crd
+  - user kubernetes api
+---
+
+# User [auth.alauda.io/v1]
+
+This API is installed only when the chart is deployed for the global cluster. It is not available on workload clusters.
+
+<K8sAPI name="users.auth.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/platform_cluster/userbinding.mdx
+++ b/docs/en/apis/kubernetes_apis/platform_cluster/userbinding.mdx
@@ -1,0 +1,11 @@
+---
+weight: 140
+queries:
+  - userbinding api reference
+  - userbinding crd
+  - userbinding kubernetes api
+---
+
+# UserBinding [auth.alauda.io/v1]
+
+<K8sAPI name="userbindings.auth.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/security/etcdencryptionconfig.mdx
+++ b/docs/en/apis/kubernetes_apis/security/etcdencryptionconfig.mdx
@@ -1,0 +1,11 @@
+---
+weight: 10
+queries:
+  - etcdencryptionconfig api reference
+  - etcdencryptionconfig crd
+  - etcdencryptionconfig kubernetes api
+---
+
+# EtcdEncryptionConfig [cluster.alauda.io/v1alpha1]
+
+<K8sAPI name="etcdencryptionconfigs.cluster.alauda.io" namespaced={false} />

--- a/docs/en/apis/kubernetes_apis/security/index.mdx
+++ b/docs/en/apis/kubernetes_apis/security/index.mdx
@@ -1,0 +1,11 @@
+---
+weight: 10
+queries:
+  - security api reference
+  - security kubernetes api
+  - security crd documentation
+---
+
+# Security APIs
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/configure/clusters/overview.mdx
+++ b/docs/en/configure/clusters/overview.mdx
@@ -37,6 +37,8 @@ The platform installs and manages Kubernetes on these nodes, while node OS manag
 
 This model is designed for organizations that already have established procedures or automation tools for managing their infrastructure or operating systems.
 
+To create and manage User-Provisioned Infrastructure clusters through APIs, see <ExternalSiteLink name="immutable-infra" href="/apis/index.html" children="Immutable Infrastructure API Reference" /> and go to **Provider APIs > User-Provisioned Infrastructure Provider APIs**.
+
 **Responsibilities:**
 
 | Component        | Managed by |

--- a/docs/shared/crds/ait.alauda.io_alertrules.yaml
+++ b/docs/shared/crds/ait.alauda.io_alertrules.yaml
@@ -1,0 +1,97 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: alertrules.ait.alauda.io
+spec:
+  group: ait.alauda.io
+  names:
+    kind: AlertRule
+    listKind: AlertRuleList
+    plural: alertrules
+    singular: alertrule
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: AlertRule defines alerting rules for a Prometheus instance AlertRule
+          is a copy of PrometheusRule, just different kind/group/version.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of desired alerting rule definitions for Prometheus.
+            properties:
+              groups:
+                description: Content of Prometheus rule file
+                items:
+                  description: 'RuleGroup is a list of sequentially evaluated recording
+                    and alerting rules. Note: PartialResponseStrategy is only used
+                    by ThanosRuler and will be ignored by Prometheus instances.  Valid
+                    values for this field are ''warn'' or ''abort''.  More info: https://github.com/thanos-io/thanos/blob/master/docs/components/rule.md#partial-response'
+                  properties:
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    partial_response_strategy:
+                      type: string
+                    rules:
+                      items:
+                        description: Rule describes an alerting or recording rule.
+                        properties:
+                          alert:
+                            type: string
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          expr:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          for:
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          record:
+                            type: string
+                        required:
+                        - expr
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - rules
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/docs/shared/crds/ait.alauda.io_dashboards.yaml
+++ b/docs/shared/crds/ait.alauda.io_dashboards.yaml
@@ -1,0 +1,117 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: dashboards.ait.alauda.io
+spec:
+  group: ait.alauda.io
+  names:
+    kind: Dashboard
+    listKind: DashboardList
+    plural: dashboards
+    singular: dashboard
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Dashboard is the Schema for the dashboards API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DashboardSpec defines the desired state of Dashboard
+            properties:
+              panels:
+                description: Dashboard contains panels to show monitor indicator.
+                items:
+                  description: DashboardPanel defines the info of panel, including
+                    title, targets, position.
+                  properties:
+                    description:
+                      description: Description is the description of a panel
+                      type: string
+                    targets:
+                      description: Targets define an array of indicator
+                      items:
+                        properties:
+                          displayName:
+                            description: DisplayName is the displayName of indicator
+                            type: string
+                          expr:
+                            description: Expr is the prometheus expression to query
+                              for custom indicator; no need for builtin indicator
+                            type: string
+                          indicator:
+                            description: Indicator is the name of indicator for builtin
+                              indicator, md5 of expr for custom indicator
+                            type: string
+                          legend:
+                            description: Legend is format to show the query result
+                            type: string
+                          resources:
+                            description: Resources defines the resources to monitor,
+                              empty array for all resources in a application; no need
+                              for custom indicator
+                            items:
+                              properties:
+                                kind:
+                                  description: Kind defines the kind of a resource
+                                  type: string
+                                name:
+                                  description: Name defines the name of a resource
+                                  type: string
+                                namespace:
+                                  description: Namespace defines the namespace of
+                                    a resource
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            type: array
+                          type:
+                            description: Type is the type of a indicator, builtin
+                              or custom
+                            type: string
+                          unit:
+                            description: Unit is the unit of indicator
+                            type: string
+                        required:
+                        - displayName
+                        type: object
+                      type: array
+                    title:
+                      description: Title is the title of a panel
+                      type: string
+                  required:
+                  - description
+                  - title
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/docs/shared/crds/ait.alauda.io_grafanadashboards.yaml
+++ b/docs/shared/crds/ait.alauda.io_grafanadashboards.yaml
@@ -1,0 +1,105 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: grafanadashboards.ait.alauda.io
+spec:
+  group: ait.alauda.io
+  names:
+    kind: GrafanaDashboard
+    listKind: GrafanaDashboardList
+    plural: grafanadashboards
+    shortNames:
+    - gd
+    singular: grafanadashboard
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GrafanaDashboard is the Schema for the grafanadashboards API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GrafanaDashboardSpec defines the desired state of GrafanaDashboard
+            properties:
+              folder:
+                description: Folder is an folder title for GrafanaDashboard. Edit
+                  GrafanaDashboard_types.go to remove/update
+                type: string
+              json:
+                description: Json is an json content for GrafanaDashboard. Edit GrafanaDashboard_types.go
+                  to remove/update
+                type: string
+            required:
+            - folder
+            - json
+            type: object
+          status:
+            description: GrafanaDashboardStatus defines the observed state of GrafanaDashboard
+            properties:
+              conditions:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                items:
+                  description: GrafanaDashboardCondition contains condition information
+                    for a grafana dashboard object.
+                  properties:
+                    destMD5:
+                      description: DestMD5 is md5 for content in grafana
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transit from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Brief reason for the condition's last transition.
+                      type: string
+                    specMD5:
+                      description: SpecMD5 is md5 for spec field in grafana dashboard
+                        instance
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of grafana dashboard condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/docs/shared/crds/ait.alauda.io_monitordashboards.yaml
+++ b/docs/shared/crds/ait.alauda.io_monitordashboards.yaml
@@ -18,6 +18,38 @@ spec:
     singular: monitordashboard
   scope: Namespaced
   versions:
+    - name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: MonitorDashboard is the Schema for the templates API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                body:
+                  description: Body is a json content for MonitorDashboard. Same as
+                    GrafanaDashboard's Json
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
     - name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -470,35 +502,3 @@ spec:
           type: object
       served: true
       storage: false
-    - name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: MonitorDashboard is the Schema for the templates API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                body:
-                  description: Body is a json content for MonitorDashboard. Same as
-                    GrafanaDashboard's Json
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true

--- a/docs/shared/crds/ait.alauda.io_monitordashboards.yaml
+++ b/docs/shared/crds/ait.alauda.io_monitordashboards.yaml
@@ -1,0 +1,500 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+    cert-manager.io/inject-ca-from: cpaas-system/warlock-serving-cert
+  creationTimestamp: null
+  name: monitordashboards.ait.alauda.io
+spec:
+  group: ait.alauda.io
+  names:
+    kind: MonitorDashboard
+    listKind: MonitorDashboardList
+    plural: monitordashboards
+    shortNames:
+      - md
+    singular: monitordashboard
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: MonitorDashboard is the Schema for the templates API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MonitorDashboardSpec defines the desired state of MonitorDashboard
+              properties:
+                cols:
+                  description: Cols in a row
+                  type: integer
+                gutter:
+                  description: Gutter is space between panel
+                  type: integer
+                options:
+                  description: Options for dashboard
+                  items:
+                    description: DashboardOption defines an option for MonitorDashboard
+                    properties:
+                      expr:
+                        description: Expr is promql for this option
+                        type: string
+                      hide:
+                        description: Hide determines show or not
+                        type: integer
+                      includeAll:
+                        description: IncludeAll show all option or not
+                        type: boolean
+                      label:
+                        description: Label is display name for this option
+                        type: string
+                      multipleEnabled:
+                        description: MultipleEnabled enable multiple options
+                        type: boolean
+                      name:
+                        description: Name for this option
+                        type: string
+                      regex:
+                        description: Regex to get substring
+                        type: string
+                      sort:
+                        description: Sort options for variables
+                        type: string
+                      type:
+                        description: Type for this option
+                        type: string
+                      values:
+                        description: Value for this option
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - name
+                      - type
+                    type: object
+                  type: array
+                panels:
+                  description: Panels for dashboard
+                  items:
+                    description: DashboardPanel defines a panel for MonitorDashboard
+                    properties:
+                      description:
+                        description: Description for this panel
+                        type: string
+                      id:
+                        description: ID for this panel
+                        type: string
+                      layout:
+                        description: Layout configuration for this panel
+                        properties:
+                          h:
+                            description: H is height for this panel
+                            type: integer
+                          lx:
+                            description: X-axis for this panel
+                            type: integer
+                          ly:
+                            description: Y-axis for this panel
+                            type: integer
+                          w:
+                            description: W is weight for this panel
+                            type: integer
+                        required:
+                          - h
+                          - lx
+                          - ly
+                          - w
+                        type: object
+                      links:
+                        description: Links for this panel
+                        items:
+                          description: PanelLink for Panel
+                          properties:
+                            targetBlank:
+                              description: TargetBlank for link
+                              type: boolean
+                            title:
+                              description: Title for link
+                              type: string
+                            url:
+                              description: Url for link
+                              type: string
+                          type: object
+                        type: array
+                      options:
+                        description: Options defines extra configuration for this panel
+                        properties:
+                          experimentalAttributes:
+                            description: ExperimentalAttributes defines other configurations
+                              for panel options
+                            type: object
+                          general:
+                            description: General configuration for this panel
+                            properties:
+                              layout:
+                                description: Layout for stat panel
+                                type: string
+                              mappings:
+                                description: Mappings define a list of mapping ways
+                                items:
+                                  description: PanelOptionMapping define a mapping way
+                                  properties:
+                                    text:
+                                      description: Text displayed on panel
+                                      type: string
+                                    type:
+                                      description: Type for mapping
+                                      type: string
+                                    values:
+                                      description: Values range for mapping
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              maxValue:
+                                description: MaxValue for gauge or bar-gauge panel
+                                type: string
+                              method:
+                                description: Method for stat panel
+                                type: string
+                              minValue:
+                                description: MinValue for gauge or bar-gauge panel
+                                type: string
+                              overrides:
+                                description: Overrides defines a list of override
+                                items:
+                                  description: PanelOptionOverride defines a list of
+                                    override
+                                  properties:
+                                    displayName:
+                                      description: DisplayName of table overrides
+                                      type: string
+                                    key:
+                                      description: Key of table overrides
+                                      type: string
+                                    unit:
+                                      description: Unit of table overrides
+                                      type: string
+                                    unitType:
+                                      description: UnitType of table overrides
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                          legend:
+                            description: Legend configuration for this panel
+                            properties:
+                              position:
+                                description: Position of legend
+                                type: string
+                              show:
+                                description: Show legend or not
+                                type: boolean
+                              values:
+                                description: Values displayed on legend
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          stat:
+                            description: Stat configuration for this panel
+                            properties:
+                              mappings:
+                                description: Mappings define a list of mapping ways
+                                items:
+                                  description: PanelOptionMapping define a mapping way
+                                  properties:
+                                    text:
+                                      description: Text displayed on panel
+                                      type: string
+                                    type:
+                                      description: Type for mapping
+                                      type: string
+                                    values:
+                                      description: Values range for mapping
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              method:
+                                description: Method for stat panel
+                                type: string
+                            type: object
+                          table:
+                            description: Table configuration for this panel
+                            properties:
+                              alignment:
+                                description: Alignment for table panel
+                                type: string
+                              hideColumn:
+                                description: Hide columns for table panel
+                                items:
+                                  type: string
+                                type: array
+                              pagination:
+                                description: Pagination for table panel
+                                type: boolean
+                            type: object
+                          text:
+                            description: Text configuration for this panel
+                            properties:
+                              titleSize:
+                                description: TitleSize for PanelOptionText
+                                format: int64
+                                type: integer
+                              valueSize:
+                                description: ValueSize for PanelOptionText
+                                format: int64
+                                type: integer
+                            type: object
+                          threshold:
+                            description: Threshold configuration for this panel
+                            properties:
+                              data:
+                                description: Data value for threshold
+                                type: string
+                              show:
+                                description: Show threshold or not
+                                type: boolean
+                              text:
+                                description: Text displayed on panel
+                                type: string
+                              values:
+                                description: ThresholdValues for PanelOptionThreshold
+                                items:
+                                  description: PanelThresholdValue for PanelOptionThreshold
+                                  properties:
+                                    color:
+                                      description: Color displayed on panel
+                                      type: string
+                                    data:
+                                      description: Data value for threshold
+                                      type: string
+                                    text:
+                                      description: Text displayed on panel
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                          tooltip:
+                            description: Tooltip configuration for this panel
+                            properties:
+                              show:
+                                description: Show tooltip or not
+                                type: boolean
+                              sort:
+                                description: Sort method for this panel
+                                type: string
+                            type: object
+                          type:
+                            description: Type for this panel
+                            type: string
+                          unit:
+                            description: Unit for this panel
+                            type: string
+                        required:
+                          - type
+                        type: object
+                      targets:
+                        description: Targets defines queries for this panel
+                        properties:
+                          custom:
+                            description: Custom defines other configurations for panel
+                              targets
+                            type: object
+                          indicators:
+                            description: Indicators defines a list indicator used by
+                              this panel
+                            items:
+                              description: PanelTargetIndicator defines a indicator
+                                used by DashboardPanel
+                              properties:
+                                id:
+                                  description: ID is unique id for this indicator
+                                  type: string
+                                indicator:
+                                  description: Indicator name
+                                  type: string
+                                legend:
+                                  description: Legend for query result
+                                  type: string
+                                variables:
+                                  additionalProperties:
+                                    type: string
+                                  description: Variables to render indicator
+                                  type: object
+                              required:
+                                - id
+                                - indicator
+                              type: object
+                            type: array
+                          queries:
+                            description: Queries defines a list of PromQL used by this
+                              panel
+                            items:
+                              description: PanelTargetQuery defines a PromQL used by
+                                DashboardPanel
+                              properties:
+                                expr:
+                                  description: Expr is a PromQL
+                                  type: string
+                                id:
+                                  description: ID is unique id for this query
+                                  type: string
+                                indicator:
+                                  description: Indicator name
+                                  type: string
+                                legend:
+                                  description: Legend for query result
+                                  type: string
+                                name:
+                                  description: Name is display name for this indicator
+                                  type: string
+                                unit:
+                                  description: Unit for query
+                                  type: string
+                                variables:
+                                  additionalProperties:
+                                    type: string
+                                  description: Variables to render indicator
+                                  type: object
+                              type: object
+                            type: array
+                          step:
+                            description: Step used to do query range
+                            type: integer
+                        required:
+                          - step
+                        type: object
+                      title:
+                        description: Title is display name for this panel
+                        type: string
+                      transformations:
+                        description: PanelTransformation defines transformation for
+                          a panel
+                        properties:
+                          primaryKeys:
+                            description: PrimaryKey defines panel primary key of transformation
+                            items:
+                              description: PanelPrimaryKey defines panel primary key
+                                of transformation
+                              properties:
+                                isGlobal:
+                                  description: QueryID is the id of target query
+                                  type: boolean
+                                name:
+                                  description: Name is the name of
+                                  type: string
+                                queryId:
+                                  description: QueryID is the id of target query
+                                  type: string
+                              required:
+                                - name
+                                - queryId
+                              type: object
+                            type: array
+                        type: object
+                    required:
+                      - id
+                      - layout
+                      - options
+                      - targets
+                      - title
+                    type: object
+                  type: array
+                refresh:
+                  description: Refresh is configuration for refresh
+                  properties:
+                    now:
+                      description: Now is current configuration for refresh
+                      type: string
+                    options:
+                      description: Options contain a list of refresh options
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                rowHeight:
+                  description: Row is height for panel
+                  type: integer
+                tags:
+                  description: Tags for dashboard
+                  items:
+                    type: string
+                  type: array
+                time:
+                  description: Time is options for time range
+                  properties:
+                    from:
+                      description: From is start time for query
+                      type: string
+                    options:
+                      description: Options contain a list of time options
+                      items:
+                        type: string
+                      type: array
+                    to:
+                      description: To is end time for query
+                      type: string
+                  required:
+                    - from
+                    - options
+                    - to
+                  type: object
+              required:
+                - cols
+                - gutter
+                - options
+                - rowHeight
+                - time
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+    - name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: MonitorDashboard is the Schema for the templates API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                body:
+                  description: Body is a json content for MonitorDashboard. Same as
+                    GrafanaDashboard's Json
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true

--- a/docs/shared/crds/ait.alauda.io_monitordashboards.yaml
+++ b/docs/shared/crds/ait.alauda.io_monitordashboards.yaml
@@ -24,14 +24,16 @@ spec:
           description: MonitorDashboard is the Schema for the templates API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -474,14 +476,16 @@ spec:
           description: MonitorDashboard is the Schema for the templates API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object

--- a/docs/shared/crds/alauda.io_alaudafeaturegates.yaml
+++ b/docs/shared/crds/alauda.io_alaudafeaturegates.yaml
@@ -23,14 +23,16 @@ spec:
           description: AlaudaFeatureGate describes a feature gate of the alauda product.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object

--- a/docs/shared/crds/alauda.io_alaudafeaturegates.yaml
+++ b/docs/shared/crds/alauda.io_alaudafeaturegates.yaml
@@ -1,0 +1,84 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: alaudafeaturegates.alauda.io
+spec:
+  group: alauda.io
+  names:
+    kind: AlaudaFeatureGate
+    listKind: AlaudaFeatureGateList
+    plural: alaudafeaturegates
+    singular: alaudafeaturegate
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.enabled
+          name: ENABLED
+          type: boolean
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: AlaudaFeatureGate describes a feature gate of the alauda product.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AlaudaFeatureGateSpec defines the desired state of AlaudaFeatureGate.
+              properties:
+                dependency:
+                  description: Dependency is the denpendencies of the feature gate.
+                  properties:
+                    featureGates:
+                      description: FeatureGates is the names of feature gates that depends
+                        on.
+                      items:
+                        type: string
+                      type: array
+                    type:
+                      description: Type is the type of dependency, should be one of
+                        "all" or "any".
+                      type: string
+                  type: object
+                description:
+                  description: Description is a human readable text of the feature gate.
+                  type: string
+                descriptionEn:
+                  description: DescriptionEn is an English human readable text of the feature gate.
+                  type: string
+                enabled:
+                  description: Enabled indicates if the feature gate is enabled manually.
+                  type: boolean
+                stage:
+                  description: Stage is the stage of the feature gate, should be one
+                    of "Alpha", "Beta", "GA" or "EOF".
+                  type: string
+              required:
+                - description
+                - enabled
+                - stage
+              type: object
+            status:
+              description: AlaudaFeatureGateStatus defines the observed state of AlaudaFeatureGate
+              properties:
+                enabled:
+                  description: Enabled indicates if the feature gate is enabled at runtime.
+                  type: boolean
+              required:
+                - enabled
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/docs/shared/crds/alauda.io_clusteralaudafeaturegates.yaml
+++ b/docs/shared/crds/alauda.io_clusteralaudafeaturegates.yaml
@@ -1,0 +1,85 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: clusteralaudafeaturegates.alauda.io
+spec:
+  group: alauda.io
+  names:
+    kind: ClusterAlaudaFeatureGate
+    listKind: ClusterAlaudaFeatureGateList
+    plural: clusteralaudafeaturegates
+    singular: clusteralaudafeaturegate
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.enabled
+          name: ENABLED
+          type: boolean
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterAlaudaFeatureGate describes a cluster level feature gate
+            of the alauda product
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AlaudaFeatureGateSpec defines the desired state of AlaudaFeatureGate.
+              properties:
+                dependency:
+                  description: Dependency is the denpendencies of the feature gate.
+                  properties:
+                    featureGates:
+                      description: FeatureGates is the names of feature gates that depends
+                        on.
+                      items:
+                        type: string
+                      type: array
+                    type:
+                      description: Type is the type of dependency, should be one of
+                        "all" or "any".
+                      type: string
+                  type: object
+                description:
+                  description: Description is a human readable text of the feature gate.
+                  type: string
+                descriptionEn:
+                  description: DescriptionEn is an English human readable text of the feature gate.
+                  type: string
+                enabled:
+                  description: Enabled indicates if the feature gate is enabled manually.
+                  type: boolean
+                stage:
+                  description: Stage is the stage of the feature gate, should be one
+                    of "Alpha", "Beta", "GA" or "EOF".
+                  type: string
+              required:
+                - description
+                - enabled
+                - stage
+              type: object
+            status:
+              description: AlaudaFeatureGateStatus defines the observed state of AlaudaFeatureGate
+              properties:
+                enabled:
+                  description: Enabled indicates if the feature gate is enabled at runtime.
+                  type: boolean
+              required:
+                - enabled
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/docs/shared/crds/alauda.io_clusteralaudafeaturegates.yaml
+++ b/docs/shared/crds/alauda.io_clusteralaudafeaturegates.yaml
@@ -24,14 +24,16 @@ spec:
             of the alauda product
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object

--- a/docs/shared/crds/alaudalio_productentries.yaml
+++ b/docs/shared/crds/alaudalio_productentries.yaml
@@ -30,14 +30,16 @@ spec:
           description: ProductEntry is the Schema for the productentries API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object

--- a/docs/shared/crds/alaudalio_productentries.yaml
+++ b/docs/shared/crds/alaudalio_productentries.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: productentries.alauda.io
+spec:
+  group: alauda.io
+  names:
+    kind: ProductEntry
+    listKind: ProductEntryList
+    plural: productentries
+    shortNames:
+      - prde
+    singular: productentry
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.catalog.en
+          name: Catalog
+          type: string
+        - jsonPath: .spec.displayName.en
+          name: DisplayName
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ProductEntry is the Schema for the productentries API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ProductEntrySpec defines the desired state of ProductEntry
+              properties:
+                catalog:
+                  description: Catalog stands for the product's catalog
+                  properties:
+                    en:
+                      description: EN stands for text with English
+                      type: string
+                    zh:
+                      description: ZH stands for text with Simple Chinese
+                      type: string
+                  type: object
+                description:
+                  description: Description stands for the product's description
+                  properties:
+                    en:
+                      description: EN stands for text with English
+                      type: string
+                    zh:
+                      description: ZH stands for text with Simple Chinese
+                      type: string
+                  type: object
+                displayName:
+                  description: DisplayName stands for the product's display name
+                  properties:
+                    en:
+                      description: EN stands for text with English
+                      type: string
+                    zh:
+                      description: ZH stands for text with Simple Chinese
+                      type: string
+                  type: object
+                entrypoint:
+                  description: Entrypoint stands for the entrypoint of sub app
+                  type: string
+                logo:
+                  description: Logo stands for the product logo with base64 encoded
+                    data uri
+                  type: string
+                packType:
+                  description: PackType is the product's package type
+                  enum:
+                    - Integrated
+                    - BuildIn
+                    - AdminPage
+                    - Portal
+                  type: string
+                ssoEnabled:
+                  description: SSOEnabled stands for if SSO enabled
+                  type: boolean
+                version:
+                  description: Version stands for product version
+                  type: string
+                entryTarget:
+                  type: string
+              required:
+                - description
+                - displayName
+                - entrypoint
+                - logo
+                - packType
+                - version
+              type: object
+            status:
+              description: ProductEntryStatus defines the observed state of ProductEntry
+              properties:
+                hiddenOnMenu:
+                  description: HiddenOnPortal stands for if this product is hidden on
+                    menu
+                  type: boolean
+                hiddenOnPortal:
+                  description: HiddenOnPortal stands for if this product is hidden on
+                    portal
+                  type: boolean
+                orderOnMenu:
+                  description: OrderOnMenu stands for the product's order on menu
+                  type: integer
+                orderOnPortal:
+                  description: OrderOnPortal stands for the product's order on portal
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/docs/shared/crds/app.alauda.io_artifacts.yaml
+++ b/docs/shared/crds/app.alauda.io_artifacts.yaml
@@ -21,14 +21,16 @@ spec:
           description: Artifact is the Schema for the artifacts API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -129,9 +131,10 @@ spec:
               description: ArtifactStatus defines the observed state of Artifact
               properties:
                 availableArtifactVersion:
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                  description: |-
+                    INSERT ADDITIONAL STATUS FIELD - define observed state
+                    of cluster Important: Run "make" to regenerate code after modifying
+                    this file
                   type: integer
                 lastUpdateTime:
                   format: date-time

--- a/docs/shared/crds/app.alauda.io_artifacts.yaml
+++ b/docs/shared/crds/app.alauda.io_artifacts.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: artifacts.app.alauda.io
+spec:
+  group: app.alauda.io
+  names:
+    kind: Artifact
+    listKind: ArtifactList
+    plural: artifacts
+    singular: artifact
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Artifact is the Schema for the artifacts API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ArtifactSpec defines the desired state of Artifact
+              properties:
+                artifactVersionSelector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the key
+                          and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to
+                              a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                description:
+                  type: string
+                displayName:
+                  type: string
+                imagePullSecrets:
+                  items:
+                    type: string
+                  type: array
+                present:
+                  type: boolean
+                registry:
+                  type: string
+                repository:
+                  type: string
+                tagPatterns:
+                  items:
+                    description: Pattern is image version pattern
+                    properties:
+                      maxQuantity:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                      name:
+                        type: string
+                      regex:
+                        type: string
+                    required:
+                      - maxQuantity
+                      - name
+                      - regex
+                    type: object
+                  type: array
+                  nullable: true
+                type:
+                  type: string
+              required:
+                - artifactVersionSelector
+                - present
+                - registry
+                - repository
+                - type
+              type: object
+            status:
+              description: ArtifactStatus defines the observed state of Artifact
+              properties:
+                availableArtifactVersion:
+                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                  type: integer
+                lastUpdateTime:
+                  format: date-time
+                  type: string
+                synced:
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: { }
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: [ ]
+  storedVersions: [ ]

--- a/docs/shared/crds/app.alauda.io_artifactversions.yaml
+++ b/docs/shared/crds/app.alauda.io_artifactversions.yaml
@@ -34,14 +34,16 @@ spec:
           description: ArtifactVersion is the Schema for the artifactversions API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -67,9 +69,10 @@ spec:
                   type: string
                 phase:
                   default: unknown
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                  description: |-
+                    INSERT ADDITIONAL STATUS FIELD - define observed state
+                    of cluster Important: Run "make" to regenerate code after modifying
+                    this file
                   type: string
                 reason:
                   default: ""

--- a/docs/shared/crds/app.alauda.io_artifactversions.yaml
+++ b/docs/shared/crds/app.alauda.io_artifactversions.yaml
@@ -1,0 +1,253 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: artifactversions.app.alauda.io
+spec:
+  group: app.alauda.io
+  names:
+    kind: ArtifactVersion
+    listKind: ArtifactVersionList
+    plural: artifactversions
+    singular: artifactversion
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.name
+          name: name
+          type: string
+        - jsonPath: .status.version
+          name: version
+          type: string
+        - jsonPath: .status.phase
+          name: phase
+          type: string
+        - jsonPath: .status.reason
+          name: reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ArtifactVersion is the Schema for the artifactversions API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ArtifactVersionSpec defines the desired state of ArtifactVersion
+              properties:
+                present:
+                  type: boolean
+                tag:
+                  type: string
+              required:
+                - present
+                - tag
+              type: object
+            status:
+              description: ArtifactVersionStatus defines the observed state of ArtifactVersion
+              properties:
+                message:
+                  default: ""
+                  type: string
+                name:
+                  default: ""
+                  type: string
+                phase:
+                  default: unknown
+                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                  type: string
+                reason:
+                  default: ""
+                  type: string
+                type:
+                  default: ""
+                  type: string
+                version:
+                  default: ""
+                  type: string
+                chartInfo:
+                  description: ChartInfo defines the struct of chart info
+                  properties:
+                    files:
+                      description: Files are miscellaneous files in a chart archive,
+                        e.g. README, LICENSE, etc.
+                      items:
+                        description: "File represents a file as a name/value pair. \n
+                          By convention, name is a relative path within the scope of
+                          the chart's base directory."
+                        properties:
+                          data:
+                            description: Data is the template as byte data.
+                            format: byte
+                            type: string
+                          name:
+                            description: Name is the path-like name of the template.
+                            type: string
+                        required:
+                        - data
+                        - name
+                        type: object
+                      type: array
+                    metadata:
+                      description: Metadata is the contents of the Chartfile.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations are additional mappings uninterpreted
+                            by Helm, made available for inspection by other applications.
+                          type: object
+                        apiVersion:
+                          description: The API Version of this chart. Required.
+                          type: string
+                        appVersion:
+                          description: The version of the application enclosed inside
+                            of this chart.
+                          type: string
+                        condition:
+                          description: The condition to check to enable chart
+                          type: string
+                        dependencies:
+                          description: Dependencies are a list of dependencies for a
+                            chart.
+                          items:
+                            description: "Dependency describes a chart upon which another
+                              chart depends. \n Dependencies can be used to express
+                              developer intent, or to capture the state of a chart."
+                            properties:
+                              alias:
+                                description: Alias usable alias to be used for the chart
+                                type: string
+                              condition:
+                                description: A yaml path that resolves to a boolean,
+                                  used for enabling/disabling charts (e.g. subchart1.enabled
+                                  )
+                                type: string
+                              enabled:
+                                description: Enabled bool determines if chart should
+                                  be loaded
+                                type: boolean
+                              import-values:
+                                description: ImportValues holds the mapping of source
+                                  values to parent key to be imported. Each item can
+                                  be a string or pair of child/parent sublist items.
+                                items:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                type: array
+                              name:
+                                description: "Name is the name of the dependency. \n
+                                  This must mach the name in the dependency's Chart.yaml."
+                                type: string
+                              repository:
+                                description: "The URL to the repository. \n Appending
+                                  `index.yaml` to this string should result in a URL
+                                  that can be used to fetch the repository index."
+                                type: string
+                              tags:
+                                description: Tags can be used to group charts for enabling/disabling
+                                  together
+                                items:
+                                  type: string
+                                type: array
+                              version:
+                                description: "Version is the version (range) of this
+                                  chart. \n A lock file will always produce a single
+                                  version, while a dependency may contain a semantic
+                                  version range."
+                                type: string
+                            type: object
+                          type: array
+                        deprecated:
+                          description: Whether or not this chart is deprecated
+                          type: boolean
+                        description:
+                          description: A one-sentence description of the chart
+                          type: string
+                        home:
+                          description: The URL to a relevant project page, git repo,
+                            or contact person
+                          type: string
+                        icon:
+                          description: The URL to an icon file.
+                          type: string
+                        keywords:
+                          description: A list of string keywords
+                          items:
+                            type: string
+                          type: array
+                        kubeVersion:
+                          description: KubeVersion is a SemVer constraint specifying
+                            the version of Kubernetes required.
+                          type: string
+                        maintainers:
+                          description: A list of name and URL/email address combinations
+                            for the maintainer(s)
+                          items:
+                            description: Maintainer describes a Chart maintainer.
+                            properties:
+                              email:
+                                description: Email is an optional email address to contact
+                                  the named maintainer
+                                type: string
+                              name:
+                                description: Name is a user name or organization name
+                                type: string
+                              url:
+                                description: URL is an optional URL to an address for
+                                  the named maintainer
+                                type: string
+                            type: object
+                          type: array
+                        name:
+                          description: The name of the chart. Required.
+                          type: string
+                        sources:
+                          description: Source is the URL to the source code of this
+                            chart
+                          items:
+                            type: string
+                          type: array
+                        tags:
+                          description: The tags to check to enable chart
+                          type: string
+                        type:
+                          description: 'Specifies the chart type: application or library'
+                          type: string
+                        version:
+                          description: A SemVer 2 conformant version string of the chart.
+                            Required.
+                          type: string
+                      type: object
+                    values:
+                      description: Values are default config for this chart.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: { }
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: [ ]
+  storedVersions: [ ]

--- a/docs/shared/crds/app.alauda.io_chartrepos.yaml
+++ b/docs/shared/crds/app.alauda.io_chartrepos.yaml
@@ -1,0 +1,167 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: chartrepos.app.alauda.io
+spec:
+  conversion:
+    strategy: None
+  group: app.alauda.io
+  names:
+    kind: ChartRepo
+    listKind: ChartRepoList
+    plural: chartrepos
+    shortNames:
+    - ctr
+    singular: chartrepo
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The url of this chart repo
+      jsonPath: .spec.url
+      name: URL
+      type: string
+    - description: The phase of this ChartRepo
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              secret:
+                description: Secret contains information about how to auth to this
+                  repo
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                nullable: true
+                type: object
+              url:
+                description: URL is the repo's url
+                type: string
+            required:
+            - url
+            type: object
+          status:
+            properties:
+              phase:
+                description: Phase ... After create, this phase will be updated to
+                  indicate it's sync status If receive update event, and some field
+                  in spec changed, sync agagin.
+                type: string
+              reason:
+                description: Reason is the failed reason
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+  - additionalPrinterColumns:
+    - description: The url of this chart repo
+      jsonPath: .spec.url
+      name: URL
+      type: string
+    - description: The phase of this ChartRepo
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              secret:
+                description: Secret contains information about how to auth to this
+                  repo
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                nullable: true
+                type: object
+              source:
+                description: new in v1beta1.if type is Chart, this is optional and
+                  it will provide some compatible with v1alpha1
+                properties:
+                  path:
+                    description: may be root, may be a subdir
+                    type: string
+                  url:
+                    description: vcs url
+                    type: string
+                required:
+                - url
+                nullable: true
+                type: object
+              type:
+                description: new in v1beta1
+                type: string
+              url:
+                description: URL is the repo's url
+                type: string
+            required:
+            - type
+            - url
+            type: object
+          status:
+            properties:
+              phase:
+                description: Phase ... After create, this phase will be updated to
+                  indicate it's sync status If receive update event, and some field
+                  in spec changed, sync agagin.
+                type: string
+              reason:
+                description: Reason is the failed reason
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/docs/shared/crds/app.alauda.io_chartrepos.yaml
+++ b/docs/shared/crds/app.alauda.io_chartrepos.yaml
@@ -27,72 +27,6 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              secret:
-                description: Secret contains information about how to auth to this
-                  repo
-                properties:
-                  name:
-                    description: Name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: Namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                nullable: true
-                type: object
-              url:
-                description: URL is the repo's url
-                type: string
-            required:
-            - url
-            type: object
-          status:
-            properties:
-              phase:
-                description: Phase ... After create, this phase will be updated to
-                  indicate it's sync status If receive update event, and some field
-                  in spec changed, sync agagin.
-                type: string
-              reason:
-                description: Reason is the failed reason
-                type: string
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: false
-  - additionalPrinterColumns:
-    - description: The url of this chart repo
-      jsonPath: .spec.url
-      name: URL
-      type: string
-    - description: The phase of this ChartRepo
-      jsonPath: .status.phase
-      name: Phase
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -165,3 +99,69 @@ spec:
         type: object
     served: true
     storage: true
+  - additionalPrinterColumns:
+    - description: The url of this chart repo
+      jsonPath: .spec.url
+      name: URL
+      type: string
+    - description: The phase of this ChartRepo
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              secret:
+                description: Secret contains information about how to auth to this
+                  repo
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                nullable: true
+                type: object
+              url:
+                description: URL is the repo's url
+                type: string
+            required:
+            - url
+            type: object
+          status:
+            properties:
+              phase:
+                description: Phase ... After create, this phase will be updated to
+                  indicate it's sync status If receive update event, and some field
+                  in spec changed, sync agagin.
+                type: string
+              reason:
+                description: Reason is the failed reason
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false

--- a/docs/shared/crds/app.alauda.io_charts.yaml
+++ b/docs/shared/crds/app.alauda.io_charts.yaml
@@ -23,45 +23,6 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              versions:
-                items:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                type: array
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: false
-  - additionalPrinterColumns:
-    - jsonPath: .spec.versions[0].version
-      name: Version
-      type: string
-    - jsonPath: .spec.versions[0].appVersion
-      name: AppVersion
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -91,3 +52,42 @@ spec:
         type: object
     served: true
     storage: true
+  - additionalPrinterColumns:
+    - jsonPath: .spec.versions[0].version
+      name: Version
+      type: string
+    - jsonPath: .spec.versions[0].appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              versions:
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false

--- a/docs/shared/crds/app.alauda.io_charts.yaml
+++ b/docs/shared/crds/app.alauda.io_charts.yaml
@@ -1,0 +1,93 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: charts.app.alauda.io
+spec:
+  conversion:
+    strategy: None
+  group: app.alauda.io
+  names:
+    kind: Chart
+    listKind: ChartList
+    plural: charts
+    singular: chart
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.versions[0].version
+      name: Version
+      type: string
+    - jsonPath: .spec.versions[0].appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              versions:
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+  - additionalPrinterColumns:
+    - jsonPath: .spec.versions[0].version
+      name: Version
+      type: string
+    - jsonPath: .spec.versions[0].appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              versions:
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/docs/shared/crds/app.alauda.io_helmrequests.yaml
+++ b/docs/shared/crds/app.alauda.io_helmrequests.yaml
@@ -1,0 +1,483 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: helmrequests.app.alauda.io
+spec:
+  group: app.alauda.io
+  conversion:
+    strategy: None
+  names:
+    kind: HelmRequest
+    listKind: HelmRequestList
+    plural: helmrequests
+    singular: helmrequest
+    shortNames:
+      - hr
+      - hrs
+  scope: Namespaced
+  versions:
+  - name: v1
+    additionalPrinterColumns:
+    - name: Chart
+      type: string
+      description: The chart of this HelmRequest
+      jsonPath: .spec.chart
+    - name: Version
+      type: string
+      description: Version of this chart
+      jsonPath: .spec.version
+    - name: Namespace
+      type: string
+      description: The namespace which the chart deployed to
+      jsonPath: .spec.namespace
+    - name: AllCluster
+      type: boolean
+      description: Is this chart will be installed to all cluster
+      jsonPath: .spec.installToAllClusters
+    - name: Phase
+      type: string
+      description: The phase of this HelmRequest
+      jsonPath: .status.phase
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              chart:
+                type: string
+              clusterName:
+                description: ClusterName is the cluster where the chart will be installed.
+                  If InstallToAllClusters=true, this field will be ignored
+                type: string
+              dependencies:
+                description: Dependencies is the dependencies of this HelmRequest,
+                  it's a list of there names THe dependencies must lives in the same
+                  namespace, and each of them must be in Synced status before we sync
+                  this HelmRequest
+                items:
+                  type: string
+                type: array
+              installToAllClusters:
+                description: InstallToAllClusters will install this chart to all available
+                  clusters, even the cluster was created after this chart. If this
+                  field is true, ClusterName will be ignored(useless)
+                type: boolean
+              namespace:
+                description: Namespace is the namespace where the Release object will
+                  be lived in. Notes this should be used with the values defined in
+                  the chart， otherwise the install will failed
+                type: string
+              releaseName:
+                description: ReleaseName is the Release name to be generated, default
+                  to HelmRequest.Name. If we want to manually install this chart to
+                  multi clusters, we may have different HelmRequest name(with cluster
+                  prefix or suffix) and same release name
+                type: string
+              source:
+                description: Source defines the source of chart, If this field is
+                  set, Chart and Version field will be ignored(useless)
+                properties:
+                  http:
+                    properties:
+                      secretRef:
+                        description: SecretRef A Secret reference, the secret should
+                          contain accessKeyId (user name) base64 encoded, and secretKey
+                          (password) also base64 encoded
+                        type: string
+                      url:
+                        description: URL is the URL of the http(s) endpoint
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  oci:
+                    properties:
+                      repo:
+                        description: Repo is the repo of the oci artifact
+                        type: string
+                      secretRef:
+                        description: SecretRef A Secret reference, the secret should
+                          contain accessKeyId (user name) base64 encoded, and secretKey
+                          (password) also base64 encoded
+                        type: string
+                    required:
+                    - repo
+                    type: object
+                type: object
+              targetClusters:
+                description: TargetClusters defines the target clusters which the chart will be installed
+                properties:
+                  clusterLabels:
+                    description: ClusterLabels store the key value of labels to match
+                      clusters
+                    properties:
+                      labelSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    required:
+                    - labelSelector
+                    type: object
+                  clusterNames:
+                    description: ClusterNames store a list of cluster names
+                    properties:
+                      names:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - names
+                    type: object
+                type: object
+              values:
+                description: Values represents a collection of chart values.
+                type: object
+                nullable: true
+                x-kubernetes-preserve-unknown-fields: true
+              valuesFrom:
+                description: ValuesFrom represents values from ConfigMap/Secret...
+                items:
+                  description: ValuesFromSource represents a source of values, only
+                    one of it's fields may be set
+                  properties:
+                    configMapKeyRef:
+                      description: ConfigMapKeyRef selects a key of a ConfigMap
+                      properties:
+                        key:
+                          description: The key to select.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    secretKeyRef:
+                      description: SecretKeyRef selects a key of a Secret
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                  type: object
+                type: array
+              version:
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                      nullable: true
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                      nullable: true
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: 'Status is the status of the condition. Can be
+                        True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                      type: string
+                    type:
+                      description: 'Type is the type of the condition. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                      type: string
+                  type: object
+                type: array
+              lastSpecHash:
+                description: LastSpecHash store the has value of the synced spec,
+                  if this value not equal to the current one, means we need to do
+                  a update for the chart
+                type: string
+              notes:
+                description: Notes is the contents from helm (after helm install successfully
+                  it will be printed to the console
+                type: string
+              phase:
+                description: HelmRequestPhase is a label for the condition of a HelmRequest
+                  at the current time.
+                type: string
+              reason:
+                description: Reason will store the reason why the HelmRequest deploy
+                  failed
+                type: string
+              syncedClusters:
+                description: SyncedClusters will store the synced clusters if InstallToAllClusters
+                  is true
+                items:
+                  type: string
+                type: array
+              targetClusterSyncResults:
+                additionalProperties:
+                  properties:
+                    name:
+                      description: Name store the name of cluster
+                      type: string
+                    appStatus:
+                      description: AppStatus store the status of the application
+                      type: string
+                    endpoint:
+                      description: Endpoint store the apiserver's endpoint of the cluster
+                      type: string
+                    lastUpdateAt:
+                      description: LastUpdateAt store the last update time
+                      format: date-time
+                      type: string
+                    phase:
+                      description: Phase store the phase of the chart which installed
+                        into current cluster
+                      type: string
+                    reason:
+                      description: Reason store the reason why the HelmRequest deploy
+                        failed
+                      type: string
+                  type: object
+                description: TargetClusterSyncResults will store the chart sync result of every target cluster
+                type: object
+              version:
+                description: Verions is the real version that installed
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1alpha1
+    additionalPrinterColumns:
+    - name: Chart
+      type: string
+      description: The chart of this HelmRequest
+      jsonPath: .spec.chart
+    - name: Version
+      type: string
+      description: Version of this chart
+      jsonPath: .spec.version
+    - name: Namespace
+      type: string
+      description: The namespace which the chart deployed to
+      jsonPath: .spec.namespace
+    - name: AllCluster
+      type: boolean
+      description: Is this chart will be installed to all cluster
+      jsonPath: .spec.installToAllClusters
+    - name: Phase
+      type: string
+      description: The phase of this HelmRequest
+      jsonPath: .status.phase
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              chart:
+                type: string
+              clusterName:
+                description: ClusterName is the cluster where the chart will be installed.
+                  If InstallToAllClusters=true, this field will be ignored
+                type: string
+              dependencies:
+                description: Dependencies is the dependencies of this HelmRequest,
+                  it's a list of there names THe dependencies must lives in the same
+                  namespace, and each of them must be in Synced status before we sync
+                  this HelmRequest
+                items:
+                  type: string
+                type: array
+              installToAllClusters:
+                description: InstallToAllClusters will install this chart to all available
+                  clusters, even the cluster was created after this chart. If this
+                  field is true, ClusterName will be ignored(useless)
+                type: boolean
+              namespace:
+                description: Namespace is the namespace where the Release object will
+                  be lived in. Notes this should be used with the values defined in
+                  the chart， otherwise the install will failed
+                type: string
+              releaseName:
+                description: ReleaseName is the Release name to be generated, default
+                  to HelmRequest.Name. If we want to manually install this chart to
+                  multi clusters, we may have different HelmRequest name(with cluster
+                  prefix or suffix) and same release name
+                type: string
+              values:
+                description: Values represents a collection of chart values.
+                type: object
+                nullable: true
+                x-kubernetes-preserve-unknown-fields: true
+              valuesFrom:
+                description: ValuesFrom represents values from ConfigMap/Secret...
+                items:
+                  description: ValuesFromSource represents a source of values, only
+                    one of it's fields may be set
+                  properties:
+                    configMapKeyRef:
+                      description: ConfigMapKeyRef selects a key of a ConfigMap
+                      properties:
+                        key:
+                          description: The key to select.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    secretKeyRef:
+                      description: SecretKeyRef selects a key of a Secret
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                  type: object
+                type: array
+              version:
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                      nullable: true
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                      nullable: true
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: 'Status is the status of the condition. Can be
+                        True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                      type: string
+                    type:
+                      description: 'Type is the type of the condition. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                      type: string
+                  type: object
+                type: array
+              lastSpecHash:
+                description: LastSpecHash store the has value of the synced spec,
+                  if this value not equal to the current one, means we need to do
+                  a update for the chart
+                type: string
+              notes:
+                description: Notes is the contents from helm (after helm install successfully
+                  it will be printed to the console
+                type: string
+              phase:
+                description: HelmRequestPhase is a label for the condition of a HelmRequest
+                  at the current time.
+                type: string
+              reason:
+                description: Reason will store the reason why the HelmRequest deploy
+                  failed
+                type: string
+              syncedClusters:
+                description: SyncedClusters will store the synced clusters if InstallToAllClusters
+                  is true
+                items:
+                  type: string
+                type: array
+              version:
+                description: Verions is the real version that installed
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/docs/shared/crds/app.alauda.io_imagewhitelists.yaml
+++ b/docs/shared/crds/app.alauda.io_imagewhitelists.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: imagewhitelists.app.alauda.io
+spec:
+  group: app.alauda.io
+  names:
+    kind: ImageWhiteList
+    listKind: ImageWhiteListList
+    plural: imagewhitelists
+    singular: imagewhitelist
+    shortNames:
+      - iwl
+      - iwls
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ImageWhiteList is the Schema for the imagewhitelists API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImageWhiteListSpec defines the desired state of ImageWhiteList
+            properties:
+              repoList:
+                items:
+                  type: string
+                type: array
+              rewriteRules:
+                items:
+                  description: RewriteRule defines the rewrite rule of ImageWhiteList
+                  properties:
+                    regexp:
+                      type: string
+                    replacement:
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: ImageWhiteListStatus defines the observed state of ImageWhiteList
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/app.alauda.io_libraries.yaml
+++ b/docs/shared/crds/app.alauda.io_libraries.yaml
@@ -1,0 +1,119 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: libraries.app.alauda.io
+spec:
+  group: app.alauda.io
+  names:
+    kind: Library
+    listKind: LibraryList
+    plural: libraries
+    singular: library
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Library is the Schema for the libraries API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LibrarySpec defines the desired state of Library
+            properties:
+              artifactSelector:
+                description: A label selector is a label query over a set of resources.
+                  The result of matchLabels and matchExpressions are ANDed. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              imagePullSecrets:
+                items:
+                  type: string
+                type: array
+            required:
+            - artifactSelector
+            - imagePullSecrets
+            type: object
+          status:
+            description: LibraryStatus defines the observed state of Library
+            properties:
+              lastUpdateTime:
+                format: date-time
+                type: string
+              phase:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: string
+            required:
+            - lastUpdateTime
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/docs/shared/crds/auth.alauda.io_disabletokens.yaml
+++ b/docs/shared/crds/auth.alauda.io_disabletokens.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: disabletokens.auth.alauda.io
+spec:
+  group: auth.alauda.io
+  names:
+    kind: DisableToken
+    listKind: DisableTokenList
+    plural: disabletokens
+    singular: disabletoken
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: DisableToken is the Schema for the disabletokens API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DisableTokenSpec defines the desired state of DisableToken
+            properties:
+              Expiration:
+                format: date-time
+                type: string
+              TokenMd5:
+                type: string
+            required:
+            - Expiration
+            - TokenMd5
+            type: object
+          status:
+            description: DisableTokenStatus defines the observed state of DisableToken
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/docs/shared/crds/auth.alauda.io_disableusers.yaml
+++ b/docs/shared/crds/auth.alauda.io_disableusers.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: disableusers.auth.alauda.io
+spec:
+  group: auth.alauda.io
+  names:
+    kind: DisableUser
+    listKind: DisableUserList
+    plural: disableusers
+    singular: disableuser
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: DisableUser is the Schema for the disableusers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DisableUserSpec defines the desired state of DisableUser
+            properties:
+              Expiration:
+                format: date-time
+                type: string
+              User:
+                type: string
+            required:
+            - Expiration
+            - User
+            type: object
+          status:
+            description: DisableUserStatus defines the observed state of DisableUser
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/docs/shared/crds/auth.alauda.io_projects.yaml
+++ b/docs/shared/crds/auth.alauda.io_projects.yaml
@@ -1,0 +1,135 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: projects.auth.alauda.io
+spec:
+  group: auth.alauda.io
+  names:
+    kind: Project
+    listKind: ProjectList
+    plural: projects
+    singular: project
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Project is the Schema for the projects API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ProjectSpec defines the desired state of Project
+              properties:
+                clusterDeletePolicy:
+                  type: string
+                clusters:
+                  description: Clusters contains the clusters associated with this Project
+                  items:
+                    description: ProjectClusters is the attribute for ProjectSpec
+                    properties:
+                      name:
+                        description: Name of the cluster
+                        type: string
+                      quota:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Quota store the quota info for Project
+                        type: object
+                      type:
+                        description: Type of the cluster
+                        type: string
+                    required:
+                      - name
+                      - quota
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: ProjectStatus defines the observed state of Project
+              properties:
+                conditions:
+                  items:
+                    description: ProjectCondition contains condition information for
+                      a cluster.
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          changed from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about the last status change.
+                        type: string
+                      projectNameSpaceDetail:
+                        description: 用来记录project同名命名空间详细信息
+                        properties:
+                          failedClusters:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            description: 原始的项目名称，即要创建ns的名称
+                            type: string
+                          successClusters:
+                            additionalProperties:
+                              type: boolean
+                            type: object
+                        type: object
+                      reason:
+                        description: Reason is a (brief) reason for the condition's
+                          last status change.
+                        type: string
+                      status:
+                        description: Status is the status of the condition. One of True,
+                          False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the cluster condition.
+                        enum:
+                          - ProjectNameSpace
+                          - Quota
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                phase:
+                  description: Phase record the state of project
+                  type: string
+                reason:
+                  type: string
+                version:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/docs/shared/crds/auth.alauda.io_projects.yaml
+++ b/docs/shared/crds/auth.alauda.io_projects.yaml
@@ -21,14 +21,16 @@ spec:
           description: Project is the Schema for the projects API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object

--- a/docs/shared/crds/auth.alauda.io_userbindings.yaml
+++ b/docs/shared/crds/auth.alauda.io_userbindings.yaml
@@ -1,0 +1,202 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: userbindings.auth.alauda.io
+spec:
+  group: auth.alauda.io
+  names:
+    kind: UserBinding
+    listKind: UserBindingList
+    plural: userbindings
+    singular: userbinding
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.subjects[0].kind
+          name: Kind
+          type: string
+        - jsonPath: .spec.subjects[0].name
+          name: Name
+          type: string
+        - jsonPath: .spec.scope
+          name: Scope
+          type: string
+        - jsonPath: .spec.roleRef
+          name: Role
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: UserBinding is the Schema for the userbindings API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: UserBindingSpec defines the desired state of UserBinding
+              properties:
+                constraint:
+                  items:
+                    properties:
+                      cluster:
+                        type: string
+                      namespace:
+                        type: string
+                      project:
+                        type: string
+                    type: object
+                  type: array
+                roleRef:
+                  type: string
+                scope:
+                  type: string
+                subjects:
+                  items:
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  type: array
+#              required:
+#                - roleRef
+#                - scope
+#                - subjects
+              type: object
+            status:
+              description: UserBindingStatus defines the observed state of UserBinding
+              properties:
+                bindingsCreated:
+                  description: BindingsCreated records the count of created bindings
+                  properties:
+                    clusterRoleBindings:
+                      description: ClusterRoleBindings count of created ClusterRoleBindings
+                      type: integer
+                    roleBindings:
+                      description: RoleBindings count of created RoleBindings
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    # required:
+                    # - status
+                    # - type
+                    type: object
+                  type: array
+                failedClusters:
+                  description: FailedClusters lists clusters that failed to sync (global
+                    cluster only)
+                  items:
+                    type: string
+                  type: array
+                failureDetails:
+                  description: FailureDetails contains detailed error information for
+                    troubleshooting
+                  properties:
+                    affectedItems:
+                      description: AffectedItems lists the specific resources that failed
+                      items:
+                        description: AffectedItem represents a specific resource that
+                          failed during reconciliation
+                        properties:
+                          error:
+                            description: Error is the specific error message for this
+                              item
+                            type: string
+                          name:
+                            description: Name is the name of the affected resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the resource
+                              (for RoleBinding)
+                            type: string
+                          type:
+                            description: Type is the resource type (ClusterRoleBinding,
+                              RoleBinding, etc.)
+                            type: string
+                        type: object
+                      type: array
+                    failureMessage:
+                      description: FailureMessage is a human-readable detailed error
+                        message
+                      type: string
+                    failureReason:
+                      description: FailureReason is a short, machine-readable reason
+                        for the failure
+                      type: string
+                    lastFailureTime:
+                      description: LastFailureTime records when the last failure occurred
+                      format: date-time
+                      type: string
+                  type: object
+                lastReconcileTime:
+                  description: |-
+                    LastReconcileTime records the last successful reconcile time
+                    Used to detect if reconciliation is stuck
+                  format: date-time
+                  type: string
+                lastSpecHash:
+                  type: string
+                nextRetryTime:
+                  description: NextRetryTime indicates when the next retry will be attempted
+                  format: date-time
+                  type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration records the last processed Generation
+                    Used to determine if status is stale
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                retryCount:
+                  description: RetryCount tracks the number of retry attempts
+                  type: integer
+                syncedClusters:
+                  description: SyncedClusters lists successfully synced clusters (global
+                    cluster only)
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/docs/shared/crds/auth.alauda.io_userbindings.yaml
+++ b/docs/shared/crds/auth.alauda.io_userbindings.yaml
@@ -41,14 +41,16 @@ spec:
           description: UserBinding is the Schema for the userbindings API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object

--- a/docs/shared/crds/auth.alauda.io_users.yaml
+++ b/docs/shared/crds/auth.alauda.io_users.yaml
@@ -31,14 +31,16 @@ spec:
           description: User is the Schema for the users API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -52,8 +54,9 @@ spec:
                 connector_name:
                   type: string
                 connector_type:
-                  description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "make" to regenerate code after modifying this file'
+                  description: |-
+                    INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                    Important: Run "make" to regenerate code after modifying this file
                   type: string
                 continuity_errors:
                   type: integer

--- a/docs/shared/crds/auth.alauda.io_users.yaml
+++ b/docs/shared/crds/auth.alauda.io_users.yaml
@@ -1,0 +1,141 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: users.auth.alauda.io
+spec:
+  group: auth.alauda.io
+  names:
+    kind: User
+    listKind: UserList
+    plural: users
+    singular: user
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+      - jsonPath: .spec.connector_type
+        name: Type
+        type: string
+      - jsonPath: .spec.email
+        name: Username
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: User is the Schema for the users API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: UserSpec defines the desired state of User
+              properties:
+                account:
+                  type: string
+                connector_id:
+                  type: string
+                connector_name:
+                  type: string
+                connector_type:
+                  description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file'
+                  type: string
+                continuity_errors:
+                  type: integer
+                email:
+                  type: string
+                expired:
+                  description: Expired ...
+                  properties:
+                    begin:
+                      format: date-time
+                      type: string
+                    end:
+                      format: date-time
+                      type: string
+                  required:
+                    - begin
+                    - end
+                  type: object
+                groups:
+                  items:
+                    type: string
+                  type: array
+                ids:
+                  items:
+                    properties:
+                      id:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - id
+                      - type
+                    type: object
+                  type: array
+                is_admin:
+                  type: boolean
+                is_disabled:
+                  type: boolean
+                last_login_time:
+                  type: string
+                mail:
+                  type: string
+                mobile:
+                  type: string
+                old_password:
+                  type: string
+                password:
+                  type: string
+                state:
+                  description: State is User's State
+                  type: string
+                username:
+                  type: string
+                valid:
+                  type: boolean
+                webhookType:
+                  type: string
+                webhookUrl:
+                  type: string
+                extra:
+                  description: "Extra contains additional arbitrary metadata for the user from third-party systems"
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - connector_name
+                - connector_type
+                - email
+                - is_admin
+                - username
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: UserStatus defines the observed state of User
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/docs/shared/crds/cluster.alauda.io_clustermodules.yaml
+++ b/docs/shared/crds/cluster.alauda.io_clustermodules.yaml
@@ -1,0 +1,663 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: clustermodules.cluster.alauda.io
+spec:
+  group: cluster.alauda.io
+  names:
+    kind: ClusterModule
+    listKind: ClusterModuleList
+    plural: clustermodules
+    shortNames:
+    - clsm
+    singular: clustermodule
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterModule is the Schema for the clustermodules API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterModuleSpec defines the desired state of ClusterModule
+            properties:
+              logAgent:
+                description: LogAgentConfig ...
+                properties:
+                  dataSource:
+                    description: DataSource ...
+                    properties:
+                      audit:
+                        type: boolean
+                      event:
+                        type: boolean
+                      kubernetes:
+                        type: boolean
+                      platform:
+                        type: boolean
+                      system:
+                        type: boolean
+                      workload:
+                        type: boolean
+                    required:
+                    - audit
+                    - event
+                    - kubernetes
+                    - platform
+                    - system
+                    - workload
+                    type: object
+                  install:
+                    type: boolean
+                required:
+                - install
+                type: object
+              parallelUpgrade:
+                description: ParallelUpgrade stands for if the upgrading could execute
+                  parallelly.
+                type: boolean
+              prometheus:
+                description: PrometheusConfig ...
+                properties:
+                  install:
+                    type: boolean
+                  replicas:
+                    type: integer
+                  storage:
+                    description: StroageConfig ...
+                    properties:
+                      capacity:
+                        type: integer
+                      nodes:
+                        items:
+                          type: string
+                        type: array
+                      path:
+                        type: string
+                      selector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      storageClass:
+                        type: string
+                      type:
+                        description: StorageType ...
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  type:
+                    type: string
+                required:
+                - install
+                type: object
+              securityAgent:
+                description: SecurityAgentConfig ...
+                properties:
+                  install:
+                    type: boolean
+                required:
+                - install
+                type: object
+              upgradeModulesInfos:
+                description: UpgradeModuleInfos stands for the information to upgrade
+                  the modules
+                items:
+                  description: UpgradeModuleInfo ...
+                  properties:
+                    config:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+              valuesOverride:
+                additionalProperties:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                description: ValuesOverride ...
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              version:
+                type: string
+              victoriametrics:
+                description: VictoriaMetricsConfig ...
+                properties:
+                  agent:
+                    description: VictoriaMetricsAgentConfig ...
+                    properties:
+                      install:
+                        type: boolean
+                      replicas:
+                        type: integer
+                      vmcluster:
+                        type: string
+                    required:
+                    - install
+                    type: object
+                  cluster:
+                    description: VictoriaMetricsClusterConfig ...
+                    properties:
+                      install:
+                        type: boolean
+                      replicas:
+                        type: integer
+                      storage:
+                        description: StroageConfig ...
+                        properties:
+                          capacity:
+                            type: integer
+                          nodes:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          selector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          storageClass:
+                            type: string
+                          type:
+                            description: StorageType ...
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - install
+                    type: object
+                type: object
+            type: object
+          status:
+            description: ClusterModuleStatus defines the observed state of ClusterModule
+            properties:
+              appReleases:
+                additionalProperties:
+                  description: AppReleaseStatus ...
+                  properties:
+                    chartVersions:
+                      items:
+                        description: ChartVersion stands for chart version
+                        properties:
+                          name:
+                            description: Name stands for the chart's name
+                            type: string
+                          version:
+                            description: Version stands for the chart's version
+                            type: string
+                        required:
+                        - name
+                        - version
+                        type: object
+                      type: array
+                    failed:
+                      type: boolean
+                    hash:
+                      type: string
+                    lastProbeTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    ready:
+                      type: boolean
+                    reason:
+                      type: string
+                    synced:
+                      type: boolean
+                  required:
+                  - failed
+                  - ready
+                  - synced
+                  type: object
+                type: object
+              base:
+                description: ModuleStatus ...
+                properties:
+                  appReleases:
+                    items:
+                      type: string
+                    type: array
+                  deployStatus:
+                    description: DeployStatus ...
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    format: date-time
+                    type: string
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  logPath:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  runningStatus:
+                    description: RunningStatus ...
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                  version:
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+              editable:
+                type: boolean
+              logAgent:
+                description: ModuleStatus ...
+                properties:
+                  appReleases:
+                    items:
+                      type: string
+                    type: array
+                  deployStatus:
+                    description: DeployStatus ...
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    format: date-time
+                    type: string
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  logPath:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  runningStatus:
+                    description: RunningStatus ...
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                  version:
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+              needUpgrade:
+                type: boolean
+              prometheus:
+                description: ModuleStatus ...
+                properties:
+                  appReleases:
+                    items:
+                      type: string
+                    type: array
+                  deployStatus:
+                    description: DeployStatus ...
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    format: date-time
+                    type: string
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  logPath:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  runningStatus:
+                    description: RunningStatus ...
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                  version:
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+              securityAgent:
+                description: ModuleStatus ...
+                properties:
+                  appReleases:
+                    items:
+                      type: string
+                    type: array
+                  deployStatus:
+                    description: DeployStatus ...
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    format: date-time
+                    type: string
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  logPath:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  runningStatus:
+                    description: RunningStatus ...
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                  version:
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+              sync:
+                description: SyncMethod ...
+                enum:
+                - Upgrade
+                - Resync
+                type: string
+              unableUpgradeReason:
+                type: string
+              upgradable:
+                type: boolean
+              victoriametrics:
+                description: ModuleStatus ...
+                properties:
+                  appReleases:
+                    items:
+                      type: string
+                    type: array
+                  deployStatus:
+                    description: DeployStatus ...
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    format: date-time
+                    type: string
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  logPath:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  runningStatus:
+                    description: RunningStatus ...
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                  version:
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+            required:
+            - editable
+            - upgradable
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterModule is the Schema for the clustermodules API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterModuleSpec defines the desired state of ClusterModule
+            properties:
+              parallelUpgrade:
+                description: ParallelUpgrade stands for if the upgrading could execute
+                  parallelly.
+                type: boolean
+              upgradeModulesInfos:
+                description: UpgradeModuleInfos stands for the information to upgrade
+                  the modules
+                items:
+                  description: UpgradeModuleInfo ...
+                  properties:
+                    config:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+              valuesOverride:
+                additionalProperties:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                description: ValuesOverride ...
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              version:
+                type: string
+            type: object
+          status:
+            description: ClusterModuleStatus defines the observed state of ClusterModule
+            properties:
+              appReleases:
+                additionalProperties:
+                  description: AppReleaseStatus ...
+                  properties:
+                    chartVersions:
+                      items:
+                        description: ChartVersion stands for chart version
+                        properties:
+                          name:
+                            description: Name stands for the chart's name
+                            type: string
+                          version:
+                            description: Version stands for the chart's version
+                            type: string
+                        required:
+                        - name
+                        - version
+                        type: object
+                      type: array
+                    failed:
+                      type: boolean
+                    hash:
+                      type: string
+                    lastProbeTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    ready:
+                      type: boolean
+                    reason:
+                      type: string
+                    synced:
+                      type: boolean
+                  required:
+                  - failed
+                  - ready
+                  - synced
+                  type: object
+                type: object
+              base:
+                description: ModuleStatus ...
+                properties:
+                  appReleases:
+                    items:
+                      type: string
+                    type: array
+                  deployStatus:
+                    description: DeployStatus ...
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    format: date-time
+                    type: string
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  logPath:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  runningStatus:
+                    description: RunningStatus ...
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                  version:
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+              editable:
+                type: boolean
+              needUpgrade:
+                type: boolean
+              sync:
+                description: SyncMethod ...
+                enum:
+                - Upgrade
+                - Resync
+                type: string
+              unableUpgradeReason:
+                type: string
+              upgradable:
+                type: boolean
+            required:
+            - editable
+            - upgradable
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/docs/shared/crds/cluster.alauda.io_clustermodules.yaml
+++ b/docs/shared/crds/cluster.alauda.io_clustermodules.yaml
@@ -16,6 +16,175 @@ spec:
     singular: clustermodule
   scope: Cluster
   versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterModule is the Schema for the clustermodules API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterModuleSpec defines the desired state of ClusterModule
+            properties:
+              parallelUpgrade:
+                description: ParallelUpgrade stands for if the upgrading could execute
+                  parallelly.
+                type: boolean
+              upgradeModulesInfos:
+                description: UpgradeModuleInfos stands for the information to upgrade
+                  the modules
+                items:
+                  description: UpgradeModuleInfo ...
+                  properties:
+                    config:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+              valuesOverride:
+                additionalProperties:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                description: ValuesOverride ...
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              version:
+                type: string
+            type: object
+          status:
+            description: ClusterModuleStatus defines the observed state of ClusterModule
+            properties:
+              appReleases:
+                additionalProperties:
+                  description: AppReleaseStatus ...
+                  properties:
+                    chartVersions:
+                      items:
+                        description: ChartVersion stands for chart version
+                        properties:
+                          name:
+                            description: Name stands for the chart's name
+                            type: string
+                          version:
+                            description: Version stands for the chart's version
+                            type: string
+                        required:
+                        - name
+                        - version
+                        type: object
+                      type: array
+                    failed:
+                      type: boolean
+                    hash:
+                      type: string
+                    lastProbeTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    ready:
+                      type: boolean
+                    reason:
+                      type: string
+                    synced:
+                      type: boolean
+                  required:
+                  - failed
+                  - ready
+                  - synced
+                  type: object
+                type: object
+              base:
+                description: ModuleStatus ...
+                properties:
+                  appReleases:
+                    items:
+                      type: string
+                    type: array
+                  deployStatus:
+                    description: DeployStatus ...
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    format: date-time
+                    type: string
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  logPath:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  runningStatus:
+                    description: RunningStatus ...
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                  version:
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+              editable:
+                type: boolean
+              needUpgrade:
+                type: boolean
+              sync:
+                description: SyncMethod ...
+                enum:
+                - Upgrade
+                - Resync
+                type: string
+              unableUpgradeReason:
+                type: string
+              upgradable:
+                type: boolean
+            required:
+            - editable
+            - upgradable
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
   - name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -490,174 +659,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        description: ClusterModule is the Schema for the clustermodules API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ClusterModuleSpec defines the desired state of ClusterModule
-            properties:
-              parallelUpgrade:
-                description: ParallelUpgrade stands for if the upgrading could execute
-                  parallelly.
-                type: boolean
-              upgradeModulesInfos:
-                description: UpgradeModuleInfos stands for the information to upgrade
-                  the modules
-                items:
-                  description: UpgradeModuleInfo ...
-                  properties:
-                    config:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    name:
-                      type: string
-                    version:
-                      type: string
-                  required:
-                  - name
-                  - version
-                  type: object
-                type: array
-              valuesOverride:
-                additionalProperties:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                description: ValuesOverride ...
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              version:
-                type: string
-            type: object
-          status:
-            description: ClusterModuleStatus defines the observed state of ClusterModule
-            properties:
-              appReleases:
-                additionalProperties:
-                  description: AppReleaseStatus ...
-                  properties:
-                    chartVersions:
-                      items:
-                        description: ChartVersion stands for chart version
-                        properties:
-                          name:
-                            description: Name stands for the chart's name
-                            type: string
-                          version:
-                            description: Version stands for the chart's version
-                            type: string
-                        required:
-                        - name
-                        - version
-                        type: object
-                      type: array
-                    failed:
-                      type: boolean
-                    hash:
-                      type: string
-                    lastProbeTime:
-                      format: date-time
-                      type: string
-                    message:
-                      type: string
-                    ready:
-                      type: boolean
-                    reason:
-                      type: string
-                    synced:
-                      type: boolean
-                  required:
-                  - failed
-                  - ready
-                  - synced
-                  type: object
-                type: object
-              base:
-                description: ModuleStatus ...
-                properties:
-                  appReleases:
-                    items:
-                      type: string
-                    type: array
-                  deployStatus:
-                    description: DeployStatus ...
-                    enum:
-                    - NotDeployed
-                    - Pending
-                    - Deploying
-                    - DeployFailed
-                    - Upgrading
-                    - UpgradeFailed
-                    - Completed
-                    type: string
-                  deployTime:
-                    format: date-time
-                    type: string
-                  lastProbeTime:
-                    format: date-time
-                    type: string
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  logPath:
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  runningStatus:
-                    description: RunningStatus ...
-                    enum:
-                    - NotRunning
-                    - Healthy
-                    - Abnormal
-                    type: string
-                  version:
-                    type: string
-                required:
-                - deployStatus
-                - runningStatus
-                type: object
-              editable:
-                type: boolean
-              needUpgrade:
-                type: boolean
-              sync:
-                description: SyncMethod ...
-                enum:
-                - Upgrade
-                - Resync
-                type: string
-              unableUpgradeReason:
-                type: string
-              upgradable:
-                type: boolean
-            required:
-            - editable
-            - upgradable
-            type: object
-        type: object
-    served: true
-    storage: false
     subresources:
       status: {}

--- a/docs/shared/crds/cluster.alauda.io_etcdencryptionconfigs.yaml
+++ b/docs/shared/crds/cluster.alauda.io_etcdencryptionconfigs.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: etcdencryptionconfigs.cluster.alauda.io
+spec:
+  group: cluster.alauda.io
+  names:
+    kind: EtcdEncryptionConfig
+    listKind: EtcdEncryptionConfigList
+    plural: etcdencryptionconfigs
+    shortNames:
+    - eec
+    singular: etcdencryptionconfig
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: EtcdEncryptionConfig is the Schema for the etcdencryptionconfig
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              resources:
+                items:
+                  type: string
+                type: array
+              rotationInterval:
+                type: string
+              type:
+                enum:
+                - aesgcm
+                type: string
+            required:
+            - resources
+            - rotationInterval
+            - type
+            type: object
+          status:
+            properties:
+              deployStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    revision:
+                      format: int64
+                      type: integer
+                    state:
+                      enum:
+                      - Processing
+                      - Updated
+                      - Success
+                      - UpdateFailed
+                      - RestartFailed
+                      type: string
+                  required:
+                  - message
+                  - revision
+                  - state
+                  type: object
+                type: object
+              migration:
+                properties:
+                  completeTimestamp:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  resources:
+                    items:
+                      type: string
+                    type: array
+                  revision:
+                    format: int64
+                    type: integer
+                  state:
+                    enum:
+                    - Processing
+                    - Success
+                    - Failed
+                    type: string
+                required:
+                - message
+                - resources
+                - revision
+                - state
+                type: object
+              revision:
+                format: int64
+                type: integer
+            required:
+            - revision
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/common-config.yaml
+++ b/docs/shared/crds/common-config.yaml
@@ -1,0 +1,291 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.2
+  name: commonconfigs.operator.alauda.io
+spec:
+  conversion:
+    strategy: None
+  group: operator.alauda.io
+  names:
+    kind: CommonConfig
+    listKind: CommonConfigList
+    plural: commonconfigs
+    singular: commonconfig
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: CommonConfig is the Schema for the commonconfigs API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this
+                            representation of an object. Servers should convert recognized
+                            schemas to the latest internal value, and may reject unrecognized
+                            values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CommonConfigSpec defines the desired state of
+                CommonConfig
+              properties:
+                elasticsearch:
+                  description: Elasticsearch Config
+                  properties:
+                    host:
+                      description: Server address
+                      type: string
+                    nodes:
+                      description: Log nodes
+                      items:
+                        type: string
+                      type: array
+                    password:
+                      description: Password
+                      type: string
+                    username:
+                      description: Uername
+                      type: string
+                  type: object
+                etcd:
+                  description: Etcd Config
+                  properties:
+                    ectdCaSecret:
+                      description: Etcd Ca Secret
+                      properties:
+                        secretSource:
+                          properties:
+                            tls.crt:
+                              format: byte
+                              type: string
+                            tls.key:
+                              format: byte
+                              type: string
+                          required:
+                            - tls.crt
+                            - tls.key
+                          type: object
+                      required:
+                        - secretSource
+                      type: object
+                    ectdPeerSecret:
+                      description: Etcd Peer secret
+                      properties:
+                        secretSource:
+                          properties:
+                            tls.crt:
+                              format: byte
+                              type: string
+                            tls.key:
+                              format: byte
+                              type: string
+                          required:
+                            - tls.crt
+                            - tls.key
+                          type: object
+                      required:
+                        - secretSource
+                      type: object
+                    servers:
+                      description: Etcd servers
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                  required:
+                    - ectdCaSecret
+                    - ectdPeerSecret
+                    - servers
+                  type: object
+                ext:
+                  description: Ext Config
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                global:
+                  description: Global configuration
+                  properties:
+                    apiAddress:
+                      description: Platform api address
+                      minLength: 1
+                      type: string
+                    defaultAdmin:
+                      description: The platform deploys a management
+                        account by default, and the default email
+                        admin@cpaas.io
+                      minLength: 1
+                      type: string
+                    erebusApiAddress:
+                      description: Platform api gateway address
+                      minLength: 1
+                      type: string
+                    host:
+                      description: Platform access host address,
+                        support domain name or IP
+                      minLength: 1
+                      type: string
+                    isOCP:
+                      description: Whether to deploy on openshift
+                        cluster
+                      type: boolean
+                    labelBaseDomain:
+                      description: Platform resource instance label
+                        field, the default is cpaas.io
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: The namespace deployed by the
+                        platform, default cpaas-system
+                      minLength: 1
+                      type: string
+                    replicas:
+                      description: The number of instances of platform
+                        common deployment components, the default
+                        is 2
+                      minimum: 0
+                      type: integer
+                    scheme:
+                      description: Platform access protocol, support
+                        http or https
+                      enum:
+                        - http
+                        - https
+                      type: string
+                    tlsSecret:
+                      description: Tls Secret
+                      properties:
+                        secretSource:
+                          properties:
+                            tls.crt:
+                              format: byte
+                              type: string
+                            tls.key:
+                              format: byte
+                              type: string
+                          required:
+                            - tls.crt
+                            - tls.key
+                          type: object
+                      required:
+                        - secretSource
+                      type: object
+                  required:
+                    - apiAddress
+                    - defaultAdmin
+                    - erebusApiAddress
+                    - host
+                    - labelBaseDomain
+                    - replicas
+                    - tlsSecret
+                  type: object
+                kafka:
+                  description: Kafka Config
+                  properties:
+                    auth:
+                      description: Whether to enable authentication
+                      type: boolean
+                    host:
+                      description: Server address
+                      type: string
+                    kafka_password:
+                      type: string
+                    kafka_user:
+                      type: string
+                    zk_acl_password:
+                      type: string
+                    zk_password:
+                      type: string
+                    zk_user:
+                      type: string
+                  required:
+                    - auth
+                    - host
+                    - kafka_password
+                    - kafka_user
+                    - zk_acl_password
+                    - zk_password
+                    - zk_user
+                  type: object
+                oidc:
+                  description: OIDC Config
+                  properties:
+                    clientID:
+                      description: OIDC Client ID
+                      minLength: 1
+                      type: string
+                    clientSecret:
+                      description: OIDC Client Secret
+                      minLength: 1
+                      type: string
+                    issuer:
+                      description: OIDC server address
+                      minLength: 1
+                      type: string
+                    responseType:
+                      description: OIDC Response Type
+                      enum:
+                        - code
+                        - token
+                        - id_token
+                      type: string
+                    scopes:
+                      description: OIDC Scopes
+                      minLength: 1
+                      type: string
+                  required:
+                    - clientID
+                    - clientSecret
+                    - issuer
+                    - responseType
+                    - scopes
+                  type: object
+                release:
+                  description: Release verison
+                  minLength: 1
+                  type: string
+                repositories:
+                  description: Repositories Config
+                  items:
+                    description: Repository Config
+                    properties:
+                      type:
+                        description: Repository type
+                        enum:
+                          - chart
+                          - image
+                          - yum
+                          - apt
+                        type: string
+                      url:
+                        description: Repository url
+                        minLength: 1
+                        type: string
+                    required:
+                      - type
+                      - url
+                    type: object
+                  minItems: 1
+                  type: array
+              required:
+                - etcd
+                - global
+                - oidc
+                - release
+                - repositories
+              type: object
+            status:
+              description: CommonConfigStatus defines the observed state
+                of CommonConfig
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/docs/shared/crds/featrues-crd.yaml
+++ b/docs/shared/crds/featrues-crd.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: features.infrastructure.alauda.io
+spec:
+  conversion:
+    strategy: None
+  group: infrastructure.alauda.io
+  names:
+    kind: Feature
+    listKind: FeatureList
+    plural: features
+    shortNames:
+      - ft
+    singular: feature
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                accessInfo:
+                  description: accessInfo defines the server info,if
+                    the addon support some interface to access. eg
+                    promtheus, grafana
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                deployInfo:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                instanceType:
+                  description: 'instanceType defines the tool to support
+                                    the type. eg: prometheus, fluentd'
+                  type: string
+                resourceInfo:
+                  description: resourceInfo defines all the resource
+                    the addons contains
+                  items:
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  type: array
+                type:
+                  description: 'type defines the type of the addon.
+                                    eg: metric, log, application etc...'
+                  type: string
+                version:
+                  description: version defines the version of the addon.
+                    it is used to compare with the version of the
+                    instance to descide upgrade or not
+                  type: string
+              required:
+                - version
+                - type
+              type: object
+            status:
+              properties:
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/docs/shared/crds/middleware.alauda.io_imageversions.yaml
+++ b/docs/shared/crds/middleware.alauda.io_imageversions.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: imageversions.middleware.alauda.io
+spec:
+  group: middleware.alauda.io
+  names:
+    kind: ImageVersion
+    listKind: ImageVersionList
+    plural: imageversions
+    singular: imageversion
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ImageVersion is the Schema for the imageversions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImageVersionSpec defines the desired state of ImageVersion
+            properties:
+              components:
+                additionalProperties:
+                  properties:
+                    coreComponent:
+                      type: boolean
+                    versions:
+                      items:
+                        properties:
+                          displayVersion:
+                            type: string
+                          extensions:
+                            additionalProperties:
+                              properties:
+                                version:
+                                  type: string
+                              required:
+                              - version
+                              type: object
+                            type: object
+                          image:
+                            type: string
+                          tag:
+                            type: string
+                          version:
+                            type: string
+                        required:
+                        - image
+                        - tag
+                        type: object
+                      type: array
+                  required:
+                  - versions
+                  type: object
+                type: object
+              crVersion:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file'
+                type: string
+            type: object
+          status:
+            description: ImageVersionStatus defines the observed state of ImageVersion
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/operator.etcd.io_etcdclusters.yaml
+++ b/docs/shared/crds/operator.etcd.io_etcdclusters.yaml
@@ -1,0 +1,229 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: etcdclusters.operator.etcd.io
+spec:
+  group: operator.etcd.io
+  names:
+    kind: EtcdCluster
+    listKind: EtcdClusterList
+    plural: etcdclusters
+    singular: etcdcluster
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: EtcdCluster is the Schema for the etcdclusters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EtcdClusterSpec defines the desired state of EtcdCluster.
+            properties:
+              etcdOptions:
+                description: etcd configuration options are passed as command line
+                  arguments to the etcd container, refer to etcd documentation for
+                  configuration options applicable for the version of etcd being used.
+                items:
+                  type: string
+                type: array
+              imageRegistry:
+                description: |-
+                  ImageRegistry specifies the container registry that hosts the etcd images.
+                  If unset, it defaults to the value provided via the controller's
+                  --image-registry flag, which itself defaults to "gcr.io/etcd-development/etcd".
+                type: string
+              podTemplate:
+                description: PodTemplate is the pod template to use for the etcd cluster.
+                properties:
+                  metadata:
+                    description: Metadata is the metadata to add to the pod.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              size:
+                description: Size is the expected size of the etcd cluster.
+                minimum: 1
+                type: integer
+              storageSpec:
+                description: StorageSpec is the name of the StorageSpec to use for
+                  the etcd cluster. If not provided, then each POD just uses the temporary
+                  storage inside the container.
+                properties:
+                  accessModes:
+                    type: string
+                  pvcName:
+                    type: string
+                  storageClassName:
+                    type: string
+                  volumeSizeLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  volumeSizeRequest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                required:
+                - volumeSizeRequest
+                type: object
+              tls:
+                description: TLS is the TLS certificate configuration to use for the
+                  etcd cluster and etcd operator.
+                properties:
+                  provider:
+                    type: string
+                  providerCfg:
+                    properties:
+                      autoCfg:
+                        properties:
+                          altNames:
+                            description: |-
+                              AltNames contains the domain names and IP addresses that will be added
+                              to the x509 certificate SubAltNames fields. The values will be passed
+                              directly to the x509.Certificate object.
+                            properties:
+                              dnsNames:
+                                description: |-
+                                  DNSNames is the expected array of DNS subject alternative names.
+                                  if empty defaults to $(POD_NAME).$(ETCD_CLUSTER_NAME).$(POD_NAMESPACE).svc.cluster.local
+                                items:
+                                  type: string
+                                type: array
+                              ipAddresses:
+                                description: IPs is the expected array of IP address
+                                  subject alternative names.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          caBundleSecret:
+                            description: |-
+                              CABundleSecret is the expected secret name with CABundle present. It's used
+                              by each etcd POD to verify TLS communications with its peers or clients. If it isn't
+                              provided, the CA included in the secret generated by certificate provider will be
+                              used instead if present; otherwise, there is no way to verify TLS communications.
+                            type: string
+                          commonName:
+                            description: |-
+                              CommonName is the expected common name X509 certificate subject attribute.
+                              Should have a length of 64 characters or fewer to avoid generating invalid CSRs.
+                            type: string
+                          organizations:
+                            description: Organization is the expected array of Organization
+                              names to be used on the Certificate.
+                            items:
+                              type: string
+                            type: array
+                          validityDuration:
+                            description: |-
+                              ValidityDuration is the expected duration until which the certificate will be valid,
+                              expects in human-readable duration: 100d12h, if empty defaults to 90d
+                            type: string
+                        type: object
+                      certManagerCfg:
+                        properties:
+                          altNames:
+                            description: |-
+                              AltNames contains the domain names and IP addresses that will be added
+                              to the x509 certificate SubAltNames fields. The values will be passed
+                              directly to the x509.Certificate object.
+                            properties:
+                              dnsNames:
+                                description: |-
+                                  DNSNames is the expected array of DNS subject alternative names.
+                                  if empty defaults to $(POD_NAME).$(ETCD_CLUSTER_NAME).$(POD_NAMESPACE).svc.cluster.local
+                                items:
+                                  type: string
+                                type: array
+                              ipAddresses:
+                                description: IPs is the expected array of IP address
+                                  subject alternative names.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          caBundleSecret:
+                            description: |-
+                              CABundleSecret is the expected secret name with CABundle present. It's used
+                              by each etcd POD to verify TLS communications with its peers or clients. If it isn't
+                              provided, the CA included in the secret generated by certificate provider will be
+                              used instead if present; otherwise, there is no way to verify TLS communications.
+                            type: string
+                          commonName:
+                            description: |-
+                              CommonName is the expected common name X509 certificate subject attribute.
+                              Should have a length of 64 characters or fewer to avoid generating invalid CSRs.
+                            type: string
+                          issuerKind:
+                            description: IssuerKind is the expected kind of Issuer,
+                              either "ClusterIssuer" or "Issuer"
+                            type: string
+                          issuerName:
+                            description: IssuerName is the expected name of Issuer
+                              required to issue a certificate
+                            type: string
+                          organizations:
+                            description: Organization is the expected array of Organization
+                              names to be used on the Certificate.
+                            items:
+                              type: string
+                            type: array
+                          validityDuration:
+                            description: |-
+                              ValidityDuration is the expected duration until which the certificate will be valid,
+                              expects in human-readable duration: 100d12h, if empty defaults to 90d
+                            type: string
+                        required:
+                        - issuerKind
+                        - issuerName
+                        type: object
+                    type: object
+                type: object
+              version:
+                description: Version is the expected version of the etcd container
+                  image.
+                type: string
+            required:
+            - size
+            - version
+            type: object
+          status:
+            description: EtcdClusterStatus defines the observed state of EtcdCluster.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/operators.coreos.com_catalogsources.yaml
+++ b/docs/shared/crds/operators.coreos.com_catalogsources.yaml
@@ -1,0 +1,248 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: catalogsources.operators.coreos.com
+spec:
+  group: operators.coreos.com
+  names:
+    categories:
+      - olm
+    kind: CatalogSource
+    listKind: CatalogSourceList
+    plural: catalogsources
+    shortNames:
+      - catsrc
+    singular: catalogsource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The pretty name of the catalog
+          jsonPath: .spec.displayName
+          name: Display
+          type: string
+        - description: The type of the catalog
+          jsonPath: .spec.sourceType
+          name: Type
+          type: string
+        - description: The publisher of the catalog
+          jsonPath: .spec.publisher
+          name: Publisher
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: CatalogSource is a repository of CSVs, CRDs, and operator packages.
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - sourceType
+              properties:
+                address:
+                  description: 'Address is a host that OLM can use to connect to a pre-existing registry. Format: <registry-host or ip>:<port> Only used when SourceType = SourceTypeGrpc. Ignored when the Image field is set.'
+                  type: string
+                configMap:
+                  description: ConfigMap is the name of the ConfigMap to be used to back a configmap-server registry. Only used when SourceType = SourceTypeConfigmap or SourceTypeInternal.
+                  type: string
+                description:
+                  type: string
+                displayName:
+                  description: Metadata
+                  type: string
+                grpcPodConfig:
+                  description: GrpcPodConfig exposes different overrides for the pod spec of the CatalogSource Pod. Only used when SourceType = SourceTypeGrpc and Image is set.
+                  type: object
+                  properties:
+                    nodeSelector:
+                      description: NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node.
+                      type: object
+                      additionalProperties:
+                        type: string
+                    priorityClassName:
+                      description: If specified, indicates the pod's priority. If not specified, the pod priority will be default or zero if there is no default.
+                      type: string
+                    tolerations:
+                      description: Tolerations are the catalog source's pod's tolerations.
+                      type: array
+                      items:
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        type: object
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            type: integer
+                            format: int64
+                          value:
+                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                icon:
+                  type: object
+                  required:
+                    - base64data
+                    - mediatype
+                  properties:
+                    base64data:
+                      type: string
+                    mediatype:
+                      type: string
+                image:
+                  description: Image is an operator-registry container image to instantiate a registry-server with. Only used when SourceType = SourceTypeGrpc. If present, the address field is ignored.
+                  type: string
+                priority:
+                  description: 'Priority field assigns a weight to the catalog source to prioritize them so that it can be consumed by the dependency resolver. Usage: Higher weight indicates that this catalog source is preferred over lower weighted catalog sources during dependency resolution. The range of the priority value can go from positive to negative in the range of int32. The default value to a catalog source with unassigned priority would be 0. The catalog source with the same priority values will be ranked lexicographically based on its name.'
+                  type: integer
+                publisher:
+                  type: string
+                secrets:
+                  description: Secrets represent set of secrets that can be used to access the contents of the catalog. It is best to keep this list small, since each will need to be tried for every catalog entry.
+                  type: array
+                  items:
+                    type: string
+                sourceType:
+                  description: SourceType is the type of source
+                  type: string
+                updateStrategy:
+                  description: UpdateStrategy defines how updated catalog source images can be discovered Consists of an interval that defines polling duration and an embedded strategy type
+                  type: object
+                  properties:
+                    registryPoll:
+                      type: object
+                      properties:
+                        interval:
+                          description: Interval is used to determine the time interval between checks of the latest catalog source version. The catalog operator polls to see if a new version of the catalog source is available. If available, the latest image is pulled and gRPC traffic is directed to the latest catalog source.
+                          type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: Represents the state of a CatalogSource. Note that Message and Reason represent the original status information, which may be migrated to be conditions based in the future. Any new features introduced will use conditions.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                configMapReference:
+                  type: object
+                  required:
+                    - name
+                    - namespace
+                  properties:
+                    lastUpdateTime:
+                      type: string
+                      format: date-time
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    resourceVersion:
+                      type: string
+                    uid:
+                      description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                      type: string
+                connectionState:
+                  type: object
+                  required:
+                    - lastObservedState
+                  properties:
+                    address:
+                      type: string
+                    lastConnect:
+                      type: string
+                      format: date-time
+                    lastObservedState:
+                      type: string
+                latestImageRegistryPoll:
+                  description: The last time the CatalogSource image registry has been polled to ensure the image is up-to-date
+                  type: string
+                  format: date-time
+                message:
+                  description: A human readable message indicating details about why the CatalogSource is in this condition.
+                  type: string
+                reason:
+                  description: Reason is the reason the CatalogSource was transitioned to its current state.
+                  type: string
+                registryService:
+                  type: object
+                  properties:
+                    createdAt:
+                      type: string
+                      format: date-time
+                    port:
+                      type: string
+                    protocol:
+                      type: string
+                    serviceName:
+                      type: string
+                    serviceNamespace:
+                      type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/docs/shared/crds/operators.coreos.com_clusterserviceversions.yaml
+++ b/docs/shared/crds/operators.coreos.com_clusterserviceversions.yaml
@@ -1,0 +1,5023 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: clusterserviceversions.operators.coreos.com
+spec:
+  group: operators.coreos.com
+  names:
+    categories:
+      - olm
+    kind: ClusterServiceVersion
+    listKind: ClusterServiceVersionList
+    plural: clusterserviceversions
+    shortNames:
+      - csv
+      - csvs
+    singular: clusterserviceversion
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The name of the CSV
+          jsonPath: .spec.displayName
+          name: Display
+          type: string
+        - description: The version of the CSV
+          jsonPath: .spec.version
+          name: Version
+          type: string
+        - description: The name of a CSV that this one replaces
+          jsonPath: .spec.replaces
+          name: Replaces
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ClusterServiceVersion is a Custom Resource of type `ClusterServiceVersionSpec`.
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterServiceVersionSpec declarations tell OLM how to install an operator that can manage apps for a given version.
+              type: object
+              required:
+                - displayName
+                - install
+              properties:
+                annotations:
+                  description: Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata.
+                  type: object
+                  additionalProperties:
+                    type: string
+                apiservicedefinitions:
+                  description: APIServiceDefinitions declares all of the extension apis managed or required by an operator being ran by ClusterServiceVersion.
+                  type: object
+                  properties:
+                    owned:
+                      type: array
+                      items:
+                        description: APIServiceDescription provides details to OLM about apis provided via aggregation
+                        type: object
+                        required:
+                          - group
+                          - kind
+                          - name
+                          - version
+                        properties:
+                          actionDescriptors:
+                            type: array
+                            items:
+                              description: ActionDescriptor describes a declarative action that can be performed on a custom resource instance
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          containerPort:
+                            type: integer
+                            format: int32
+                          deploymentName:
+                            type: string
+                          description:
+                            type: string
+                          displayName:
+                            type: string
+                          group:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          resources:
+                            type: array
+                            items:
+                              description: APIResourceReference is a Kubernetes resource type used by a custom resource
+                              type: object
+                              required:
+                                - kind
+                                - name
+                                - version
+                              properties:
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                version:
+                                  type: string
+                          specDescriptors:
+                            type: array
+                            items:
+                              description: SpecDescriptor describes a field in a spec block of a CRD so that OLM can consume it
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          statusDescriptors:
+                            type: array
+                            items:
+                              description: StatusDescriptor describes a field in a status block of a CRD so that OLM can consume it
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          version:
+                            type: string
+                    required:
+                      type: array
+                      items:
+                        description: APIServiceDescription provides details to OLM about apis provided via aggregation
+                        type: object
+                        required:
+                          - group
+                          - kind
+                          - name
+                          - version
+                        properties:
+                          actionDescriptors:
+                            type: array
+                            items:
+                              description: ActionDescriptor describes a declarative action that can be performed on a custom resource instance
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          containerPort:
+                            type: integer
+                            format: int32
+                          deploymentName:
+                            type: string
+                          description:
+                            type: string
+                          displayName:
+                            type: string
+                          group:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          resources:
+                            type: array
+                            items:
+                              description: APIResourceReference is a Kubernetes resource type used by a custom resource
+                              type: object
+                              required:
+                                - kind
+                                - name
+                                - version
+                              properties:
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                version:
+                                  type: string
+                          specDescriptors:
+                            type: array
+                            items:
+                              description: SpecDescriptor describes a field in a spec block of a CRD so that OLM can consume it
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          statusDescriptors:
+                            type: array
+                            items:
+                              description: StatusDescriptor describes a field in a status block of a CRD so that OLM can consume it
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          version:
+                            type: string
+                cleanup:
+                  description: Cleanup specifies the cleanup behaviour when the CSV gets deleted
+                  type: object
+                  required:
+                    - enabled
+                  properties:
+                    enabled:
+                      type: boolean
+                customresourcedefinitions:
+                  description: "CustomResourceDefinitions declares all of the CRDs managed or required by an operator being ran by ClusterServiceVersion. \n If the CRD is present in the Owned list, it is implicitly required."
+                  type: object
+                  properties:
+                    owned:
+                      type: array
+                      items:
+                        description: CRDDescription provides details to OLM about the CRDs
+                        type: object
+                        required:
+                          - kind
+                          - name
+                          - version
+                        properties:
+                          actionDescriptors:
+                            type: array
+                            items:
+                              description: ActionDescriptor describes a declarative action that can be performed on a custom resource instance
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          description:
+                            type: string
+                          displayName:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          resources:
+                            type: array
+                            items:
+                              description: APIResourceReference is a Kubernetes resource type used by a custom resource
+                              type: object
+                              required:
+                                - kind
+                                - name
+                                - version
+                              properties:
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                version:
+                                  type: string
+                          specDescriptors:
+                            type: array
+                            items:
+                              description: SpecDescriptor describes a field in a spec block of a CRD so that OLM can consume it
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          statusDescriptors:
+                            type: array
+                            items:
+                              description: StatusDescriptor describes a field in a status block of a CRD so that OLM can consume it
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          version:
+                            type: string
+                    required:
+                      type: array
+                      items:
+                        description: CRDDescription provides details to OLM about the CRDs
+                        type: object
+                        required:
+                          - kind
+                          - name
+                          - version
+                        properties:
+                          actionDescriptors:
+                            type: array
+                            items:
+                              description: ActionDescriptor describes a declarative action that can be performed on a custom resource instance
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          description:
+                            type: string
+                          displayName:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          resources:
+                            type: array
+                            items:
+                              description: APIResourceReference is a Kubernetes resource type used by a custom resource
+                              type: object
+                              required:
+                                - kind
+                                - name
+                                - version
+                              properties:
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                version:
+                                  type: string
+                          specDescriptors:
+                            type: array
+                            items:
+                              description: SpecDescriptor describes a field in a spec block of a CRD so that OLM can consume it
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          statusDescriptors:
+                            type: array
+                            items:
+                              description: StatusDescriptor describes a field in a status block of a CRD so that OLM can consume it
+                              type: object
+                              required:
+                                - path
+                              properties:
+                                description:
+                                  type: string
+                                displayName:
+                                  type: string
+                                path:
+                                  type: string
+                                value:
+                                  description: RawMessage is a raw encoded JSON value. It implements Marshaler and Unmarshaler and can be used to delay JSON decoding or precompute a JSON encoding.
+                                  type: string
+                                  format: byte
+                                x-descriptors:
+                                  type: array
+                                  items:
+                                    type: string
+                          version:
+                            type: string
+                description:
+                  type: string
+                displayName:
+                  type: string
+                icon:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - base64data
+                      - mediatype
+                    properties:
+                      base64data:
+                        type: string
+                      mediatype:
+                        type: string
+                install:
+                  description: NamedInstallStrategy represents the block of an ClusterServiceVersion resource where the install strategy is specified.
+                  type: object
+                  required:
+                    - strategy
+                  properties:
+                    spec:
+                      description: StrategyDetailsDeployment represents the parsed details of a Deployment InstallStrategy.
+                      type: object
+                      required:
+                        - deployments
+                      properties:
+                        clusterPermissions:
+                          type: array
+                          items:
+                            description: StrategyDeploymentPermissions describe the rbac rules and service account needed by the install strategy
+                            type: object
+                            required:
+                              - rules
+                              - serviceAccountName
+                            properties:
+                              rules:
+                                type: array
+                                items:
+                                  description: PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+                                  type: object
+                                  required:
+                                    - verbs
+                                  properties:
+                                    apiGroups:
+                                      description: APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+                                      type: array
+                                      items:
+                                        type: string
+                                    nonResourceURLs:
+                                      description: NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                                      type: array
+                                      items:
+                                        type: string
+                                    resourceNames:
+                                      description: ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+                                      type: array
+                                      items:
+                                        type: string
+                                    resources:
+                                      description: Resources is a list of resources this rule applies to. '*' represents all resources.
+                                      type: array
+                                      items:
+                                        type: string
+                                    verbs:
+                                      description: Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
+                                      type: array
+                                      items:
+                                        type: string
+                              serviceAccountName:
+                                type: string
+                        deployments:
+                          type: array
+                          items:
+                            description: StrategyDeploymentSpec contains the name, spec and labels for the deployment ALM should create
+                            type: object
+                            required:
+                              - name
+                              - spec
+                            properties:
+                              label:
+                                description: Set is a map of label:value. It implements Labels.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              name:
+                                type: string
+                              spec:
+                                description: DeploymentSpec is the specification of the desired behavior of the Deployment.
+                                type: object
+                                required:
+                                  - selector
+                                  - template
+                                properties:
+                                  minReadySeconds:
+                                    description: Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+                                    type: integer
+                                    format: int32
+                                  paused:
+                                    description: Indicates that the deployment is paused.
+                                    type: boolean
+                                  progressDeadlineSeconds:
+                                    description: The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+                                    type: integer
+                                    format: int32
+                                  replicas:
+                                    description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+                                    type: integer
+                                    format: int32
+                                  revisionHistoryLimit:
+                                    description: The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+                                    type: integer
+                                    format: int32
+                                  selector:
+                                    description: Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        type: array
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          type: object
+                                          required:
+                                            - key
+                                            - operator
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                  strategy:
+                                    description: The deployment strategy to use to replace existing pods with new ones.
+                                    type: object
+                                    properties:
+                                      rollingUpdate:
+                                        description: 'Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate. --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be.'
+                                        type: object
+                                        properties:
+                                          maxSurge:
+                                            description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          maxUnavailable:
+                                            description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                      type:
+                                        description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                        type: string
+                                  template:
+                                    description: Template describes the pods that will be created.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      spec:
+                                        description: 'Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                                        type: object
+                                        required:
+                                          - containers
+                                        properties:
+                                          activeDeadlineSeconds:
+                                            description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
+                                            type: integer
+                                            format: int64
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                          automountServiceAccountToken:
+                                            description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                                            type: boolean
+                                          containers:
+                                            description: List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
+                                            type: array
+                                            items:
+                                              description: A single application container that you want to run within a pod.
+                                              type: object
+                                              required:
+                                                - name
+                                              properties:
+                                                args:
+                                                  description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                command:
+                                                  description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                env:
+                                                  description: List of environment variables to set in the container. Cannot be updated.
+                                                  type: array
+                                                  items:
+                                                    description: EnvVar represents an environment variable present in a Container.
+                                                    type: object
+                                                    required:
+                                                      - name
+                                                    properties:
+                                                      name:
+                                                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                                        type: string
+                                                      value:
+                                                        description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                                        type: string
+                                                      valueFrom:
+                                                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                                        type: object
+                                                        properties:
+                                                          configMapKeyRef:
+                                                            description: Selects a key of a ConfigMap.
+                                                            type: object
+                                                            required:
+                                                              - key
+                                                            properties:
+                                                              key:
+                                                                description: The key to select.
+                                                                type: string
+                                                              name:
+                                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                type: string
+                                                              optional:
+                                                                description: Specify whether the ConfigMap or its key must be defined
+                                                                type: boolean
+                                                          fieldRef:
+                                                            description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                                            type: object
+                                                            required:
+                                                              - fieldPath
+                                                            properties:
+                                                              apiVersion:
+                                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                                type: string
+                                                              fieldPath:
+                                                                description: Path of the field to select in the specified API version.
+                                                                type: string
+                                                          resourceFieldRef:
+                                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                                            type: object
+                                                            required:
+                                                              - resource
+                                                            properties:
+                                                              containerName:
+                                                                description: 'Container name: required for volumes, optional for env vars'
+                                                                type: string
+                                                              divisor:
+                                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                x-kubernetes-int-or-string: true
+                                                              resource:
+                                                                description: 'Required: resource to select'
+                                                                type: string
+                                                          secretKeyRef:
+                                                            description: Selects a key of a secret in the pod's namespace
+                                                            type: object
+                                                            required:
+                                                              - key
+                                                            properties:
+                                                              key:
+                                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                                type: string
+                                                              name:
+                                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                type: string
+                                                              optional:
+                                                                description: Specify whether the Secret or its key must be defined
+                                                                type: boolean
+                                                envFrom:
+                                                  description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                                                  type: array
+                                                  items:
+                                                    description: EnvFromSource represents the source of a set of ConfigMaps
+                                                    type: object
+                                                    properties:
+                                                      configMapRef:
+                                                        description: The ConfigMap to select from
+                                                        type: object
+                                                        properties:
+                                                          name:
+                                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                            type: string
+                                                          optional:
+                                                            description: Specify whether the ConfigMap must be defined
+                                                            type: boolean
+                                                      prefix:
+                                                        description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                                        type: string
+                                                      secretRef:
+                                                        description: The Secret to select from
+                                                        type: object
+                                                        properties:
+                                                          name:
+                                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                            type: string
+                                                          optional:
+                                                            description: Specify whether the Secret must be defined
+                                                            type: boolean
+                                                image:
+                                                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                                                  type: string
+                                                imagePullPolicy:
+                                                  description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                                  type: string
+                                                lifecycle:
+                                                  description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+                                                  type: object
+                                                  properties:
+                                                    postStart:
+                                                      description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                                      type: object
+                                                      properties:
+                                                        exec:
+                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          type: object
+                                                          properties:
+                                                            command:
+                                                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                        httpGet:
+                                                          description: HTTPGet specifies the http request to perform.
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                              type: string
+                                                            httpHeaders:
+                                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                              type: array
+                                                              items:
+                                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                                type: object
+                                                                required:
+                                                                  - name
+                                                                  - value
+                                                                properties:
+                                                                  name:
+                                                                    description: The header field name
+                                                                    type: string
+                                                                  value:
+                                                                    description: The header field value
+                                                                    type: string
+                                                            path:
+                                                              description: Path to access on the HTTP server.
+                                                              type: string
+                                                            port:
+                                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                              type: string
+                                                        tcpSocket:
+                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                              type: string
+                                                            port:
+                                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                    preStop:
+                                                      description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                                      type: object
+                                                      properties:
+                                                        exec:
+                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          type: object
+                                                          properties:
+                                                            command:
+                                                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                        httpGet:
+                                                          description: HTTPGet specifies the http request to perform.
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                              type: string
+                                                            httpHeaders:
+                                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                              type: array
+                                                              items:
+                                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                                type: object
+                                                                required:
+                                                                  - name
+                                                                  - value
+                                                                properties:
+                                                                  name:
+                                                                    description: The header field name
+                                                                    type: string
+                                                                  value:
+                                                                    description: The header field value
+                                                                    type: string
+                                                            path:
+                                                              description: Path to access on the HTTP server.
+                                                              type: string
+                                                            port:
+                                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                              type: string
+                                                        tcpSocket:
+                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                              type: string
+                                                            port:
+                                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                livenessProbe:
+                                                  description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    failureThreshold:
+                                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    httpGet:
+                                                      description: HTTPGet specifies the http request to perform.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                          type: string
+                                                        httpHeaders:
+                                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                          type: array
+                                                          items:
+                                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                            type: object
+                                                            required:
+                                                              - name
+                                                              - value
+                                                            properties:
+                                                              name:
+                                                                description: The header field name
+                                                                type: string
+                                                              value:
+                                                                description: The header field value
+                                                                type: string
+                                                        path:
+                                                          description: Path to access on the HTTP server.
+                                                          type: string
+                                                        port:
+                                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                          type: string
+                                                    initialDelaySeconds:
+                                                      description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                    periodSeconds:
+                                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    successThreshold:
+                                                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    tcpSocket:
+                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                          type: string
+                                                        port:
+                                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                    terminationGracePeriodSeconds:
+                                                      description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                      type: integer
+                                                      format: int64
+                                                    timeoutSeconds:
+                                                      description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                name:
+                                                  description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                                                  type: string
+                                                ports:
+                                                  description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                                                  type: array
+                                                  items:
+                                                    description: ContainerPort represents a network port in a single container.
+                                                    type: object
+                                                    required:
+                                                      - containerPort
+                                                    properties:
+                                                      containerPort:
+                                                        description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                                        type: integer
+                                                        format: int32
+                                                      hostIP:
+                                                        description: What host IP to bind the external port to.
+                                                        type: string
+                                                      hostPort:
+                                                        description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                                                        type: integer
+                                                        format: int32
+                                                      name:
+                                                        description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                                                        type: string
+                                                      protocol:
+                                                        description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                                        type: string
+                                                        default: TCP
+                                                  x-kubernetes-list-map-keys:
+                                                    - containerPort
+                                                    - protocol
+                                                  x-kubernetes-list-type: map
+                                                readinessProbe:
+                                                  description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    failureThreshold:
+                                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    httpGet:
+                                                      description: HTTPGet specifies the http request to perform.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                          type: string
+                                                        httpHeaders:
+                                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                          type: array
+                                                          items:
+                                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                            type: object
+                                                            required:
+                                                              - name
+                                                              - value
+                                                            properties:
+                                                              name:
+                                                                description: The header field name
+                                                                type: string
+                                                              value:
+                                                                description: The header field value
+                                                                type: string
+                                                        path:
+                                                          description: Path to access on the HTTP server.
+                                                          type: string
+                                                        port:
+                                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                          type: string
+                                                    initialDelaySeconds:
+                                                      description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                    periodSeconds:
+                                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    successThreshold:
+                                                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    tcpSocket:
+                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                          type: string
+                                                        port:
+                                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                    terminationGracePeriodSeconds:
+                                                      description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                      type: integer
+                                                      format: int64
+                                                    timeoutSeconds:
+                                                      description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                resources:
+                                                  description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  type: object
+                                                  properties:
+                                                    limits:
+                                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                      additionalProperties:
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    requests:
+                                                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                      additionalProperties:
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                securityContext:
+                                                  description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                                  type: object
+                                                  properties:
+                                                    allowPrivilegeEscalation:
+                                                      description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                                      type: boolean
+                                                    capabilities:
+                                                      description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                                      type: object
+                                                      properties:
+                                                        add:
+                                                          description: Added capabilities
+                                                          type: array
+                                                          items:
+                                                            description: Capability represent POSIX capabilities type
+                                                            type: string
+                                                        drop:
+                                                          description: Removed capabilities
+                                                          type: array
+                                                          items:
+                                                            description: Capability represent POSIX capabilities type
+                                                            type: string
+                                                    privileged:
+                                                      description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                                      type: boolean
+                                                    procMount:
+                                                      description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                                      type: string
+                                                    readOnlyRootFilesystem:
+                                                      description: Whether this container has a read-only root filesystem. Default is false.
+                                                      type: boolean
+                                                    runAsGroup:
+                                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: integer
+                                                      format: int64
+                                                    runAsNonRoot:
+                                                      description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: boolean
+                                                    runAsUser:
+                                                      description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: integer
+                                                      format: int64
+                                                    seLinuxOptions:
+                                                      description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: object
+                                                      properties:
+                                                        level:
+                                                          description: Level is SELinux level label that applies to the container.
+                                                          type: string
+                                                        role:
+                                                          description: Role is a SELinux role label that applies to the container.
+                                                          type: string
+                                                        type:
+                                                          description: Type is a SELinux type label that applies to the container.
+                                                          type: string
+                                                        user:
+                                                          description: User is a SELinux user label that applies to the container.
+                                                          type: string
+                                                    seccompProfile:
+                                                      description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                                      type: object
+                                                      required:
+                                                        - type
+                                                      properties:
+                                                        localhostProfile:
+                                                          description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                                          type: string
+                                                        type:
+                                                          description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                                          type: string
+                                                    windowsOptions:
+                                                      description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: object
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                          type: string
+                                                        hostProcess:
+                                                          description: HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                          type: boolean
+                                                        runAsUserName:
+                                                          description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                          type: string
+                                                startupProbe:
+                                                  description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    failureThreshold:
+                                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    httpGet:
+                                                      description: HTTPGet specifies the http request to perform.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                          type: string
+                                                        httpHeaders:
+                                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                          type: array
+                                                          items:
+                                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                            type: object
+                                                            required:
+                                                              - name
+                                                              - value
+                                                            properties:
+                                                              name:
+                                                                description: The header field name
+                                                                type: string
+                                                              value:
+                                                                description: The header field value
+                                                                type: string
+                                                        path:
+                                                          description: Path to access on the HTTP server.
+                                                          type: string
+                                                        port:
+                                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                          type: string
+                                                    initialDelaySeconds:
+                                                      description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                    periodSeconds:
+                                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    successThreshold:
+                                                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    tcpSocket:
+                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                          type: string
+                                                        port:
+                                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                    terminationGracePeriodSeconds:
+                                                      description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                      type: integer
+                                                      format: int64
+                                                    timeoutSeconds:
+                                                      description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                stdin:
+                                                  description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                                                  type: boolean
+                                                stdinOnce:
+                                                  description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                                                  type: boolean
+                                                terminationMessagePath:
+                                                  description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                                                  type: string
+                                                terminationMessagePolicy:
+                                                  description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                                                  type: string
+                                                tty:
+                                                  description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                                                  type: boolean
+                                                volumeDevices:
+                                                  description: volumeDevices is the list of block devices to be used by the container.
+                                                  type: array
+                                                  items:
+                                                    description: volumeDevice describes a mapping of a raw block device within a container.
+                                                    type: object
+                                                    required:
+                                                      - devicePath
+                                                      - name
+                                                    properties:
+                                                      devicePath:
+                                                        description: devicePath is the path inside of the container that the device will be mapped to.
+                                                        type: string
+                                                      name:
+                                                        description: name must match the name of a persistentVolumeClaim in the pod
+                                                        type: string
+                                                volumeMounts:
+                                                  description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                                  type: array
+                                                  items:
+                                                    description: VolumeMount describes a mounting of a Volume within a container.
+                                                    type: object
+                                                    required:
+                                                      - mountPath
+                                                      - name
+                                                    properties:
+                                                      mountPath:
+                                                        description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                                        type: string
+                                                      mountPropagation:
+                                                        description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                                        type: string
+                                                      name:
+                                                        description: This must match the Name of a Volume.
+                                                        type: string
+                                                      readOnly:
+                                                        description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                                        type: boolean
+                                                      subPath:
+                                                        description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                                        type: string
+                                                      subPathExpr:
+                                                        description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                                        type: string
+                                                workingDir:
+                                                  description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                                                  type: string
+                                          dnsConfig:
+                                            description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
+                                            type: object
+                                            properties:
+                                              nameservers:
+                                                description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
+                                                type: array
+                                                items:
+                                                  type: string
+                                              options:
+                                                description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
+                                                type: array
+                                                items:
+                                                  description: PodDNSConfigOption defines DNS resolver options of a pod.
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      description: Required.
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                              searches:
+                                                description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
+                                                type: array
+                                                items:
+                                                  type: string
+                                          dnsPolicy:
+                                            description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+                                            type: string
+                                          enableServiceLinks:
+                                            description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                                            type: boolean
+                                          ephemeralContainers:
+                                            description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
+                                            type: array
+                                            items:
+                                              description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
+                                              type: object
+                                              required:
+                                                - name
+                                              properties:
+                                                args:
+                                                  description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                command:
+                                                  description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                env:
+                                                  description: List of environment variables to set in the container. Cannot be updated.
+                                                  type: array
+                                                  items:
+                                                    description: EnvVar represents an environment variable present in a Container.
+                                                    type: object
+                                                    required:
+                                                      - name
+                                                    properties:
+                                                      name:
+                                                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                                        type: string
+                                                      value:
+                                                        description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                                        type: string
+                                                      valueFrom:
+                                                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                                        type: object
+                                                        properties:
+                                                          configMapKeyRef:
+                                                            description: Selects a key of a ConfigMap.
+                                                            type: object
+                                                            required:
+                                                              - key
+                                                            properties:
+                                                              key:
+                                                                description: The key to select.
+                                                                type: string
+                                                              name:
+                                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                type: string
+                                                              optional:
+                                                                description: Specify whether the ConfigMap or its key must be defined
+                                                                type: boolean
+                                                          fieldRef:
+                                                            description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                                            type: object
+                                                            required:
+                                                              - fieldPath
+                                                            properties:
+                                                              apiVersion:
+                                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                                type: string
+                                                              fieldPath:
+                                                                description: Path of the field to select in the specified API version.
+                                                                type: string
+                                                          resourceFieldRef:
+                                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                                            type: object
+                                                            required:
+                                                              - resource
+                                                            properties:
+                                                              containerName:
+                                                                description: 'Container name: required for volumes, optional for env vars'
+                                                                type: string
+                                                              divisor:
+                                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                x-kubernetes-int-or-string: true
+                                                              resource:
+                                                                description: 'Required: resource to select'
+                                                                type: string
+                                                          secretKeyRef:
+                                                            description: Selects a key of a secret in the pod's namespace
+                                                            type: object
+                                                            required:
+                                                              - key
+                                                            properties:
+                                                              key:
+                                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                                type: string
+                                                              name:
+                                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                type: string
+                                                              optional:
+                                                                description: Specify whether the Secret or its key must be defined
+                                                                type: boolean
+                                                envFrom:
+                                                  description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                                                  type: array
+                                                  items:
+                                                    description: EnvFromSource represents the source of a set of ConfigMaps
+                                                    type: object
+                                                    properties:
+                                                      configMapRef:
+                                                        description: The ConfigMap to select from
+                                                        type: object
+                                                        properties:
+                                                          name:
+                                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                            type: string
+                                                          optional:
+                                                            description: Specify whether the ConfigMap must be defined
+                                                            type: boolean
+                                                      prefix:
+                                                        description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                                        type: string
+                                                      secretRef:
+                                                        description: The Secret to select from
+                                                        type: object
+                                                        properties:
+                                                          name:
+                                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                            type: string
+                                                          optional:
+                                                            description: Specify whether the Secret must be defined
+                                                            type: boolean
+                                                image:
+                                                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                                  type: string
+                                                imagePullPolicy:
+                                                  description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                                  type: string
+                                                lifecycle:
+                                                  description: Lifecycle is not allowed for ephemeral containers.
+                                                  type: object
+                                                  properties:
+                                                    postStart:
+                                                      description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                                      type: object
+                                                      properties:
+                                                        exec:
+                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          type: object
+                                                          properties:
+                                                            command:
+                                                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                        httpGet:
+                                                          description: HTTPGet specifies the http request to perform.
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                              type: string
+                                                            httpHeaders:
+                                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                              type: array
+                                                              items:
+                                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                                type: object
+                                                                required:
+                                                                  - name
+                                                                  - value
+                                                                properties:
+                                                                  name:
+                                                                    description: The header field name
+                                                                    type: string
+                                                                  value:
+                                                                    description: The header field value
+                                                                    type: string
+                                                            path:
+                                                              description: Path to access on the HTTP server.
+                                                              type: string
+                                                            port:
+                                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                              type: string
+                                                        tcpSocket:
+                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                              type: string
+                                                            port:
+                                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                    preStop:
+                                                      description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                                      type: object
+                                                      properties:
+                                                        exec:
+                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          type: object
+                                                          properties:
+                                                            command:
+                                                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                        httpGet:
+                                                          description: HTTPGet specifies the http request to perform.
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                              type: string
+                                                            httpHeaders:
+                                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                              type: array
+                                                              items:
+                                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                                type: object
+                                                                required:
+                                                                  - name
+                                                                  - value
+                                                                properties:
+                                                                  name:
+                                                                    description: The header field name
+                                                                    type: string
+                                                                  value:
+                                                                    description: The header field value
+                                                                    type: string
+                                                            path:
+                                                              description: Path to access on the HTTP server.
+                                                              type: string
+                                                            port:
+                                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                              type: string
+                                                        tcpSocket:
+                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                              type: string
+                                                            port:
+                                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                livenessProbe:
+                                                  description: Probes are not allowed for ephemeral containers.
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    failureThreshold:
+                                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    httpGet:
+                                                      description: HTTPGet specifies the http request to perform.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                          type: string
+                                                        httpHeaders:
+                                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                          type: array
+                                                          items:
+                                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                            type: object
+                                                            required:
+                                                              - name
+                                                              - value
+                                                            properties:
+                                                              name:
+                                                                description: The header field name
+                                                                type: string
+                                                              value:
+                                                                description: The header field value
+                                                                type: string
+                                                        path:
+                                                          description: Path to access on the HTTP server.
+                                                          type: string
+                                                        port:
+                                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                          type: string
+                                                    initialDelaySeconds:
+                                                      description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                    periodSeconds:
+                                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    successThreshold:
+                                                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    tcpSocket:
+                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                          type: string
+                                                        port:
+                                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                    terminationGracePeriodSeconds:
+                                                      description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                      type: integer
+                                                      format: int64
+                                                    timeoutSeconds:
+                                                      description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                name:
+                                                  description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
+                                                  type: string
+                                                ports:
+                                                  description: Ports are not allowed for ephemeral containers.
+                                                  type: array
+                                                  items:
+                                                    description: ContainerPort represents a network port in a single container.
+                                                    type: object
+                                                    required:
+                                                      - containerPort
+                                                    properties:
+                                                      containerPort:
+                                                        description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                                        type: integer
+                                                        format: int32
+                                                      hostIP:
+                                                        description: What host IP to bind the external port to.
+                                                        type: string
+                                                      hostPort:
+                                                        description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                                                        type: integer
+                                                        format: int32
+                                                      name:
+                                                        description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                                                        type: string
+                                                      protocol:
+                                                        description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                                        type: string
+                                                        default: TCP
+                                                readinessProbe:
+                                                  description: Probes are not allowed for ephemeral containers.
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    failureThreshold:
+                                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    httpGet:
+                                                      description: HTTPGet specifies the http request to perform.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                          type: string
+                                                        httpHeaders:
+                                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                          type: array
+                                                          items:
+                                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                            type: object
+                                                            required:
+                                                              - name
+                                                              - value
+                                                            properties:
+                                                              name:
+                                                                description: The header field name
+                                                                type: string
+                                                              value:
+                                                                description: The header field value
+                                                                type: string
+                                                        path:
+                                                          description: Path to access on the HTTP server.
+                                                          type: string
+                                                        port:
+                                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                          type: string
+                                                    initialDelaySeconds:
+                                                      description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                    periodSeconds:
+                                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    successThreshold:
+                                                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    tcpSocket:
+                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                          type: string
+                                                        port:
+                                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                    terminationGracePeriodSeconds:
+                                                      description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                      type: integer
+                                                      format: int64
+                                                    timeoutSeconds:
+                                                      description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                resources:
+                                                  description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
+                                                  type: object
+                                                  properties:
+                                                    limits:
+                                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                      additionalProperties:
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    requests:
+                                                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                      additionalProperties:
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                securityContext:
+                                                  description: 'Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.'
+                                                  type: object
+                                                  properties:
+                                                    allowPrivilegeEscalation:
+                                                      description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                                      type: boolean
+                                                    capabilities:
+                                                      description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                                      type: object
+                                                      properties:
+                                                        add:
+                                                          description: Added capabilities
+                                                          type: array
+                                                          items:
+                                                            description: Capability represent POSIX capabilities type
+                                                            type: string
+                                                        drop:
+                                                          description: Removed capabilities
+                                                          type: array
+                                                          items:
+                                                            description: Capability represent POSIX capabilities type
+                                                            type: string
+                                                    privileged:
+                                                      description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                                      type: boolean
+                                                    procMount:
+                                                      description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                                      type: string
+                                                    readOnlyRootFilesystem:
+                                                      description: Whether this container has a read-only root filesystem. Default is false.
+                                                      type: boolean
+                                                    runAsGroup:
+                                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: integer
+                                                      format: int64
+                                                    runAsNonRoot:
+                                                      description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: boolean
+                                                    runAsUser:
+                                                      description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: integer
+                                                      format: int64
+                                                    seLinuxOptions:
+                                                      description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: object
+                                                      properties:
+                                                        level:
+                                                          description: Level is SELinux level label that applies to the container.
+                                                          type: string
+                                                        role:
+                                                          description: Role is a SELinux role label that applies to the container.
+                                                          type: string
+                                                        type:
+                                                          description: Type is a SELinux type label that applies to the container.
+                                                          type: string
+                                                        user:
+                                                          description: User is a SELinux user label that applies to the container.
+                                                          type: string
+                                                    seccompProfile:
+                                                      description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                                      type: object
+                                                      required:
+                                                        - type
+                                                      properties:
+                                                        localhostProfile:
+                                                          description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                                          type: string
+                                                        type:
+                                                          description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                                          type: string
+                                                    windowsOptions:
+                                                      description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: object
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                          type: string
+                                                        hostProcess:
+                                                          description: HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                          type: boolean
+                                                        runAsUserName:
+                                                          description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                          type: string
+                                                startupProbe:
+                                                  description: Probes are not allowed for ephemeral containers.
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    failureThreshold:
+                                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    httpGet:
+                                                      description: HTTPGet specifies the http request to perform.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                          type: string
+                                                        httpHeaders:
+                                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                          type: array
+                                                          items:
+                                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                            type: object
+                                                            required:
+                                                              - name
+                                                              - value
+                                                            properties:
+                                                              name:
+                                                                description: The header field name
+                                                                type: string
+                                                              value:
+                                                                description: The header field value
+                                                                type: string
+                                                        path:
+                                                          description: Path to access on the HTTP server.
+                                                          type: string
+                                                        port:
+                                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                          type: string
+                                                    initialDelaySeconds:
+                                                      description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                    periodSeconds:
+                                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    successThreshold:
+                                                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    tcpSocket:
+                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                          type: string
+                                                        port:
+                                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                    terminationGracePeriodSeconds:
+                                                      description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                      type: integer
+                                                      format: int64
+                                                    timeoutSeconds:
+                                                      description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                stdin:
+                                                  description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                                                  type: boolean
+                                                stdinOnce:
+                                                  description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                                                  type: boolean
+                                                targetContainerName:
+                                                  description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
+                                                  type: string
+                                                terminationMessagePath:
+                                                  description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                                                  type: string
+                                                terminationMessagePolicy:
+                                                  description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                                                  type: string
+                                                tty:
+                                                  description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                                                  type: boolean
+                                                volumeDevices:
+                                                  description: volumeDevices is the list of block devices to be used by the container.
+                                                  type: array
+                                                  items:
+                                                    description: volumeDevice describes a mapping of a raw block device within a container.
+                                                    type: object
+                                                    required:
+                                                      - devicePath
+                                                      - name
+                                                    properties:
+                                                      devicePath:
+                                                        description: devicePath is the path inside of the container that the device will be mapped to.
+                                                        type: string
+                                                      name:
+                                                        description: name must match the name of a persistentVolumeClaim in the pod
+                                                        type: string
+                                                volumeMounts:
+                                                  description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                                  type: array
+                                                  items:
+                                                    description: VolumeMount describes a mounting of a Volume within a container.
+                                                    type: object
+                                                    required:
+                                                      - mountPath
+                                                      - name
+                                                    properties:
+                                                      mountPath:
+                                                        description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                                        type: string
+                                                      mountPropagation:
+                                                        description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                                        type: string
+                                                      name:
+                                                        description: This must match the Name of a Volume.
+                                                        type: string
+                                                      readOnly:
+                                                        description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                                        type: boolean
+                                                      subPath:
+                                                        description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                                        type: string
+                                                      subPathExpr:
+                                                        description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                                        type: string
+                                                workingDir:
+                                                  description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                                                  type: string
+                                          hostAliases:
+                                            description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
+                                            type: array
+                                            items:
+                                              description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+                                              type: object
+                                              properties:
+                                                hostnames:
+                                                  description: Hostnames for the above IP address.
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                ip:
+                                                  description: IP address of the host file entry.
+                                                  type: string
+                                          hostIPC:
+                                            description: 'Use the host''s ipc namespace. Optional: Default to false.'
+                                            type: boolean
+                                          hostNetwork:
+                                            description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
+                                            type: boolean
+                                          hostPID:
+                                            description: 'Use the host''s pid namespace. Optional: Default to false.'
+                                            type: boolean
+                                          hostname:
+                                            description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
+                                            type: string
+                                          imagePullSecrets:
+                                            description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                            type: array
+                                            items:
+                                              description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                          initContainers:
+                                            description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                                            type: array
+                                            items:
+                                              description: A single application container that you want to run within a pod.
+                                              type: object
+                                              required:
+                                                - name
+                                              properties:
+                                                args:
+                                                  description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                command:
+                                                  description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                env:
+                                                  description: List of environment variables to set in the container. Cannot be updated.
+                                                  type: array
+                                                  items:
+                                                    description: EnvVar represents an environment variable present in a Container.
+                                                    type: object
+                                                    required:
+                                                      - name
+                                                    properties:
+                                                      name:
+                                                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                                        type: string
+                                                      value:
+                                                        description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                                        type: string
+                                                      valueFrom:
+                                                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                                        type: object
+                                                        properties:
+                                                          configMapKeyRef:
+                                                            description: Selects a key of a ConfigMap.
+                                                            type: object
+                                                            required:
+                                                              - key
+                                                            properties:
+                                                              key:
+                                                                description: The key to select.
+                                                                type: string
+                                                              name:
+                                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                type: string
+                                                              optional:
+                                                                description: Specify whether the ConfigMap or its key must be defined
+                                                                type: boolean
+                                                          fieldRef:
+                                                            description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                                            type: object
+                                                            required:
+                                                              - fieldPath
+                                                            properties:
+                                                              apiVersion:
+                                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                                type: string
+                                                              fieldPath:
+                                                                description: Path of the field to select in the specified API version.
+                                                                type: string
+                                                          resourceFieldRef:
+                                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                                            type: object
+                                                            required:
+                                                              - resource
+                                                            properties:
+                                                              containerName:
+                                                                description: 'Container name: required for volumes, optional for env vars'
+                                                                type: string
+                                                              divisor:
+                                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                x-kubernetes-int-or-string: true
+                                                              resource:
+                                                                description: 'Required: resource to select'
+                                                                type: string
+                                                          secretKeyRef:
+                                                            description: Selects a key of a secret in the pod's namespace
+                                                            type: object
+                                                            required:
+                                                              - key
+                                                            properties:
+                                                              key:
+                                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                                type: string
+                                                              name:
+                                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                type: string
+                                                              optional:
+                                                                description: Specify whether the Secret or its key must be defined
+                                                                type: boolean
+                                                envFrom:
+                                                  description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                                                  type: array
+                                                  items:
+                                                    description: EnvFromSource represents the source of a set of ConfigMaps
+                                                    type: object
+                                                    properties:
+                                                      configMapRef:
+                                                        description: The ConfigMap to select from
+                                                        type: object
+                                                        properties:
+                                                          name:
+                                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                            type: string
+                                                          optional:
+                                                            description: Specify whether the ConfigMap must be defined
+                                                            type: boolean
+                                                      prefix:
+                                                        description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                                        type: string
+                                                      secretRef:
+                                                        description: The Secret to select from
+                                                        type: object
+                                                        properties:
+                                                          name:
+                                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                            type: string
+                                                          optional:
+                                                            description: Specify whether the Secret must be defined
+                                                            type: boolean
+                                                image:
+                                                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                                                  type: string
+                                                imagePullPolicy:
+                                                  description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                                  type: string
+                                                lifecycle:
+                                                  description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+                                                  type: object
+                                                  properties:
+                                                    postStart:
+                                                      description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                                      type: object
+                                                      properties:
+                                                        exec:
+                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          type: object
+                                                          properties:
+                                                            command:
+                                                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                        httpGet:
+                                                          description: HTTPGet specifies the http request to perform.
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                              type: string
+                                                            httpHeaders:
+                                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                              type: array
+                                                              items:
+                                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                                type: object
+                                                                required:
+                                                                  - name
+                                                                  - value
+                                                                properties:
+                                                                  name:
+                                                                    description: The header field name
+                                                                    type: string
+                                                                  value:
+                                                                    description: The header field value
+                                                                    type: string
+                                                            path:
+                                                              description: Path to access on the HTTP server.
+                                                              type: string
+                                                            port:
+                                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                              type: string
+                                                        tcpSocket:
+                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                              type: string
+                                                            port:
+                                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                    preStop:
+                                                      description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                                      type: object
+                                                      properties:
+                                                        exec:
+                                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                          type: object
+                                                          properties:
+                                                            command:
+                                                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                        httpGet:
+                                                          description: HTTPGet specifies the http request to perform.
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                              type: string
+                                                            httpHeaders:
+                                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                              type: array
+                                                              items:
+                                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                                type: object
+                                                                required:
+                                                                  - name
+                                                                  - value
+                                                                properties:
+                                                                  name:
+                                                                    description: The header field name
+                                                                    type: string
+                                                                  value:
+                                                                    description: The header field value
+                                                                    type: string
+                                                            path:
+                                                              description: Path to access on the HTTP server.
+                                                              type: string
+                                                            port:
+                                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                              type: string
+                                                        tcpSocket:
+                                                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                          type: object
+                                                          required:
+                                                            - port
+                                                          properties:
+                                                            host:
+                                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                              type: string
+                                                            port:
+                                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                              anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                livenessProbe:
+                                                  description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    failureThreshold:
+                                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    httpGet:
+                                                      description: HTTPGet specifies the http request to perform.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                          type: string
+                                                        httpHeaders:
+                                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                          type: array
+                                                          items:
+                                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                            type: object
+                                                            required:
+                                                              - name
+                                                              - value
+                                                            properties:
+                                                              name:
+                                                                description: The header field name
+                                                                type: string
+                                                              value:
+                                                                description: The header field value
+                                                                type: string
+                                                        path:
+                                                          description: Path to access on the HTTP server.
+                                                          type: string
+                                                        port:
+                                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                          type: string
+                                                    initialDelaySeconds:
+                                                      description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                    periodSeconds:
+                                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    successThreshold:
+                                                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    tcpSocket:
+                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                          type: string
+                                                        port:
+                                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                    terminationGracePeriodSeconds:
+                                                      description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                      type: integer
+                                                      format: int64
+                                                    timeoutSeconds:
+                                                      description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                name:
+                                                  description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                                                  type: string
+                                                ports:
+                                                  description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                                                  type: array
+                                                  items:
+                                                    description: ContainerPort represents a network port in a single container.
+                                                    type: object
+                                                    required:
+                                                      - containerPort
+                                                    properties:
+                                                      containerPort:
+                                                        description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                                        type: integer
+                                                        format: int32
+                                                      hostIP:
+                                                        description: What host IP to bind the external port to.
+                                                        type: string
+                                                      hostPort:
+                                                        description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                                                        type: integer
+                                                        format: int32
+                                                      name:
+                                                        description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                                                        type: string
+                                                      protocol:
+                                                        description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                                        type: string
+                                                        default: TCP
+                                                  x-kubernetes-list-map-keys:
+                                                    - containerPort
+                                                    - protocol
+                                                  x-kubernetes-list-type: map
+                                                readinessProbe:
+                                                  description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    failureThreshold:
+                                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    httpGet:
+                                                      description: HTTPGet specifies the http request to perform.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                          type: string
+                                                        httpHeaders:
+                                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                          type: array
+                                                          items:
+                                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                            type: object
+                                                            required:
+                                                              - name
+                                                              - value
+                                                            properties:
+                                                              name:
+                                                                description: The header field name
+                                                                type: string
+                                                              value:
+                                                                description: The header field value
+                                                                type: string
+                                                        path:
+                                                          description: Path to access on the HTTP server.
+                                                          type: string
+                                                        port:
+                                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                          type: string
+                                                    initialDelaySeconds:
+                                                      description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                    periodSeconds:
+                                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    successThreshold:
+                                                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    tcpSocket:
+                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                          type: string
+                                                        port:
+                                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                    terminationGracePeriodSeconds:
+                                                      description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                      type: integer
+                                                      format: int64
+                                                    timeoutSeconds:
+                                                      description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                resources:
+                                                  description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  type: object
+                                                  properties:
+                                                    limits:
+                                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                      additionalProperties:
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    requests:
+                                                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                      additionalProperties:
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                securityContext:
+                                                  description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                                  type: object
+                                                  properties:
+                                                    allowPrivilegeEscalation:
+                                                      description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                                      type: boolean
+                                                    capabilities:
+                                                      description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                                      type: object
+                                                      properties:
+                                                        add:
+                                                          description: Added capabilities
+                                                          type: array
+                                                          items:
+                                                            description: Capability represent POSIX capabilities type
+                                                            type: string
+                                                        drop:
+                                                          description: Removed capabilities
+                                                          type: array
+                                                          items:
+                                                            description: Capability represent POSIX capabilities type
+                                                            type: string
+                                                    privileged:
+                                                      description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                                      type: boolean
+                                                    procMount:
+                                                      description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                                      type: string
+                                                    readOnlyRootFilesystem:
+                                                      description: Whether this container has a read-only root filesystem. Default is false.
+                                                      type: boolean
+                                                    runAsGroup:
+                                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: integer
+                                                      format: int64
+                                                    runAsNonRoot:
+                                                      description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: boolean
+                                                    runAsUser:
+                                                      description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: integer
+                                                      format: int64
+                                                    seLinuxOptions:
+                                                      description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: object
+                                                      properties:
+                                                        level:
+                                                          description: Level is SELinux level label that applies to the container.
+                                                          type: string
+                                                        role:
+                                                          description: Role is a SELinux role label that applies to the container.
+                                                          type: string
+                                                        type:
+                                                          description: Type is a SELinux type label that applies to the container.
+                                                          type: string
+                                                        user:
+                                                          description: User is a SELinux user label that applies to the container.
+                                                          type: string
+                                                    seccompProfile:
+                                                      description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                                      type: object
+                                                      required:
+                                                        - type
+                                                      properties:
+                                                        localhostProfile:
+                                                          description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                                          type: string
+                                                        type:
+                                                          description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                                          type: string
+                                                    windowsOptions:
+                                                      description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                      type: object
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                          type: string
+                                                        hostProcess:
+                                                          description: HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                          type: boolean
+                                                        runAsUserName:
+                                                          description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                          type: string
+                                                startupProbe:
+                                                  description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    failureThreshold:
+                                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    httpGet:
+                                                      description: HTTPGet specifies the http request to perform.
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                          type: string
+                                                        httpHeaders:
+                                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                          type: array
+                                                          items:
+                                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                            type: object
+                                                            required:
+                                                              - name
+                                                              - value
+                                                            properties:
+                                                              name:
+                                                                description: The header field name
+                                                                type: string
+                                                              value:
+                                                                description: The header field value
+                                                                type: string
+                                                        path:
+                                                          description: Path to access on the HTTP server.
+                                                          type: string
+                                                        port:
+                                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                          type: string
+                                                    initialDelaySeconds:
+                                                      description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                    periodSeconds:
+                                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    successThreshold:
+                                                      description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                      type: integer
+                                                      format: int32
+                                                    tcpSocket:
+                                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                                      type: object
+                                                      required:
+                                                        - port
+                                                      properties:
+                                                        host:
+                                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                          type: string
+                                                        port:
+                                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                    terminationGracePeriodSeconds:
+                                                      description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                      type: integer
+                                                      format: int64
+                                                    timeoutSeconds:
+                                                      description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                                      type: integer
+                                                      format: int32
+                                                stdin:
+                                                  description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                                                  type: boolean
+                                                stdinOnce:
+                                                  description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                                                  type: boolean
+                                                terminationMessagePath:
+                                                  description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                                                  type: string
+                                                terminationMessagePolicy:
+                                                  description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                                                  type: string
+                                                tty:
+                                                  description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                                                  type: boolean
+                                                volumeDevices:
+                                                  description: volumeDevices is the list of block devices to be used by the container.
+                                                  type: array
+                                                  items:
+                                                    description: volumeDevice describes a mapping of a raw block device within a container.
+                                                    type: object
+                                                    required:
+                                                      - devicePath
+                                                      - name
+                                                    properties:
+                                                      devicePath:
+                                                        description: devicePath is the path inside of the container that the device will be mapped to.
+                                                        type: string
+                                                      name:
+                                                        description: name must match the name of a persistentVolumeClaim in the pod
+                                                        type: string
+                                                volumeMounts:
+                                                  description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                                  type: array
+                                                  items:
+                                                    description: VolumeMount describes a mounting of a Volume within a container.
+                                                    type: object
+                                                    required:
+                                                      - mountPath
+                                                      - name
+                                                    properties:
+                                                      mountPath:
+                                                        description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                                        type: string
+                                                      mountPropagation:
+                                                        description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                                        type: string
+                                                      name:
+                                                        description: This must match the Name of a Volume.
+                                                        type: string
+                                                      readOnly:
+                                                        description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                                        type: boolean
+                                                      subPath:
+                                                        description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                                        type: string
+                                                      subPathExpr:
+                                                        description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                                        type: string
+                                                workingDir:
+                                                  description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                                                  type: string
+                                          nodeName:
+                                            description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
+                                            type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                            x-kubernetes-map-type: atomic
+                                          overhead:
+                                            description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.'
+                                            type: object
+                                            additionalProperties:
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                          preemptionPolicy:
+                                            description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+                                            type: string
+                                          priority:
+                                            description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
+                                            type: integer
+                                            format: int32
+                                          priorityClassName:
+                                            description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+                                            type: string
+                                          readinessGates:
+                                            description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                                            type: array
+                                            items:
+                                              description: PodReadinessGate contains the reference to a pod condition
+                                              type: object
+                                              required:
+                                                - conditionType
+                                              properties:
+                                                conditionType:
+                                                  description: ConditionType refers to a condition in the pod's condition list with matching type.
+                                                  type: string
+                                          restartPolicy:
+                                            description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                                            type: string
+                                          runtimeClassName:
+                                            description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class This is a beta feature as of Kubernetes v1.14.'
+                                            type: string
+                                          schedulerName:
+                                            description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
+                                            type: string
+                                          securityContext:
+                                            description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
+                                            type: object
+                                            properties:
+                                              fsGroup:
+                                                description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
+                                                type: integer
+                                                format: int64
+                                              fsGroupChangePolicy:
+                                                description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.'
+                                                type: string
+                                              runAsGroup:
+                                                description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                                type: integer
+                                                format: int64
+                                              runAsNonRoot:
+                                                description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                                type: integer
+                                                format: int64
+                                              seLinuxOptions:
+                                                description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                                type: object
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                              seccompProfile:
+                                                description: The seccomp options to use by the containers in this pod.
+                                                type: object
+                                                required:
+                                                  - type
+                                                properties:
+                                                  localhostProfile:
+                                                    description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                                    type: string
+                                                  type:
+                                                    description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                                    type: string
+                                              supplementalGroups:
+                                                description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
+                                                type: array
+                                                items:
+                                                  type: integer
+                                                  format: int64
+                                              sysctls:
+                                                description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
+                                                type: array
+                                                items:
+                                                  description: Sysctl defines a kernel parameter to be set
+                                                  type: object
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  properties:
+                                                    name:
+                                                      description: Name of a property to set
+                                                      type: string
+                                                    value:
+                                                      description: Value of a property to set
+                                                      type: string
+                                              windowsOptions:
+                                                description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: object
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                    type: string
+                                                  hostProcess:
+                                                    description: HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                    type: boolean
+                                                  runAsUserName:
+                                                    description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                    type: string
+                                          serviceAccount:
+                                            description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
+                                            type: string
+                                          serviceAccountName:
+                                            description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                                            type: string
+                                          setHostnameAsFQDN:
+                                            description: If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.
+                                            type: boolean
+                                          shareProcessNamespace:
+                                            description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
+                                            type: boolean
+                                          subdomain:
+                                            description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
+                                            type: string
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
+                                            type: integer
+                                            format: int64
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                          topologySpreadConstraints:
+                                            description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
+                                            type: array
+                                            items:
+                                              description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                                              type: object
+                                              required:
+                                                - maxSkew
+                                                - topologyKey
+                                                - whenUnsatisfiable
+                                              properties:
+                                                labelSelector:
+                                                  description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                      type: array
+                                                      items:
+                                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                        type: object
+                                                        required:
+                                                          - key
+                                                          - operator
+                                                        properties:
+                                                          key:
+                                                            description: key is the label key that the selector applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchLabels:
+                                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                maxSkew:
+                                                  description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                                  type: integer
+                                                  format: int32
+                                                topologyKey:
+                                                  description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                                                  type: string
+                                                whenUnsatisfiable:
+                                                  description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                                  type: string
+                                            x-kubernetes-list-map-keys:
+                                              - topologyKey
+                                              - whenUnsatisfiable
+                                            x-kubernetes-list-type: map
+                                          volumes:
+                                            description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                                            type: array
+                                            items:
+                                              description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                                              type: object
+                                              required:
+                                                - name
+                                              properties:
+                                                awsElasticBlockStore:
+                                                  description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                                  type: object
+                                                  required:
+                                                    - volumeID
+                                                  properties:
+                                                    fsType:
+                                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                                      type: string
+                                                    partition:
+                                                      description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                                      type: integer
+                                                      format: int32
+                                                    readOnly:
+                                                      description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                                      type: boolean
+                                                    volumeID:
+                                                      description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                                      type: string
+                                                azureDisk:
+                                                  description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                                  type: object
+                                                  required:
+                                                    - diskName
+                                                    - diskURI
+                                                  properties:
+                                                    cachingMode:
+                                                      description: 'Host Caching mode: None, Read Only, Read Write.'
+                                                      type: string
+                                                    diskName:
+                                                      description: The Name of the data disk in the blob storage
+                                                      type: string
+                                                    diskURI:
+                                                      description: The URI the data disk in the blob storage
+                                                      type: string
+                                                    fsType:
+                                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                      type: string
+                                                    kind:
+                                                      description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                                      type: string
+                                                    readOnly:
+                                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                                      type: boolean
+                                                azureFile:
+                                                  description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                                  type: object
+                                                  required:
+                                                    - secretName
+                                                    - shareName
+                                                  properties:
+                                                    readOnly:
+                                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                                      type: boolean
+                                                    secretName:
+                                                      description: the name of secret that contains Azure Storage Account Name and Key
+                                                      type: string
+                                                    shareName:
+                                                      description: Share Name
+                                                      type: string
+                                                cephfs:
+                                                  description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                                                  type: object
+                                                  required:
+                                                    - monitors
+                                                  properties:
+                                                    monitors:
+                                                      description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    path:
+                                                      description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                                      type: string
+                                                    readOnly:
+                                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                                      type: boolean
+                                                    secretFile:
+                                                      description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                                      type: string
+                                                    secretRef:
+                                                      description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                                      type: object
+                                                      properties:
+                                                        name:
+                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          type: string
+                                                    user:
+                                                      description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                                      type: string
+                                                cinder:
+                                                  description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                                  type: object
+                                                  required:
+                                                    - volumeID
+                                                  properties:
+                                                    fsType:
+                                                      description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                                      type: string
+                                                    readOnly:
+                                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                                      type: boolean
+                                                    secretRef:
+                                                      description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                                      type: object
+                                                      properties:
+                                                        name:
+                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          type: string
+                                                    volumeID:
+                                                      description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                                      type: string
+                                                configMap:
+                                                  description: ConfigMap represents a configMap that should populate this volume
+                                                  type: object
+                                                  properties:
+                                                    defaultMode:
+                                                      description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      type: integer
+                                                      format: int32
+                                                    items:
+                                                      description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                      type: array
+                                                      items:
+                                                        description: Maps a string key to a path within a volume.
+                                                        type: object
+                                                        required:
+                                                          - key
+                                                          - path
+                                                        properties:
+                                                          key:
+                                                            description: The key to project.
+                                                            type: string
+                                                          mode:
+                                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            type: integer
+                                                            format: int32
+                                                          path:
+                                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                            type: string
+                                                    name:
+                                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the ConfigMap or its keys must be defined
+                                                      type: boolean
+                                                csi:
+                                                  description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                                                  type: object
+                                                  required:
+                                                    - driver
+                                                  properties:
+                                                    driver:
+                                                      description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                                      type: string
+                                                    fsType:
+                                                      description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                                      type: string
+                                                    nodePublishSecretRef:
+                                                      description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                                      type: object
+                                                      properties:
+                                                        name:
+                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          type: string
+                                                    readOnly:
+                                                      description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                                      type: boolean
+                                                    volumeAttributes:
+                                                      description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                downwardAPI:
+                                                  description: DownwardAPI represents downward API about the pod that should populate this volume
+                                                  type: object
+                                                  properties:
+                                                    defaultMode:
+                                                      description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      type: integer
+                                                      format: int32
+                                                    items:
+                                                      description: Items is a list of downward API volume file
+                                                      type: array
+                                                      items:
+                                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                        type: object
+                                                        required:
+                                                          - path
+                                                        properties:
+                                                          fieldRef:
+                                                            description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                            type: object
+                                                            required:
+                                                              - fieldPath
+                                                            properties:
+                                                              apiVersion:
+                                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                                type: string
+                                                              fieldPath:
+                                                                description: Path of the field to select in the specified API version.
+                                                                type: string
+                                                          mode:
+                                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            type: integer
+                                                            format: int32
+                                                          path:
+                                                            description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                            type: string
+                                                          resourceFieldRef:
+                                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                            type: object
+                                                            required:
+                                                              - resource
+                                                            properties:
+                                                              containerName:
+                                                                description: 'Container name: required for volumes, optional for env vars'
+                                                                type: string
+                                                              divisor:
+                                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                x-kubernetes-int-or-string: true
+                                                              resource:
+                                                                description: 'Required: resource to select'
+                                                                type: string
+                                                emptyDir:
+                                                  description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                                  type: object
+                                                  properties:
+                                                    medium:
+                                                      description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                                      type: string
+                                                    sizeLimit:
+                                                      description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                ephemeral:
+                                                  description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time. \n This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled."
+                                                  type: object
+                                                  properties:
+                                                    volumeClaimTemplate:
+                                                      description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
+                                                      type: object
+                                                      required:
+                                                        - spec
+                                                      properties:
+                                                        metadata:
+                                                          description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                                          type: object
+                                                        spec:
+                                                          description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                                          type: object
+                                                          properties:
+                                                            accessModes:
+                                                              description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            dataSource:
+                                                              description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                                              type: object
+                                                              required:
+                                                                - kind
+                                                                - name
+                                                              properties:
+                                                                apiGroup:
+                                                                  description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                                  type: string
+                                                                kind:
+                                                                  description: Kind is the type of resource being referenced
+                                                                  type: string
+                                                                name:
+                                                                  description: Name is the name of resource being referenced
+                                                                  type: string
+                                                            dataSourceRef:
+                                                              description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                                              type: object
+                                                              required:
+                                                                - kind
+                                                                - name
+                                                              properties:
+                                                                apiGroup:
+                                                                  description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                                  type: string
+                                                                kind:
+                                                                  description: Kind is the type of resource being referenced
+                                                                  type: string
+                                                                name:
+                                                                  description: Name is the name of resource being referenced
+                                                                  type: string
+                                                            resources:
+                                                              description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                              type: object
+                                                              properties:
+                                                                limits:
+                                                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                    anyOf:
+                                                                      - type: integer
+                                                                      - type: string
+                                                                    x-kubernetes-int-or-string: true
+                                                                requests:
+                                                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                    anyOf:
+                                                                      - type: integer
+                                                                      - type: string
+                                                                    x-kubernetes-int-or-string: true
+                                                            selector:
+                                                              description: A label query over volumes to consider for binding.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            storageClassName:
+                                                              description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                              type: string
+                                                            volumeMode:
+                                                              description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                                              type: string
+                                                            volumeName:
+                                                              description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                                              type: string
+                                                fc:
+                                                  description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                                                  type: object
+                                                  properties:
+                                                    fsType:
+                                                      description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                                      type: string
+                                                    lun:
+                                                      description: 'Optional: FC target lun number'
+                                                      type: integer
+                                                      format: int32
+                                                    readOnly:
+                                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                                      type: boolean
+                                                    targetWWNs:
+                                                      description: 'Optional: FC target worldwide names (WWNs)'
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    wwids:
+                                                      description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                flexVolume:
+                                                  description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                                                  type: object
+                                                  required:
+                                                    - driver
+                                                  properties:
+                                                    driver:
+                                                      description: Driver is the name of the driver to use for this volume.
+                                                      type: string
+                                                    fsType:
+                                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                                      type: string
+                                                    options:
+                                                      description: 'Optional: Extra command options if any.'
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                    readOnly:
+                                                      description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                                      type: boolean
+                                                    secretRef:
+                                                      description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                                      type: object
+                                                      properties:
+                                                        name:
+                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          type: string
+                                                flocker:
+                                                  description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                                                  type: object
+                                                  properties:
+                                                    datasetName:
+                                                      description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                                      type: string
+                                                    datasetUUID:
+                                                      description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                                      type: string
+                                                gcePersistentDisk:
+                                                  description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                                  type: object
+                                                  required:
+                                                    - pdName
+                                                  properties:
+                                                    fsType:
+                                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                                      type: string
+                                                    partition:
+                                                      description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                                      type: integer
+                                                      format: int32
+                                                    pdName:
+                                                      description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                                      type: string
+                                                    readOnly:
+                                                      description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                                      type: boolean
+                                                gitRepo:
+                                                  description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                                                  type: object
+                                                  required:
+                                                    - repository
+                                                  properties:
+                                                    directory:
+                                                      description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                                      type: string
+                                                    repository:
+                                                      description: Repository URL
+                                                      type: string
+                                                    revision:
+                                                      description: Commit hash for the specified revision.
+                                                      type: string
+                                                glusterfs:
+                                                  description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                                  type: object
+                                                  required:
+                                                    - endpoints
+                                                    - path
+                                                  properties:
+                                                    endpoints:
+                                                      description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                                      type: string
+                                                    path:
+                                                      description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                                      type: string
+                                                    readOnly:
+                                                      description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                                      type: boolean
+                                                hostPath:
+                                                  description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                                                  type: object
+                                                  required:
+                                                    - path
+                                                  properties:
+                                                    path:
+                                                      description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                                      type: string
+                                                    type:
+                                                      description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                                      type: string
+                                                iscsi:
+                                                  description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                                  type: object
+                                                  required:
+                                                    - iqn
+                                                    - lun
+                                                    - targetPortal
+                                                  properties:
+                                                    chapAuthDiscovery:
+                                                      description: whether support iSCSI Discovery CHAP authentication
+                                                      type: boolean
+                                                    chapAuthSession:
+                                                      description: whether support iSCSI Session CHAP authentication
+                                                      type: boolean
+                                                    fsType:
+                                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                                      type: string
+                                                    initiatorName:
+                                                      description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                                      type: string
+                                                    iqn:
+                                                      description: Target iSCSI Qualified Name.
+                                                      type: string
+                                                    iscsiInterface:
+                                                      description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                                      type: string
+                                                    lun:
+                                                      description: iSCSI Target Lun number.
+                                                      type: integer
+                                                      format: int32
+                                                    portals:
+                                                      description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    readOnly:
+                                                      description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                                      type: boolean
+                                                    secretRef:
+                                                      description: CHAP Secret for iSCSI target and initiator authentication
+                                                      type: object
+                                                      properties:
+                                                        name:
+                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          type: string
+                                                    targetPortal:
+                                                      description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                                      type: string
+                                                name:
+                                                  description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                  type: string
+                                                nfs:
+                                                  description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                                  type: object
+                                                  required:
+                                                    - path
+                                                    - server
+                                                  properties:
+                                                    path:
+                                                      description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                                      type: string
+                                                    readOnly:
+                                                      description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                                      type: boolean
+                                                    server:
+                                                      description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                                      type: string
+                                                persistentVolumeClaim:
+                                                  description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                                  type: object
+                                                  required:
+                                                    - claimName
+                                                  properties:
+                                                    claimName:
+                                                      description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                                      type: string
+                                                    readOnly:
+                                                      description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                                      type: boolean
+                                                photonPersistentDisk:
+                                                  description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                                                  type: object
+                                                  required:
+                                                    - pdID
+                                                  properties:
+                                                    fsType:
+                                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                      type: string
+                                                    pdID:
+                                                      description: ID that identifies Photon Controller persistent disk
+                                                      type: string
+                                                portworxVolume:
+                                                  description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                                                  type: object
+                                                  required:
+                                                    - volumeID
+                                                  properties:
+                                                    fsType:
+                                                      description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                                      type: string
+                                                    readOnly:
+                                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                                      type: boolean
+                                                    volumeID:
+                                                      description: VolumeID uniquely identifies a Portworx volume
+                                                      type: string
+                                                projected:
+                                                  description: Items for all in one resources secrets, configmaps, and downward API
+                                                  type: object
+                                                  properties:
+                                                    defaultMode:
+                                                      description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                                      type: integer
+                                                      format: int32
+                                                    sources:
+                                                      description: list of volume projections
+                                                      type: array
+                                                      items:
+                                                        description: Projection that may be projected along with other supported volume types
+                                                        type: object
+                                                        properties:
+                                                          configMap:
+                                                            description: information about the configMap data to project
+                                                            type: object
+                                                            properties:
+                                                              items:
+                                                                description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                                type: array
+                                                                items:
+                                                                  description: Maps a string key to a path within a volume.
+                                                                  type: object
+                                                                  required:
+                                                                    - key
+                                                                    - path
+                                                                  properties:
+                                                                    key:
+                                                                      description: The key to project.
+                                                                      type: string
+                                                                    mode:
+                                                                      description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                                      type: integer
+                                                                      format: int32
+                                                                    path:
+                                                                      description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                                      type: string
+                                                              name:
+                                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                type: string
+                                                              optional:
+                                                                description: Specify whether the ConfigMap or its keys must be defined
+                                                                type: boolean
+                                                          downwardAPI:
+                                                            description: information about the downwardAPI data to project
+                                                            type: object
+                                                            properties:
+                                                              items:
+                                                                description: Items is a list of DownwardAPIVolume file
+                                                                type: array
+                                                                items:
+                                                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                                  type: object
+                                                                  required:
+                                                                    - path
+                                                                  properties:
+                                                                    fieldRef:
+                                                                      description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                                      type: object
+                                                                      required:
+                                                                        - fieldPath
+                                                                      properties:
+                                                                        apiVersion:
+                                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                                          type: string
+                                                                        fieldPath:
+                                                                          description: Path of the field to select in the specified API version.
+                                                                          type: string
+                                                                    mode:
+                                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                                      type: integer
+                                                                      format: int32
+                                                                    path:
+                                                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                                      type: string
+                                                                    resourceFieldRef:
+                                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                                      type: object
+                                                                      required:
+                                                                        - resource
+                                                                      properties:
+                                                                        containerName:
+                                                                          description: 'Container name: required for volumes, optional for env vars'
+                                                                          type: string
+                                                                        divisor:
+                                                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                          anyOf:
+                                                                            - type: integer
+                                                                            - type: string
+                                                                          x-kubernetes-int-or-string: true
+                                                                        resource:
+                                                                          description: 'Required: resource to select'
+                                                                          type: string
+                                                          secret:
+                                                            description: information about the secret data to project
+                                                            type: object
+                                                            properties:
+                                                              items:
+                                                                description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                                type: array
+                                                                items:
+                                                                  description: Maps a string key to a path within a volume.
+                                                                  type: object
+                                                                  required:
+                                                                    - key
+                                                                    - path
+                                                                  properties:
+                                                                    key:
+                                                                      description: The key to project.
+                                                                      type: string
+                                                                    mode:
+                                                                      description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                                      type: integer
+                                                                      format: int32
+                                                                    path:
+                                                                      description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                                      type: string
+                                                              name:
+                                                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                                type: string
+                                                              optional:
+                                                                description: Specify whether the Secret or its key must be defined
+                                                                type: boolean
+                                                          serviceAccountToken:
+                                                            description: information about the serviceAccountToken data to project
+                                                            type: object
+                                                            required:
+                                                              - path
+                                                            properties:
+                                                              audience:
+                                                                description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                                type: string
+                                                              expirationSeconds:
+                                                                description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                                type: integer
+                                                                format: int64
+                                                              path:
+                                                                description: Path is the path relative to the mount point of the file to project the token into.
+                                                                type: string
+                                                quobyte:
+                                                  description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                                                  type: object
+                                                  required:
+                                                    - registry
+                                                    - volume
+                                                  properties:
+                                                    group:
+                                                      description: Group to map volume access to Default is no group
+                                                      type: string
+                                                    readOnly:
+                                                      description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                                      type: boolean
+                                                    registry:
+                                                      description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                                      type: string
+                                                    tenant:
+                                                      description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                                      type: string
+                                                    user:
+                                                      description: User to map volume access to Defaults to serivceaccount user
+                                                      type: string
+                                                    volume:
+                                                      description: Volume is a string that references an already created Quobyte volume by name.
+                                                      type: string
+                                                rbd:
+                                                  description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                                  type: object
+                                                  required:
+                                                    - image
+                                                    - monitors
+                                                  properties:
+                                                    fsType:
+                                                      description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                                      type: string
+                                                    image:
+                                                      description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                                      type: string
+                                                    keyring:
+                                                      description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                                      type: string
+                                                    monitors:
+                                                      description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    pool:
+                                                      description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                                      type: string
+                                                    readOnly:
+                                                      description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                                      type: boolean
+                                                    secretRef:
+                                                      description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                                      type: object
+                                                      properties:
+                                                        name:
+                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          type: string
+                                                    user:
+                                                      description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                                      type: string
+                                                scaleIO:
+                                                  description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                                  type: object
+                                                  required:
+                                                    - gateway
+                                                    - secretRef
+                                                    - system
+                                                  properties:
+                                                    fsType:
+                                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                                      type: string
+                                                    gateway:
+                                                      description: The host address of the ScaleIO API Gateway.
+                                                      type: string
+                                                    protectionDomain:
+                                                      description: The name of the ScaleIO Protection Domain for the configured storage.
+                                                      type: string
+                                                    readOnly:
+                                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                                      type: boolean
+                                                    secretRef:
+                                                      description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                                      type: object
+                                                      properties:
+                                                        name:
+                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          type: string
+                                                    sslEnabled:
+                                                      description: Flag to enable/disable SSL communication with Gateway, default false
+                                                      type: boolean
+                                                    storageMode:
+                                                      description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                                      type: string
+                                                    storagePool:
+                                                      description: The ScaleIO Storage Pool associated with the protection domain.
+                                                      type: string
+                                                    system:
+                                                      description: The name of the storage system as configured in ScaleIO.
+                                                      type: string
+                                                    volumeName:
+                                                      description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                                      type: string
+                                                secret:
+                                                  description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                                  type: object
+                                                  properties:
+                                                    defaultMode:
+                                                      description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                      type: integer
+                                                      format: int32
+                                                    items:
+                                                      description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                      type: array
+                                                      items:
+                                                        description: Maps a string key to a path within a volume.
+                                                        type: object
+                                                        required:
+                                                          - key
+                                                          - path
+                                                        properties:
+                                                          key:
+                                                            description: The key to project.
+                                                            type: string
+                                                          mode:
+                                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                            type: integer
+                                                            format: int32
+                                                          path:
+                                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                            type: string
+                                                    optional:
+                                                      description: Specify whether the Secret or its keys must be defined
+                                                      type: boolean
+                                                    secretName:
+                                                      description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                                      type: string
+                                                storageos:
+                                                  description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                                  type: object
+                                                  properties:
+                                                    fsType:
+                                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                      type: string
+                                                    readOnly:
+                                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                                      type: boolean
+                                                    secretRef:
+                                                      description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                                      type: object
+                                                      properties:
+                                                        name:
+                                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                          type: string
+                                                    volumeName:
+                                                      description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                                      type: string
+                                                    volumeNamespace:
+                                                      description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                                      type: string
+                                                vsphereVolume:
+                                                  description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                                                  type: object
+                                                  required:
+                                                    - volumePath
+                                                  properties:
+                                                    fsType:
+                                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                      type: string
+                                                    storagePolicyID:
+                                                      description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                                      type: string
+                                                    storagePolicyName:
+                                                      description: Storage Policy Based Management (SPBM) profile name.
+                                                      type: string
+                                                    volumePath:
+                                                      description: Path that identifies vSphere volume vmdk
+                                                      type: string
+                        permissions:
+                          type: array
+                          items:
+                            description: StrategyDeploymentPermissions describe the rbac rules and service account needed by the install strategy
+                            type: object
+                            required:
+                              - rules
+                              - serviceAccountName
+                            properties:
+                              rules:
+                                type: array
+                                items:
+                                  description: PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+                                  type: object
+                                  required:
+                                    - verbs
+                                  properties:
+                                    apiGroups:
+                                      description: APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+                                      type: array
+                                      items:
+                                        type: string
+                                    nonResourceURLs:
+                                      description: NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                                      type: array
+                                      items:
+                                        type: string
+                                    resourceNames:
+                                      description: ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+                                      type: array
+                                      items:
+                                        type: string
+                                    resources:
+                                      description: Resources is a list of resources this rule applies to. '*' represents all resources.
+                                      type: array
+                                      items:
+                                        type: string
+                                    verbs:
+                                      description: Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
+                                      type: array
+                                      items:
+                                        type: string
+                              serviceAccountName:
+                                type: string
+                    strategy:
+                      type: string
+                installModes:
+                  description: InstallModes specify supported installation types
+                  type: array
+                  items:
+                    description: InstallMode associates an InstallModeType with a flag representing if the CSV supports it
+                    type: object
+                    required:
+                      - supported
+                      - type
+                    properties:
+                      supported:
+                        type: boolean
+                      type:
+                        description: InstallModeType is a supported type of install mode for CSV installation
+                        type: string
+                keywords:
+                  type: array
+                  items:
+                    type: string
+                labels:
+                  description: Map of string keys and values that can be used to organize and categorize (scope and select) objects.
+                  type: object
+                  additionalProperties:
+                    type: string
+                links:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                maintainers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      email:
+                        type: string
+                      name:
+                        type: string
+                maturity:
+                  type: string
+                minKubeVersion:
+                  type: string
+                nativeAPIs:
+                  type: array
+                  items:
+                    description: GroupVersionKind unambiguously identifies a kind.  It doesn't anonymously include GroupVersion to avoid automatic coersion.  It doesn't use a GroupVersion to avoid custom marshalling
+                    type: object
+                    required:
+                      - group
+                      - kind
+                      - version
+                    properties:
+                      group:
+                        type: string
+                      kind:
+                        type: string
+                      version:
+                        type: string
+                provider:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    url:
+                      type: string
+                relatedImages:
+                  description: List any related images, or other container images that your Operator might require to perform their functions. This list should also include operand images as well. All image references should be specified by digest (SHA) and not by tag. This field is only used during catalog creation and plays no part in cluster runtime.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - image
+                      - name
+                    properties:
+                      image:
+                        type: string
+                      name:
+                        type: string
+                replaces:
+                  description: The name of a CSV this one replaces. Should match the `metadata.Name` field of the old CSV.
+                  type: string
+                selector:
+                  description: Label selector for related resources.
+                  type: object
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      type: array
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        type: object
+                        required:
+                          - key
+                          - operator
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                      additionalProperties:
+                        type: string
+                skips:
+                  description: The name(s) of one or more CSV(s) that should be skipped in the upgrade graph. Should match the `metadata.Name` field of the CSV that should be skipped. This field is only used during catalog creation and plays no part in cluster runtime.
+                  type: array
+                  items:
+                    type: string
+                version:
+                  description: OperatorVersion is a wrapper around semver.Version which supports correct marshaling to YAML and JSON.
+                  type: string
+                webhookdefinitions:
+                  type: array
+                  items:
+                    description: WebhookDescription provides details to OLM about required webhooks
+                    type: object
+                    required:
+                      - admissionReviewVersions
+                      - generateName
+                      - sideEffects
+                      - type
+                    properties:
+                      admissionReviewVersions:
+                        type: array
+                        items:
+                          type: string
+                      containerPort:
+                        type: integer
+                        format: int32
+                        default: 443
+                        maximum: 65535
+                        minimum: 1
+                      conversionCRDs:
+                        type: array
+                        items:
+                          type: string
+                      deploymentName:
+                        type: string
+                      failurePolicy:
+                        description: FailurePolicyType specifies a failure policy that defines how unrecognized errors from the admission endpoint are handled.
+                        type: string
+                      generateName:
+                        type: string
+                      matchPolicy:
+                        description: MatchPolicyType specifies the type of match policy.
+                        type: string
+                      objectSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        type: object
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            type: array
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              type: object
+                              required:
+                                - key
+                                - operator
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                            additionalProperties:
+                              type: string
+                      reinvocationPolicy:
+                        description: ReinvocationPolicyType specifies what type of policy the admission hook uses.
+                        type: string
+                      rules:
+                        type: array
+                        items:
+                          description: RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.
+                          type: object
+                          properties:
+                            apiGroups:
+                              description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                              type: array
+                              items:
+                                type: string
+                            apiVersions:
+                              description: APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+                              type: array
+                              items:
+                                type: string
+                            operations:
+                              description: Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+                              type: array
+                              items:
+                                description: OperationType specifies an operation for a request.
+                                type: string
+                            resources:
+                              description: "Resources is a list of resources this rule applies to. \n For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources. \n If wildcard is present, the validation rule will ensure resources do not overlap with each other. \n Depending on the enclosing object, subresources might not be allowed. Required."
+                              type: array
+                              items:
+                                type: string
+                            scope:
+                              description: scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+                              type: string
+                      sideEffects:
+                        description: SideEffectClass specifies the types of side effects a webhook may have.
+                        type: string
+                      targetPort:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                      timeoutSeconds:
+                        type: integer
+                        format: int32
+                      type:
+                        description: WebhookAdmissionType is the type of admission webhooks supported by OLM
+                        type: string
+                        enum:
+                          - ValidatingAdmissionWebhook
+                          - MutatingAdmissionWebhook
+                          - ConversionWebhook
+                      webhookPath:
+                        type: string
+            status:
+              description: ClusterServiceVersionStatus represents information about the status of a CSV. Status may trail the actual state of a system.
+              type: object
+              properties:
+                certsLastUpdated:
+                  description: Last time the owned APIService certs were updated
+                  type: string
+                  format: date-time
+                certsRotateAt:
+                  description: Time the owned APIService certs will rotate next
+                  type: string
+                  format: date-time
+                cleanup:
+                  description: CleanupStatus represents information about the status of cleanup while a CSV is pending deletion
+                  type: object
+                  properties:
+                    pendingDeletion:
+                      description: PendingDeletion is the list of custom resource objects that are pending deletion and blocked on finalizers. This indicates the progress of cleanup that is blocking CSV deletion or operator uninstall.
+                      type: array
+                      items:
+                        description: ResourceList represents a list of resources which are of the same Group/Kind
+                        type: object
+                        required:
+                          - group
+                          - instances
+                          - kind
+                        properties:
+                          group:
+                            type: string
+                          instances:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  description: Namespace can be empty for cluster-scoped resources
+                                  type: string
+                          kind:
+                            type: string
+                conditions:
+                  description: List of conditions, a history of state transitions
+                  type: array
+                  items:
+                    description: Conditions appear in the status as a record of state transitions on the ClusterServiceVersion
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the status transitioned from one status to another.
+                        type: string
+                        format: date-time
+                      lastUpdateTime:
+                        description: Last time we updated the status
+                        type: string
+                        format: date-time
+                      message:
+                        description: A human readable message indicating details about why the ClusterServiceVersion is in this condition.
+                        type: string
+                      phase:
+                        description: Condition of the ClusterServiceVersion
+                        type: string
+                      reason:
+                        description: A brief CamelCase message indicating details about why the ClusterServiceVersion is in this state. e.g. 'RequirementsNotMet'
+                        type: string
+                lastTransitionTime:
+                  description: Last time the status transitioned from one status to another.
+                  type: string
+                  format: date-time
+                lastUpdateTime:
+                  description: Last time we updated the status
+                  type: string
+                  format: date-time
+                message:
+                  description: A human readable message indicating details about why the ClusterServiceVersion is in this condition.
+                  type: string
+                phase:
+                  description: Current condition of the ClusterServiceVersion
+                  type: string
+                reason:
+                  description: A brief CamelCase message indicating details about why the ClusterServiceVersion is in this state. e.g. 'RequirementsNotMet'
+                  type: string
+                requirementStatus:
+                  description: The status of each requirement for this CSV
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - group
+                      - kind
+                      - message
+                      - name
+                      - status
+                      - version
+                    properties:
+                      dependents:
+                        type: array
+                        items:
+                          description: DependentStatus is the status for a dependent requirement (to prevent infinite nesting)
+                          type: object
+                          required:
+                            - group
+                            - kind
+                            - status
+                            - version
+                          properties:
+                            group:
+                              type: string
+                            kind:
+                              type: string
+                            message:
+                              type: string
+                            status:
+                              description: StatusReason is a camelcased reason for the status of a RequirementStatus or DependentStatus
+                              type: string
+                            uuid:
+                              type: string
+                            version:
+                              type: string
+                      group:
+                        type: string
+                      kind:
+                        type: string
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        description: StatusReason is a camelcased reason for the status of a RequirementStatus or DependentStatus
+                        type: string
+                      uuid:
+                        type: string
+                      version:
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/docs/shared/crds/operators.coreos.com_installplans.yaml
+++ b/docs/shared/crds/operators.coreos.com_installplans.yaml
@@ -1,0 +1,262 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: installplans.operators.coreos.com
+spec:
+  group: operators.coreos.com
+  names:
+    categories:
+      - olm
+    kind: InstallPlan
+    listKind: InstallPlanList
+    plural: installplans
+    shortNames:
+      - ip
+    singular: installplan
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The first CSV in the list of clusterServiceVersionNames
+          jsonPath: .spec.clusterServiceVersionNames[0]
+          name: CSV
+          type: string
+        - description: The approval mode
+          jsonPath: .spec.approval
+          name: Approval
+          type: string
+        - jsonPath: .spec.approved
+          name: Approved
+          type: boolean
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: InstallPlan defines the installation of a set of operators.
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: InstallPlanSpec defines a set of Application resources to be installed
+              type: object
+              required:
+                - approval
+                - approved
+                - clusterServiceVersionNames
+              properties:
+                approval:
+                  description: Approval is the user approval policy for an InstallPlan. It must be one of "Automatic" or "Manual".
+                  type: string
+                approved:
+                  type: boolean
+                clusterServiceVersionNames:
+                  type: array
+                  items:
+                    type: string
+                generation:
+                  type: integer
+                source:
+                  type: string
+                sourceNamespace:
+                  type: string
+            status:
+              description: "InstallPlanStatus represents the information about the status of steps required to complete installation. \n Status may trail the actual state of a system."
+              type: object
+              required:
+                - catalogSources
+                - phase
+              properties:
+                attenuatedServiceAccountRef:
+                  description: AttenuatedServiceAccountRef references the service account that is used to do scoped operator install.
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                bundleLookups:
+                  description: BundleLookups is the set of in-progress requests to pull and unpackage bundle content to the cluster.
+                  type: array
+                  items:
+                    description: BundleLookup is a request to pull and unpackage the content of a bundle to the cluster.
+                    type: object
+                    required:
+                      - catalogSourceRef
+                      - identifier
+                      - path
+                      - replaces
+                    properties:
+                      catalogSourceRef:
+                        description: CatalogSourceRef is a reference to the CatalogSource the bundle path was resolved from.
+                        type: object
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                      conditions:
+                        description: Conditions represents the overall state of a BundleLookup.
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - status
+                            - type
+                          properties:
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from one status to another.
+                              type: string
+                              format: date-time
+                            lastUpdateTime:
+                              description: Last time the condition was probed.
+                              type: string
+                              format: date-time
+                            message:
+                              description: A human readable message indicating details about the transition.
+                              type: string
+                            reason:
+                              description: The reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False, Unknown.
+                              type: string
+                            type:
+                              description: Type of condition.
+                              type: string
+                      identifier:
+                        description: Identifier is the catalog-unique name of the operator (the name of the CSV for bundles that contain CSVs)
+                        type: string
+                      path:
+                        description: Path refers to the location of a bundle to pull. It's typically an image reference.
+                        type: string
+                      properties:
+                        description: The effective properties of the unpacked bundle.
+                        type: string
+                      replaces:
+                        description: Replaces is the name of the bundle to replace with the one found at Path.
+                        type: string
+                catalogSources:
+                  type: array
+                  items:
+                    type: string
+                conditions:
+                  type: array
+                  items:
+                    description: InstallPlanCondition represents the overall status of the execution of an InstallPlan.
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      lastUpdateTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      reason:
+                        description: ConditionReason is a camelcased reason for the state transition.
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: InstallPlanConditionType describes the state of an InstallPlan at a certain point as a whole.
+                        type: string
+                message:
+                  description: Message is a human-readable message containing detailed information that may be important to understanding why the plan has its current status.
+                  type: string
+                phase:
+                  description: InstallPlanPhase is the current status of a InstallPlan as a whole.
+                  type: string
+                plan:
+                  type: array
+                  items:
+                    description: Step represents the status of an individual step in an InstallPlan.
+                    type: object
+                    required:
+                      - resolving
+                      - resource
+                      - status
+                    properties:
+                      resolving:
+                        type: string
+                      resource:
+                        description: StepResource represents the status of a resource to be tracked by an InstallPlan.
+                        type: object
+                        required:
+                          - group
+                          - kind
+                          - name
+                          - sourceName
+                          - sourceNamespace
+                          - version
+                        properties:
+                          group:
+                            type: string
+                          kind:
+                            type: string
+                          manifest:
+                            type: string
+                          name:
+                            type: string
+                          sourceName:
+                            type: string
+                          sourceNamespace:
+                            type: string
+                          version:
+                            type: string
+                      status:
+                        description: StepStatus is the current status of a particular resource an in InstallPlan
+                        type: string
+                startTime:
+                  description: StartTime is the time when the controller began applying the resources listed in the plan to the cluster.
+                  type: string
+                  format: date-time
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/docs/shared/crds/operators.coreos.com_olmconfigs.yaml
+++ b/docs/shared/crds/operators.coreos.com_olmconfigs.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: olmconfigs.operators.coreos.com
+spec:
+  group: operators.coreos.com
+  names:
+    categories:
+      - olm
+    kind: OLMConfig
+    listKind: OLMConfigList
+    plural: olmconfigs
+    singular: olmconfig
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: OLMConfig is a resource responsible for configuring OLM.
+          type: object
+          required:
+            - metadata
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OLMConfigSpec is the spec for an OLMConfig resource.
+              type: object
+              properties:
+                features:
+                  description: Features contains the list of configurable OLM features.
+                  type: object
+                  properties:
+                    disableCopiedCSVs:
+                      description: DisableCopiedCSVs is used to disable OLM's "Copied CSV" feature for operators installed at the cluster scope, where a cluster scoped operator is one that has been installed in an OperatorGroup that targets all namespaces. When reenabled, OLM will recreate the "Copied CSVs" for each cluster scoped operator.
+                      type: boolean
+            status:
+              description: OLMConfigStatus is the status for an OLMConfig resource.
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/docs/shared/crds/operators.coreos.com_operatorconditions.yaml
+++ b/docs/shared/crds/operators.coreos.com_operatorconditions.yaml
@@ -1,0 +1,305 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: operatorconditions.operators.coreos.com
+spec:
+  group: operators.coreos.com
+  names:
+    categories:
+      - olm
+    kind: OperatorCondition
+    listKind: OperatorConditionList
+    plural: operatorconditions
+    shortNames:
+      - condition
+    singular: operatorcondition
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: OperatorCondition is a Custom Resource of type `OperatorCondition` which is used to convey information to OLM about the state of an operator.
+          type: object
+          required:
+            - metadata
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OperatorConditionSpec allows a cluster admin to convey information about the state of an operator to OLM, potentially overriding state reported by the operator.
+              type: object
+              properties:
+                deployments:
+                  type: array
+                  items:
+                    type: string
+                overrides:
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                serviceAccounts:
+                  type: array
+                  items:
+                    type: string
+            status:
+              description: OperatorConditionStatus allows an operator to convey information its state to OLM. The status may trail the actual state of a system.
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          description: OperatorCondition is a Custom Resource of type `OperatorCondition` which is used to convey information to OLM about the state of an operator.
+          type: object
+          required:
+            - metadata
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OperatorConditionSpec allows an operator to report state to OLM and provides cluster admin with the ability to manually override state reported by the operator.
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                deployments:
+                  type: array
+                  items:
+                    type: string
+                overrides:
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                serviceAccounts:
+                  type: array
+                  items:
+                    type: string
+            status:
+              description: OperatorConditionStatus allows OLM to convey which conditions have been observed.
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/docs/shared/crds/operators.coreos.com_operatorconditions.yaml
+++ b/docs/shared/crds/operators.coreos.com_operatorconditions.yaml
@@ -18,127 +18,6 @@ spec:
     singular: operatorcondition
   scope: Namespaced
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: OperatorCondition is a Custom Resource of type `OperatorCondition` which is used to convey information to OLM about the state of an operator.
-          type: object
-          required:
-            - metadata
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: OperatorConditionSpec allows a cluster admin to convey information about the state of an operator to OLM, potentially overriding state reported by the operator.
-              type: object
-              properties:
-                deployments:
-                  type: array
-                  items:
-                    type: string
-                overrides:
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
-                    type: object
-                    required:
-                      - message
-                      - reason
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                serviceAccounts:
-                  type: array
-                  items:
-                    type: string
-            status:
-              description: OperatorConditionStatus allows an operator to convey information its state to OLM. The status may trail the actual state of a system.
-              type: object
-              properties:
-                conditions:
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-      served: true
-      storage: false
-      subresources:
-        status: {}
     - name: v2
       schema:
         openAPIV3Schema:
@@ -301,5 +180,126 @@ spec:
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
       served: true
       storage: true
+      subresources:
+        status: {}
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: OperatorCondition is a Custom Resource of type `OperatorCondition` which is used to convey information to OLM about the state of an operator.
+          type: object
+          required:
+            - metadata
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OperatorConditionSpec allows a cluster admin to convey information about the state of an operator to OLM, potentially overriding state reported by the operator.
+              type: object
+              properties:
+                deployments:
+                  type: array
+                  items:
+                    type: string
+                overrides:
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                serviceAccounts:
+                  type: array
+                  items:
+                    type: string
+            status:
+              description: OperatorConditionStatus allows an operator to convey information its state to OLM. The status may trail the actual state of a system.
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      served: true
+      storage: false
       subresources:
         status: {}

--- a/docs/shared/crds/operators.coreos.com_operatorgroups.yaml
+++ b/docs/shared/crds/operators.coreos.com_operatorgroups.yaml
@@ -1,0 +1,276 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: operatorgroups.operators.coreos.com
+spec:
+  group: operators.coreos.com
+  names:
+    categories:
+      - olm
+    kind: OperatorGroup
+    listKind: OperatorGroupList
+    plural: operatorgroups
+    shortNames:
+      - og
+    singular: operatorgroup
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: OperatorGroup is the unit of multitenancy for OLM managed operators. It constrains the installation of operators in its namespace to a specified set of target namespaces.
+          type: object
+          required:
+            - metadata
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OperatorGroupSpec is the spec for an OperatorGroup resource.
+              type: object
+              properties:
+                selector:
+                  description: Selector selects the OperatorGroup's target namespaces.
+                  type: object
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      type: array
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        type: object
+                        required:
+                          - key
+                          - operator
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                      additionalProperties:
+                        type: string
+                serviceAccountName:
+                  description: ServiceAccountName is the admin specified service account which will be used to deploy operator(s) in this operator group.
+                  type: string
+                staticProvidedAPIs:
+                  description: Static tells OLM not to update the OperatorGroup's providedAPIs annotation
+                  type: boolean
+                targetNamespaces:
+                  description: TargetNamespaces is an explicit set of namespaces to target. If it is set, Selector is ignored.
+                  type: array
+                  items:
+                    type: string
+                  x-kubernetes-list-type: set
+            status:
+              description: OperatorGroupStatus is the status for an OperatorGroupResource.
+              type: object
+              required:
+                - lastUpdated
+              properties:
+                conditions:
+                  description: Conditions is an array of the OperatorGroup's conditions.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                lastUpdated:
+                  description: LastUpdated is a timestamp of the last time the OperatorGroup's status was Updated.
+                  type: string
+                  format: date-time
+                namespaces:
+                  description: Namespaces is the set of target namespaces for the OperatorGroup.
+                  type: array
+                  items:
+                    type: string
+                  x-kubernetes-list-type: set
+                serviceAccountRef:
+                  description: ServiceAccountRef references the service account object specified.
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: OperatorGroup is the unit of multitenancy for OLM managed operators. It constrains the installation of operators in its namespace to a specified set of target namespaces.
+          type: object
+          required:
+            - metadata
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OperatorGroupSpec is the spec for an OperatorGroup resource.
+              type: object
+              properties:
+                selector:
+                  description: Selector selects the OperatorGroup's target namespaces.
+                  type: object
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      type: array
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        type: object
+                        required:
+                          - key
+                          - operator
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            type: array
+                            items:
+                              type: string
+                    matchLabels:
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                      additionalProperties:
+                        type: string
+                serviceAccountName:
+                  description: ServiceAccountName is the admin specified service account which will be used to deploy operator(s) in this operator group.
+                  type: string
+                staticProvidedAPIs:
+                  description: Static tells OLM not to update the OperatorGroup's providedAPIs annotation
+                  type: boolean
+                targetNamespaces:
+                  description: TargetNamespaces is an explicit set of namespaces to target. If it is set, Selector is ignored.
+                  type: array
+                  items:
+                    type: string
+            status:
+              description: OperatorGroupStatus is the status for an OperatorGroupResource.
+              type: object
+              required:
+                - lastUpdated
+              properties:
+                lastUpdated:
+                  description: LastUpdated is a timestamp of the last time the OperatorGroup's status was Updated.
+                  type: string
+                  format: date-time
+                namespaces:
+                  description: Namespaces is the set of target namespaces for the OperatorGroup.
+                  type: array
+                  items:
+                    type: string
+                serviceAccountRef:
+                  description: ServiceAccountRef references the service account object specified.
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+      served: true
+      storage: false
+      subresources:
+        status: {}

--- a/docs/shared/crds/operators.coreos.com_subscriptions.yaml
+++ b/docs/shared/crds/operators.coreos.com_subscriptions.yaml
@@ -1,0 +1,1354 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: subscriptions.operators.coreos.com
+spec:
+  group: operators.coreos.com
+  names:
+    categories:
+      - olm
+    kind: Subscription
+    listKind: SubscriptionList
+    plural: subscriptions
+    shortNames:
+      - sub
+      - subs
+    singular: subscription
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The package subscribed to
+          jsonPath: .spec.name
+          name: Package
+          type: string
+        - description: The catalog source for the specified package
+          jsonPath: .spec.source
+          name: Source
+          type: string
+        - description: The channel of updates to subscribe to
+          jsonPath: .spec.channel
+          name: Channel
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Subscription keeps operators up to date by tracking changes to Catalogs.
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SubscriptionSpec defines an Application that can be installed
+              type: object
+              required:
+                - name
+                - source
+                - sourceNamespace
+              properties:
+                channel:
+                  type: string
+                config:
+                  description: SubscriptionConfig contains configuration specified for a subscription.
+                  type: object
+                  properties:
+                    env:
+                      description: Env is a list of environment variables to set in the container. Cannot be updated.
+                      type: array
+                      items:
+                        description: EnvVar represents an environment variable present in a Container.
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value. Cannot be used if value is not empty.
+                            type: object
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                type: object
+                                required:
+                                  - key
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its key must be defined
+                                    type: boolean
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                type: object
+                                required:
+                                  - fieldPath
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the specified API version.
+                                    type: string
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                type: object
+                                required:
+                                  - resource
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes, optional for env vars'
+                                    type: string
+                                  divisor:
+                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's namespace
+                                type: object
+                                required:
+                                  - key
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key must be defined
+                                    type: boolean
+                    envFrom:
+                      description: EnvFrom is a list of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Immutable.
+                      type: array
+                      items:
+                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        type: object
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be defined
+                                type: boolean
+                          prefix:
+                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                    nodeSelector:
+                      description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                      type: object
+                      additionalProperties:
+                        type: string
+                    resources:
+                      description: 'Resources represents compute resources required by this container. Immutable. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                      properties:
+                        limits:
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                          additionalProperties:
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        requests:
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                          additionalProperties:
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                    selector:
+                      description: Selector is the label selector for pods to be configured. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
+                      type: object
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          type: array
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            type: object
+                            required:
+                              - key
+                              - operator
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                          additionalProperties:
+                            type: string
+                    tolerations:
+                      description: Tolerations are the pod's tolerations.
+                      type: array
+                      items:
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        type: object
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            type: integer
+                            format: int64
+                          value:
+                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                    volumeMounts:
+                      description: List of VolumeMounts to set in the container.
+                      type: array
+                      items:
+                        description: VolumeMount describes a mounting of a Volume within a container.
+                        type: object
+                        required:
+                          - mountPath
+                          - name
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                            type: string
+                    volumes:
+                      description: List of Volumes to set in the podSpec.
+                      type: array
+                      items:
+                        description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          awsElasticBlockStore:
+                            description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: object
+                            required:
+                              - volumeID
+                            properties:
+                              fsType:
+                                description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                type: string
+                              partition:
+                                description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                type: integer
+                                format: int32
+                              readOnly:
+                                description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: boolean
+                              volumeID:
+                                description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                          azureDisk:
+                            description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                            type: object
+                            required:
+                              - diskName
+                              - diskURI
+                            properties:
+                              cachingMode:
+                                description: 'Host Caching mode: None, Read Only, Read Write.'
+                                type: string
+                              diskName:
+                                description: The Name of the data disk in the blob storage
+                                type: string
+                              diskURI:
+                                description: The URI the data disk in the blob storage
+                                type: string
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                type: string
+                              readOnly:
+                                description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                          azureFile:
+                            description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                            type: object
+                            required:
+                              - secretName
+                              - shareName
+                            properties:
+                              readOnly:
+                                description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: the name of secret that contains Azure Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: Share Name
+                                type: string
+                          cephfs:
+                            description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                            type: object
+                            required:
+                              - monitors
+                            properties:
+                              monitors:
+                                description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: array
+                                items:
+                                  type: string
+                              path:
+                                description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                type: string
+                              readOnly:
+                                description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: boolean
+                              secretFile:
+                                description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                              secretRef:
+                                description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: object
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                              user:
+                                description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                          cinder:
+                            description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: object
+                            required:
+                              - volumeID
+                            properties:
+                              fsType:
+                                description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                              readOnly:
+                                description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: boolean
+                              secretRef:
+                                description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                type: object
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                              volumeID:
+                                description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                          configMap:
+                            description: ConfigMap represents a configMap that should populate this volume
+                            type: object
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                type: integer
+                                format: int32
+                              items:
+                                description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                type: array
+                                items:
+                                  description: Maps a string key to a path within a volume.
+                                  type: object
+                                  required:
+                                    - key
+                                    - path
+                                  properties:
+                                    key:
+                                      description: The key to project.
+                                      type: string
+                                    mode:
+                                      description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      type: integer
+                                      format: int32
+                                    path:
+                                      description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                      type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its keys must be defined
+                                type: boolean
+                          csi:
+                            description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                            type: object
+                            required:
+                              - driver
+                            properties:
+                              driver:
+                                description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                type: object
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                              readOnly:
+                                description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                          downwardAPI:
+                            description: DownwardAPI represents downward API about the pod that should populate this volume
+                            type: object
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                type: integer
+                                format: int32
+                              items:
+                                description: Items is a list of downward API volume file
+                                type: array
+                                items:
+                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                  type: object
+                                  required:
+                                    - path
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                      type: object
+                                      required:
+                                        - fieldPath
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in the specified API version.
+                                          type: string
+                                    mode:
+                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      type: integer
+                                      format: int32
+                                    path:
+                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                      type: object
+                                      required:
+                                        - resource
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                          emptyDir:
+                            description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            type: object
+                            properties:
+                              medium:
+                                description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: string
+                              sizeLimit:
+                                description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                          ephemeral:
+                            description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time. \n This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled."
+                            type: object
+                            properties:
+                              volumeClaimTemplate:
+                                description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
+                                type: object
+                                required:
+                                  - spec
+                                properties:
+                                  metadata:
+                                    description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                    type: object
+                                  spec:
+                                    description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                    type: object
+                                    properties:
+                                      accessModes:
+                                        description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        type: array
+                                        items:
+                                          type: string
+                                      dataSource:
+                                        description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                        type: object
+                                        required:
+                                          - kind
+                                          - name
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                      dataSourceRef:
+                                        description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                        type: object
+                                        required:
+                                          - kind
+                                          - name
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                      resources:
+                                        description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        type: object
+                                        properties:
+                                          limits:
+                                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                            additionalProperties:
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                          requests:
+                                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                            additionalProperties:
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                      selector:
+                                        description: A label query over volumes to consider for binding.
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            type: array
+                                            items:
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              type: object
+                                              required:
+                                                - key
+                                                - operator
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      storageClassName:
+                                        description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeMode:
+                                        description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                        type: string
+                          fc:
+                            description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                            type: object
+                            properties:
+                              fsType:
+                                description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                type: string
+                              lun:
+                                description: 'Optional: FC target lun number'
+                                type: integer
+                                format: int32
+                              readOnly:
+                                description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                type: boolean
+                              targetWWNs:
+                                description: 'Optional: FC target worldwide names (WWNs)'
+                                type: array
+                                items:
+                                  type: string
+                              wwids:
+                                description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                type: array
+                                items:
+                                  type: string
+                          flexVolume:
+                            description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                            type: object
+                            required:
+                              - driver
+                            properties:
+                              driver:
+                                description: Driver is the name of the driver to use for this volume.
+                                type: string
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                type: string
+                              options:
+                                description: 'Optional: Extra command options if any.'
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              readOnly:
+                                description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                type: boolean
+                              secretRef:
+                                description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                type: object
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                          flocker:
+                            description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                            type: object
+                            properties:
+                              datasetName:
+                                description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                type: string
+                              datasetUUID:
+                                description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                type: string
+                          gcePersistentDisk:
+                            description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: object
+                            required:
+                              - pdName
+                            properties:
+                              fsType:
+                                description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                type: string
+                              partition:
+                                description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: integer
+                                format: int32
+                              pdName:
+                                description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              readOnly:
+                                description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: boolean
+                          gitRepo:
+                            description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                            type: object
+                            required:
+                              - repository
+                            properties:
+                              directory:
+                                description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: Repository URL
+                                type: string
+                              revision:
+                                description: Commit hash for the specified revision.
+                                type: string
+                          glusterfs:
+                            description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                            type: object
+                            required:
+                              - endpoints
+                              - path
+                            properties:
+                              endpoints:
+                                description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              path:
+                                description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              readOnly:
+                                description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: boolean
+                          hostPath:
+                            description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                            type: object
+                            required:
+                              - path
+                            properties:
+                              path:
+                                description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                              type:
+                                description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                          iscsi:
+                            description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                            type: object
+                            required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                            properties:
+                              chapAuthDiscovery:
+                                description: whether support iSCSI Discovery CHAP authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: whether support iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                type: string
+                              initiatorName:
+                                description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                type: string
+                              iqn:
+                                description: Target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                type: string
+                              lun:
+                                description: iSCSI Target Lun number.
+                                type: integer
+                                format: int32
+                              portals:
+                                description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                type: array
+                                items:
+                                  type: string
+                              readOnly:
+                                description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: CHAP Secret for iSCSI target and initiator authentication
+                                type: object
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                              targetPortal:
+                                description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                type: string
+                          name:
+                            description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          nfs:
+                            description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: object
+                            required:
+                              - path
+                              - server
+                            properties:
+                              path:
+                                description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                              readOnly:
+                                description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: boolean
+                              server:
+                                description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                          persistentVolumeClaim:
+                            description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            type: object
+                            required:
+                              - claimName
+                            properties:
+                              claimName:
+                                description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                type: boolean
+                          photonPersistentDisk:
+                            description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                            type: object
+                            required:
+                              - pdID
+                            properties:
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: ID that identifies Photon Controller persistent disk
+                                type: string
+                          portworxVolume:
+                            description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                            type: object
+                            required:
+                              - volumeID
+                            properties:
+                              fsType:
+                                description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: VolumeID uniquely identifies a Portworx volume
+                                type: string
+                          projected:
+                            description: Items for all in one resources secrets, configmaps, and downward API
+                            type: object
+                            properties:
+                              defaultMode:
+                                description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                type: integer
+                                format: int32
+                              sources:
+                                description: list of volume projections
+                                type: array
+                                items:
+                                  description: Projection that may be projected along with other supported volume types
+                                  type: object
+                                  properties:
+                                    configMap:
+                                      description: information about the configMap data to project
+                                      type: object
+                                      properties:
+                                        items:
+                                          description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          type: array
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            type: object
+                                            required:
+                                              - key
+                                              - path
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                type: integer
+                                                format: int32
+                                              path:
+                                                description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or its keys must be defined
+                                          type: boolean
+                                    downwardAPI:
+                                      description: information about the downwardAPI data to project
+                                      type: object
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume file
+                                          type: array
+                                          items:
+                                            description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                            type: object
+                                            required:
+                                              - path
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                type: object
+                                                required:
+                                                  - fieldPath
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field to select in the specified API version.
+                                                    type: string
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                type: integer
+                                                format: int32
+                                              path:
+                                                description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                type: object
+                                                required:
+                                                  - resource
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name: required for volumes, optional for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource to select'
+                                                    type: string
+                                    secret:
+                                      description: information about the secret data to project
+                                      type: object
+                                      properties:
+                                        items:
+                                          description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          type: array
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            type: object
+                                            required:
+                                              - key
+                                              - path
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                type: integer
+                                                format: int32
+                                              path:
+                                                description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its key must be defined
+                                          type: boolean
+                                    serviceAccountToken:
+                                      description: information about the serviceAccountToken data to project
+                                      type: object
+                                      required:
+                                        - path
+                                      properties:
+                                        audience:
+                                          description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                          type: integer
+                                          format: int64
+                                        path:
+                                          description: Path is the path relative to the mount point of the file to project the token into.
+                                          type: string
+                          quobyte:
+                            description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                            type: object
+                            required:
+                              - registry
+                              - volume
+                            properties:
+                              group:
+                                description: Group to map volume access to Default is no group
+                                type: string
+                              readOnly:
+                                description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                type: boolean
+                              registry:
+                                description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                type: string
+                              tenant:
+                                description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: User to map volume access to Defaults to serivceaccount user
+                                type: string
+                              volume:
+                                description: Volume is a string that references an already created Quobyte volume by name.
+                                type: string
+                          rbd:
+                            description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                            type: object
+                            required:
+                              - image
+                              - monitors
+                            properties:
+                              fsType:
+                                description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                type: string
+                              image:
+                                description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              keyring:
+                                description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              monitors:
+                                description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: array
+                                items:
+                                  type: string
+                              pool:
+                                description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              readOnly:
+                                description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: boolean
+                              secretRef:
+                                description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: object
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                              user:
+                                description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                          scaleIO:
+                            description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                            type: object
+                            required:
+                              - gateway
+                              - secretRef
+                              - system
+                            properties:
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                type: string
+                              gateway:
+                                description: The host address of the ScaleIO API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: The name of the ScaleIO Protection Domain for the configured storage.
+                                type: string
+                              readOnly:
+                                description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                type: object
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                              sslEnabled:
+                                description: Flag to enable/disable SSL communication with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: The ScaleIO Storage Pool associated with the protection domain.
+                                type: string
+                              system:
+                                description: The name of the storage system as configured in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                type: string
+                          secret:
+                            description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            type: object
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                type: integer
+                                format: int32
+                              items:
+                                description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                type: array
+                                items:
+                                  description: Maps a string key to a path within a volume.
+                                  type: object
+                                  required:
+                                    - key
+                                    - path
+                                  properties:
+                                    key:
+                                      description: The key to project.
+                                      type: string
+                                    mode:
+                                      description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      type: integer
+                                      format: int32
+                                    path:
+                                      description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                      type: string
+                              optional:
+                                description: Specify whether the Secret or its keys must be defined
+                                type: boolean
+                              secretName:
+                                description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                type: string
+                          storageos:
+                            description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                            type: object
+                            properties:
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                type: object
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                              volumeName:
+                                description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                type: string
+                          vsphereVolume:
+                            description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                            type: object
+                            required:
+                              - volumePath
+                            properties:
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: Storage Policy Based Management (SPBM) profile name.
+                                type: string
+                              volumePath:
+                                description: Path that identifies vSphere volume vmdk
+                                type: string
+                installPlanApproval:
+                  description: Approval is the user approval policy for an InstallPlan. It must be one of "Automatic" or "Manual".
+                  type: string
+                name:
+                  type: string
+                source:
+                  type: string
+                sourceNamespace:
+                  type: string
+                startingCSV:
+                  type: string
+            status:
+              type: object
+              required:
+                - lastUpdated
+              properties:
+                catalogHealth:
+                  description: CatalogHealth contains the Subscription's view of its relevant CatalogSources' status. It is used to determine SubscriptionStatusConditions related to CatalogSources.
+                  type: array
+                  items:
+                    description: SubscriptionCatalogHealth describes the health of a CatalogSource the Subscription knows about.
+                    type: object
+                    required:
+                      - catalogSourceRef
+                      - healthy
+                      - lastUpdated
+                    properties:
+                      catalogSourceRef:
+                        description: CatalogSourceRef is a reference to a CatalogSource.
+                        type: object
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                      healthy:
+                        description: Healthy is true if the CatalogSource is healthy; false otherwise.
+                        type: boolean
+                      lastUpdated:
+                        description: LastUpdated represents the last time that the CatalogSourceHealth changed
+                        type: string
+                        format: date-time
+                conditions:
+                  description: Conditions is a list of the latest available observations about a Subscription's current state.
+                  type: array
+                  items:
+                    description: SubscriptionCondition represents the latest available observations of a Subscription's state.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastHeartbeatTime:
+                        description: LastHeartbeatTime is the last time we got an update on a given condition
+                        type: string
+                        format: date-time
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transit from one status to another
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Reason is a one-word CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of Subscription condition.
+                        type: string
+                currentCSV:
+                  description: CurrentCSV is the CSV the Subscription is progressing to.
+                  type: string
+                installPlanGeneration:
+                  description: InstallPlanGeneration is the current generation of the installplan
+                  type: integer
+                installPlanRef:
+                  description: InstallPlanRef is a reference to the latest InstallPlan that contains the Subscription's current CSV.
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                installedCSV:
+                  description: InstalledCSV is the CSV currently installed by the Subscription.
+                  type: string
+                installplan:
+                  description: 'Install is a reference to the latest InstallPlan generated for the Subscription. DEPRECATED: InstallPlanRef'
+                  type: object
+                  required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uuid
+                  properties:
+                    apiVersion:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    uuid:
+                      description: UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.
+                      type: string
+                lastUpdated:
+                  description: LastUpdated represents the last time that the Subscription status was updated.
+                  type: string
+                  format: date-time
+                reason:
+                  description: Reason is the reason the Subscription was transitioned to its current state.
+                  type: string
+                state:
+                  description: State represents the current state of the Subscription
+                  type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/docs/shared/crds/product-base.yaml
+++ b/docs/shared/crds/product-base.yaml
@@ -26,6 +26,378 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Ready')].status
       name: Ready
       type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ProductBase is the Schema for the productbases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProductBaseSpec defines the desired state of ProductBase
+            properties:
+              alternativeURLs:
+                description: AlternativeURLs is the platform's alternative urls
+                items:
+                  type: string
+                type: array
+              defaultAdmin:
+                description: DefaultAdmin stands for the admin's config
+                properties:
+                  account:
+                    description: Account stands for admin's account
+                    type: string
+                  email:
+                    description: Email stands for admin's email
+                    type: string
+                  hash:
+                    description: Hash stands for admin's password hash
+                    type: string
+                required:
+                - account
+                - email
+                type: object
+              defaultRedirectPath:
+                description: DefaultRedirectPath stands for the default redirect path
+                type: string
+              globalConfig:
+                description: GlobalConfig stands for the global config
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              http:
+                description: HTTP stands for the http config
+                properties:
+                  forceRedirectHttps:
+                    description: ForceRedirectHTTPS stands for if force redirect to
+                      https
+                    type: boolean
+                  httpPort:
+                    description: HTTPPort is the port of http
+                    type: integer
+                  httpsPort:
+                    description: HTTPPort is the port of https
+                    type: integer
+                  tls:
+                    description: TLS statnds for the server's TLS Certificate
+                    properties:
+                      secretRef:
+                        description: SecretRef is the reference for tls secret
+                        properties:
+                          name:
+                            description: Name is the name of secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                required:
+                - forceRedirectHttps
+                type: object
+              ingress:
+                description: Ingress stands for the ingress configs
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  controller:
+                    description: Controller stands for the ingress controller configs
+                    properties:
+                      install:
+                        description: Install stands for if install ingress controller
+                        type: boolean
+                      nodes:
+                        description: Nodes stands for the ingress controller's running
+                          node
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - install
+                    type: object
+                  host:
+                    description: Host stands for the host config in ingress
+                    type: string
+                  ingressClassName:
+                    description: IngressClassName stands for the ingressClassName
+                      of the ingress
+                    type: string
+                required:
+                - controller
+                - host
+                - ingressClassName
+                type: object
+              platformPublicURL:
+                description: PlatformPublicURL stands the platform's public url
+                type: string
+              platformURL:
+                description: PlatformURL is the platform's access url
+                type: string
+              productBrand:
+                description: 'ProductBrand values: TKE、ACP、Common'
+                type: string
+              registry:
+                description: Registry is Docker Registry's Config
+                properties:
+                  address:
+                    description: Address is Docker Registry's address
+                    type: string
+                  external:
+                    description: External stands for a external registry
+                    type: boolean
+                  preferPlatformURL:
+                    description: PreferPlatformURL stands for business cluster prefer
+                      platform URL as registry address
+                    type: boolean
+                  secretRef:
+                    description: SecretRef is the reference for  pullImageSecret
+                    properties:
+                      name:
+                        description: Name is the name of secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - address
+                - preferPlatformURL
+                type: object
+              replicas:
+                description: Replicas stands for the deploy replicas
+                type: integer
+              version:
+                description: Version stands for this product's version to deploy
+                type: string
+            required:
+            - defaultAdmin
+            - http
+            - platformURL
+            - registry
+            - version
+            type: object
+          status:
+            description: ProductBaseStatus defines the observed state of ProductBase
+            properties:
+              artifacts:
+                description: Artifacts stands for the product's artifacts
+                items:
+                  description: Artifact stands for the artifact's info
+                  properties:
+                    channels:
+                      description: Channels stands for the artifact's channels
+                      items:
+                        description: Channel stands for the artifact's channel
+                        properties:
+                          artifactStatus:
+                            description: ArtifactStatus stands for the channel's artifact
+                              status
+                            type: string
+                          brief:
+                            description: Brief stands for the artifact's brief
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          catalogSource:
+                            description: CatalogSource stands for the catalog source
+                              to get the operator bundle
+                            type: string
+                          categories:
+                            description: 'Categories stands for the artifact''s categories,
+                              such as: AI, Database, etc.'
+                            items:
+                              type: string
+                            type: array
+                          channel:
+                            description: Channel stands for the channel's name
+                            type: string
+                          default:
+                            description: Default stands for the artifact's default
+                              channel
+                            type: boolean
+                          description:
+                            description: Description stands for the channel's description
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          digest:
+                            description: Digest stands for the channel's digest
+                            type: string
+                          displayName:
+                            description: DisplayName stands for the artifact's display
+                              name
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          hidden:
+                            description: Hidden stands for the artifact is hidden
+                              on the Marketplace's page
+                            type: boolean
+                          packIgnore:
+                            description: PackIgnore indicates whether to skip packaging
+                            type: boolean
+                          provider:
+                            description: Provider stands for the artifact's provider
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          providerType:
+                            description: 'ProviderType stands for the artifact''s
+                              provider type, such as: platform, certified, custom,
+                              community'
+                            type: string
+                          repository:
+                            description: Repository stands for the channel's repository
+                            type: string
+                          supportedArchitectures:
+                            description: 'SupportedArchitectures stands for the supported
+                              architectures, such as: amd64, arm64, etc.'
+                            items:
+                              type: string
+                            type: array
+                          supportedPlatformVersions:
+                            description: 'SupportedPlatformVersions stands for the
+                              supported platform versions, such as: v4.0, v4.1, etc.'
+                            items:
+                              type: string
+                            type: array
+                          supportedProtocolStacks:
+                            description: 'SupportedProtocolStacks stands for the supported
+                              protocol stacks, such as: IPv4, IPv6, DualStack, etc.'
+                            items:
+                              type: string
+                            type: array
+                          tag:
+                            description: Tag stands for the channel's tag
+                            type: string
+                        required:
+                        - artifactStatus
+                        - channel
+                        - default
+                        - displayName
+                        - repository
+                        - tag
+                        type: object
+                      type: array
+                    name:
+                      description: Name stands for the artifact's name
+                      type: string
+                    packageType:
+                      description: PackageType stands for the artifact's package type
+                      type: string
+                  required:
+                  - channels
+                  - name
+                  - packageType
+                  type: object
+                type: array
+              conditions:
+                description: Conditions contains this product's conditions
+                items:
+                  description: ProductBaseCondition ...
+                  properties:
+                    lastHeartbeatTime:
+                      description: LastHeartbeatTime stands for the timestamp to check
+                        Condition
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: LastTransitionTime stands for the timestamp of
+                        Condition's status changed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message stands for Condition's message
+                      type: string
+                    reason:
+                      description: Reason stands for Condition's reason
+                      type: string
+                    status:
+                      description: Status stands for Condition's status
+                      type: string
+                    type:
+                      description: Type stands for Condition's type
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              globalID:
+                description: GlobalID stands for the global Id
+                type: string
+              phase:
+                description: Phase stands for this product's phase
+                enum:
+                - Pending
+                - Provisioning
+                - Deleting
+                - Failed
+                - Running
+                type: string
+              replicas:
+                description: Replicas stands for the product workload replicas
+                type: integer
+              version:
+                description: Version statnds for this product's current version
+                type: string
+            required:
+            - phase
+            - version
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -1156,377 +1528,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - jsonPath: .status.phase
-      name: Status
-      type: string
-    - jsonPath: .status.version
-      name: Version
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        description: ProductBase is the Schema for the productbases API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ProductBaseSpec defines the desired state of ProductBase
-            properties:
-              alternativeURLs:
-                description: AlternativeURLs is the platform's alternative urls
-                items:
-                  type: string
-                type: array
-              defaultAdmin:
-                description: DefaultAdmin stands for the admin's config
-                properties:
-                  account:
-                    description: Account stands for admin's account
-                    type: string
-                  email:
-                    description: Email stands for admin's email
-                    type: string
-                  hash:
-                    description: Hash stands for admin's password hash
-                    type: string
-                required:
-                - account
-                - email
-                type: object
-              defaultRedirectPath:
-                description: DefaultRedirectPath stands for the default redirect path
-                type: string
-              globalConfig:
-                description: GlobalConfig stands for the global config
-                properties:
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                type: object
-              http:
-                description: HTTP stands for the http config
-                properties:
-                  forceRedirectHttps:
-                    description: ForceRedirectHTTPS stands for if force redirect to
-                      https
-                    type: boolean
-                  httpPort:
-                    description: HTTPPort is the port of http
-                    type: integer
-                  httpsPort:
-                    description: HTTPPort is the port of https
-                    type: integer
-                  tls:
-                    description: TLS statnds for the server's TLS Certificate
-                    properties:
-                      secretRef:
-                        description: SecretRef is the reference for tls secret
-                        properties:
-                          name:
-                            description: Name is the name of secret
-                            type: string
-                        required:
-                        - name
-                        type: object
-                    type: object
-                required:
-                - forceRedirectHttps
-                type: object
-              ingress:
-                description: Ingress stands for the ingress configs
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  controller:
-                    description: Controller stands for the ingress controller configs
-                    properties:
-                      install:
-                        description: Install stands for if install ingress controller
-                        type: boolean
-                      nodes:
-                        description: Nodes stands for the ingress controller's running
-                          node
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - install
-                    type: object
-                  host:
-                    description: Host stands for the host config in ingress
-                    type: string
-                  ingressClassName:
-                    description: IngressClassName stands for the ingressClassName
-                      of the ingress
-                    type: string
-                required:
-                - controller
-                - host
-                - ingressClassName
-                type: object
-              platformPublicURL:
-                description: PlatformPublicURL stands the platform's public url
-                type: string
-              platformURL:
-                description: PlatformURL is the platform's access url
-                type: string
-              productBrand:
-                description: 'ProductBrand values: TKE、ACP、Common'
-                type: string
-              registry:
-                description: Registry is Docker Registry's Config
-                properties:
-                  address:
-                    description: Address is Docker Registry's address
-                    type: string
-                  external:
-                    description: External stands for a external registry
-                    type: boolean
-                  preferPlatformURL:
-                    description: PreferPlatformURL stands for business cluster prefer
-                      platform URL as registry address
-                    type: boolean
-                  secretRef:
-                    description: SecretRef is the reference for  pullImageSecret
-                    properties:
-                      name:
-                        description: Name is the name of secret
-                        type: string
-                    required:
-                    - name
-                    type: object
-                required:
-                - address
-                - preferPlatformURL
-                type: object
-              replicas:
-                description: Replicas stands for the deploy replicas
-                type: integer
-              version:
-                description: Version stands for this product's version to deploy
-                type: string
-            required:
-            - defaultAdmin
-            - http
-            - platformURL
-            - registry
-            - version
-            type: object
-          status:
-            description: ProductBaseStatus defines the observed state of ProductBase
-            properties:
-              artifacts:
-                description: Artifacts stands for the product's artifacts
-                items:
-                  description: Artifact stands for the artifact's info
-                  properties:
-                    channels:
-                      description: Channels stands for the artifact's channels
-                      items:
-                        description: Channel stands for the artifact's channel
-                        properties:
-                          artifactStatus:
-                            description: ArtifactStatus stands for the channel's artifact
-                              status
-                            type: string
-                          brief:
-                            description: Brief stands for the artifact's brief
-                            properties:
-                              en:
-                                description: EN stands for text with English
-                                type: string
-                              zh:
-                                description: ZH stands for text with Simple Chinese
-                                type: string
-                            type: object
-                          catalogSource:
-                            description: CatalogSource stands for the catalog source
-                              to get the operator bundle
-                            type: string
-                          categories:
-                            description: 'Categories stands for the artifact''s categories,
-                              such as: AI, Database, etc.'
-                            items:
-                              type: string
-                            type: array
-                          channel:
-                            description: Channel stands for the channel's name
-                            type: string
-                          default:
-                            description: Default stands for the artifact's default
-                              channel
-                            type: boolean
-                          description:
-                            description: Description stands for the channel's description
-                            properties:
-                              en:
-                                description: EN stands for text with English
-                                type: string
-                              zh:
-                                description: ZH stands for text with Simple Chinese
-                                type: string
-                            type: object
-                          digest:
-                            description: Digest stands for the channel's digest
-                            type: string
-                          displayName:
-                            description: DisplayName stands for the artifact's display
-                              name
-                            properties:
-                              en:
-                                description: EN stands for text with English
-                                type: string
-                              zh:
-                                description: ZH stands for text with Simple Chinese
-                                type: string
-                            type: object
-                          hidden:
-                            description: Hidden stands for the artifact is hidden
-                              on the Marketplace's page
-                            type: boolean
-                          packIgnore:
-                            description: PackIgnore indicates whether to skip packaging
-                            type: boolean
-                          provider:
-                            description: Provider stands for the artifact's provider
-                            properties:
-                              en:
-                                description: EN stands for text with English
-                                type: string
-                              zh:
-                                description: ZH stands for text with Simple Chinese
-                                type: string
-                            type: object
-                          providerType:
-                            description: 'ProviderType stands for the artifact''s
-                              provider type, such as: platform, certified, custom,
-                              community'
-                            type: string
-                          repository:
-                            description: Repository stands for the channel's repository
-                            type: string
-                          supportedArchitectures:
-                            description: 'SupportedArchitectures stands for the supported
-                              architectures, such as: amd64, arm64, etc.'
-                            items:
-                              type: string
-                            type: array
-                          supportedPlatformVersions:
-                            description: 'SupportedPlatformVersions stands for the
-                              supported platform versions, such as: v4.0, v4.1, etc.'
-                            items:
-                              type: string
-                            type: array
-                          supportedProtocolStacks:
-                            description: 'SupportedProtocolStacks stands for the supported
-                              protocol stacks, such as: IPv4, IPv6, DualStack, etc.'
-                            items:
-                              type: string
-                            type: array
-                          tag:
-                            description: Tag stands for the channel's tag
-                            type: string
-                        required:
-                        - artifactStatus
-                        - channel
-                        - default
-                        - displayName
-                        - repository
-                        - tag
-                        type: object
-                      type: array
-                    name:
-                      description: Name stands for the artifact's name
-                      type: string
-                    packageType:
-                      description: PackageType stands for the artifact's package type
-                      type: string
-                  required:
-                  - channels
-                  - name
-                  - packageType
-                  type: object
-                type: array
-              conditions:
-                description: Conditions contains this product's conditions
-                items:
-                  description: ProductBaseCondition ...
-                  properties:
-                    lastHeartbeatTime:
-                      description: LastHeartbeatTime stands for the timestamp to check
-                        Condition
-                      format: date-time
-                      type: string
-                    lastTransitionTime:
-                      description: LastTransitionTime stands for the timestamp of
-                        Condition's status changed
-                      format: date-time
-                      type: string
-                    message:
-                      description: Message stands for Condition's message
-                      type: string
-                    reason:
-                      description: Reason stands for Condition's reason
-                      type: string
-                    status:
-                      description: Status stands for Condition's status
-                      type: string
-                    type:
-                      description: Type stands for Condition's type
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              globalID:
-                description: GlobalID stands for the global Id
-                type: string
-              phase:
-                description: Phase stands for this product's phase
-                enum:
-                - Pending
-                - Provisioning
-                - Deleting
-                - Failed
-                - Running
-                type: string
-              replicas:
-                description: Replicas stands for the product workload replicas
-                type: integer
-              version:
-                description: Version statnds for this product's current version
-                type: string
-            required:
-            - phase
-            - version
-            type: object
-        type: object
-    served: true
-    storage: false
     subresources:
       status: {}

--- a/docs/shared/crds/product-base.yaml
+++ b/docs/shared/crds/product-base.yaml
@@ -1,0 +1,1532 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: productbases.product.alauda.io
+spec:
+  group: product.alauda.io
+  names:
+    kind: ProductBase
+    listKind: ProductBaseList
+    plural: productbases
+    shortNames:
+    - prdb
+    singular: productbase
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ProductBase is the Schema for the productbases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProductBaseSpec defines the desired state of ProductBase
+            properties:
+              aceEnable:
+                description: ACEEnable if enable ACE
+                type: boolean
+              alternativeURLs:
+                description: AlternativeURLs is the platform's alternative urls
+                items:
+                  type: string
+                type: array
+              chartMuseum:
+                description: ChartMuseum is chart meseum's config
+                properties:
+                  url:
+                    description: URL is Chart Museum's url
+                    type: string
+                required:
+                - url
+                type: object
+              chartVersions:
+                description: ChartVersions stands for the charts when deploying, they
+                  are optional and will be added to the Prouct CR
+                items:
+                  description: ChartVersion stands for chart version
+                  properties:
+                    name:
+                      description: Name stands for the chart's name
+                      type: string
+                    version:
+                      description: Version stands for the chart's version
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+              cloud:
+                description: Cloud stands for the cloud connecting configs
+                properties:
+                  connect:
+                    description: Connect stands for if connect to cloud
+                    type: boolean
+                  connectType:
+                    description: ConnectType stands for the connect type
+                    enum:
+                    - SSH-Tunnel
+                    - Public
+                    type: string
+                required:
+                - connect
+                - connectType
+                type: object
+              containerPlatform:
+                description: ContainerPlatform stands for ContainerPlatform's config
+                properties:
+                  install:
+                    description: Install stands for if install ContainerPlatform
+                    type: boolean
+                required:
+                - install
+                type: object
+              dataServices:
+                description: DataServices stands for DataServices's config
+                properties:
+                  install:
+                    description: Install stands for if install DataServices
+                    type: boolean
+                required:
+                - install
+                type: object
+              defaultAdmin:
+                description: DefaultAdmin stands for the admin's config
+                properties:
+                  account:
+                    description: Account stands for admin's account
+                    type: string
+                  email:
+                    description: Email stands for admin's email
+                    type: string
+                  hash:
+                    description: Hash stands for admin's password hash
+                    type: string
+                  password:
+                    description: Password stands for admin's password
+                    format: byte
+                    type: string
+                required:
+                - account
+                - email
+                type: object
+              defaultRedirectPath:
+                description: DefaultRedirectPath stands for the default redirect path
+                type: string
+              deployType:
+                description: DeployType stands for deploy type
+                type: string
+              devops:
+                description: Devops stands for Devops's config
+                properties:
+                  install:
+                    description: Install stands for if install DevopsConfig
+                    type: boolean
+                required:
+                - install
+                type: object
+              elasticsearch:
+                description: Elasticsearch stands for the elasticsearch's config
+                properties:
+                  extenalAddress:
+                    description: ExternalAddress statnds for external elasticsearch's
+                      address if not empty
+                    type: string
+                  install:
+                    description: Install stands for if install elasticsearch
+                    type: boolean
+                  nodes:
+                    description: Nodes stands for elasticsearch's deploy node
+                    items:
+                      type: string
+                    type: array
+                  password:
+                    description: Username stands for elasticsearch's password
+                    format: byte
+                    type: string
+                  username:
+                    description: Username stands for elasticsearch's username
+                    type: string
+                required:
+                - install
+                type: object
+              etcd:
+                description: ETCD stands for the standalone etcd configs
+                properties:
+                  hostPath:
+                    description: HostPath stands for the host path on node to storage
+                      etcd dat
+                    type: string
+                  nodes:
+                    description: Nodes stands for the etcd's running node
+                    items:
+                      type: string
+                    type: array
+                  pvcNames:
+                    description: PVCNames stands for the etcd's pvc names
+                    items:
+                      type: string
+                    type: array
+                type: object
+              globalConfig:
+                description: GlobalConfig stands for the global config
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              http:
+                description: HTTP stands for the http config
+                properties:
+                  forceRedirectHttps:
+                    description: ForceRedirectHTTPS stands for if force redirect to
+                      https
+                    type: boolean
+                  httpPort:
+                    description: HTTPPort is the port of http
+                    type: integer
+                  httpsPort:
+                    description: HTTPPort is the port of https
+                    type: integer
+                  tls:
+                    description: TLS statnds for the server's TLS Certificate
+                    properties:
+                      ca:
+                        description: CA is the CA certificate content
+                        format: byte
+                        type: string
+                      cert:
+                        description: Cert is the server certificate content
+                        format: byte
+                        type: string
+                      key:
+                        description: Key is the server's key
+                        format: byte
+                        type: string
+                      secretRef:
+                        description: SecretRef is the reference for tls secret
+                        properties:
+                          name:
+                            description: Name is the name of secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                required:
+                - forceRedirectHttps
+                type: object
+              ingress:
+                description: Ingress stands for the ingress configs
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  controller:
+                    description: Controller stands for the ingress controller configs
+                    properties:
+                      install:
+                        description: Install stands for if install ingress controller
+                        type: boolean
+                      nodes:
+                        description: Nodes stands for the ingress controller's running
+                          node
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - install
+                    type: object
+                  host:
+                    description: Host stands for the host config in ingress
+                    type: string
+                  ingressClassName:
+                    description: IngressClassName stands for the ingressClassName
+                      of the ingress
+                    type: string
+                required:
+                - controller
+                - host
+                - ingressClassName
+                type: object
+              kafka:
+                description: Kafka statnds for the kafka's config
+                properties:
+                  auth:
+                    description: Auth stands for if enable authentication
+                    type: boolean
+                  extenalAddress:
+                    description: ExternalAddress stands for external kafka's address
+                      if not empty
+                    type: string
+                  install:
+                    description: Install stands for if install kafka
+                    type: boolean
+                  nodes:
+                    description: Nodes stands for kafka's deploy node
+                    items:
+                      type: string
+                    type: array
+                  password:
+                    description: Password stands for password's username
+                    format: byte
+                    type: string
+                  username:
+                    description: Username stands for kafka's username
+                    type: string
+                required:
+                - install
+                type: object
+              logAgent:
+                description: LogAgent stands for the log agent's config
+                properties:
+                  enable:
+                    description: Enable stands for if global cluster's log agent enabled
+                    type: boolean
+                required:
+                - enable
+                type: object
+              logCenter:
+                description: LogCenter stands for the log center's config
+                properties:
+                  enable:
+                    description: Enable stands for if log center enabled
+                    type: boolean
+                required:
+                - enable
+                type: object
+              packageEdition:
+                description: 'ProductBrand values: Standard、Runtime'
+                type: string
+              platformPublicURL:
+                description: PlatformPublicURL stands the platform's public url
+                type: string
+              platformURL:
+                description: PlatformURL is the platform's access url
+                type: string
+              productBrand:
+                description: 'ProductBrand values: TKE、ACP、Common'
+                type: string
+              prometheus:
+                description: Prometheus stands for the prometheus's config
+                properties:
+                  install:
+                    description: Install stands for if install prometheus for global
+                      cluster
+                    type: boolean
+                  replicas:
+                    description: Replicas stands for prometheus's replicas
+                    type: integer
+                  storage:
+                    description: Storage stands for prometheus's storage config
+                    properties:
+                      capacity:
+                        description: Capacity stands for Prometheus storage capacity
+                        type: integer
+                      nodes:
+                        description: Nodes stands for Prometheus deploy nodes
+                        items:
+                          type: string
+                        type: array
+                      path:
+                        description: Path stands for Prometheus storage path
+                        type: string
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: Selector stands for Prometheus's PV selector
+                        type: object
+                      storageClass:
+                        description: StorageClass stands for Prometheus's storage
+                          class
+                        type: string
+                      type:
+                        description: Type stands for Prometheus storage type
+                        type: string
+                    required:
+                    - type
+                    type: object
+                required:
+                - install
+                type: object
+              registry:
+                description: Registry is Docker Registry's Config
+                properties:
+                  address:
+                    description: Address is Docker Registry's address
+                    type: string
+                  external:
+                    description: External stands for a external registry
+                    type: boolean
+                  password:
+                    description: Password is Docker Registry's login password
+                    format: byte
+                    type: string
+                  preferPlatformURL:
+                    description: PreferPlatformURL stands for business cluster prefer
+                      platform URL as registry address
+                    type: boolean
+                  secretRef:
+                    description: SecretRef is the reference for  pullImageSecret
+                    properties:
+                      name:
+                        description: Name is the name of secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  username:
+                    description: Username is Docker Registry's login user name
+                    type: string
+                required:
+                - address
+                - preferPlatformURL
+                type: object
+              replicas:
+                description: Replicas stands for the deploy replicas
+                type: integer
+              serviceMesh:
+                description: ServiceMesh stands for ServiceMesh's config
+                properties:
+                  install:
+                    description: Install stands for if install ServiceMesh
+                    type: boolean
+                required:
+                - install
+                type: object
+              useCustomerDefinedPorts:
+                description: UseCustomerDefinedPorts stands for if use customer defined
+                  ports
+                type: boolean
+              valuesOverride:
+                additionalProperties:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                description: ValuesOverride is the special values
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              version:
+                description: Version stands for this product's version to deploy
+                type: string
+            required:
+            - chartMuseum
+            - containerPlatform
+            - defaultAdmin
+            - devops
+            - elasticsearch
+            - http
+            - kafka
+            - logAgent
+            - logCenter
+            - platformURL
+            - prometheus
+            - registry
+            - serviceMesh
+            - version
+            type: object
+          status:
+            description: ProductBaseStatus defines the observed state of ProductBase
+            properties:
+              appReleases:
+                additionalProperties:
+                  description: AppReleaseStatus ...
+                  properties:
+                    failed:
+                      description: Synced stands for if AppRelease failed
+                      type: boolean
+                    lastProbeTime:
+                      description: LastProbeTime stands for the timestamp to probe
+                        AppRelease's status
+                      format: date-time
+                      type: string
+                    message:
+                      description: Reason stands for AppRelease's message
+                      type: string
+                    ready:
+                      description: Synced stands for if AppRelease ready
+                      type: boolean
+                    reason:
+                      description: Reason stands for AppRelease's reason
+                      type: string
+                    synced:
+                      description: Synced stands for if AppRelease synced
+                      type: boolean
+                  required:
+                  - failed
+                  - ready
+                  - synced
+                  type: object
+                description: AppReleases records this product's AppReleases' status
+                type: object
+              artifacts:
+                description: Artifacts stands for the product's artifacts
+                items:
+                  description: Artifact stands for the artifact's info
+                  properties:
+                    channels:
+                      description: Channels stands for the artifact's channels
+                      items:
+                        description: Channel stands for the artifact's channel
+                        properties:
+                          artifactStatus:
+                            description: ArtifactStatus stands for the channel's artifact
+                              status
+                            type: string
+                          brief:
+                            description: Brief stands for the artifact's brief
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          catalogSource:
+                            description: CatalogSource stands for the catalog source
+                              to get the operator bundle
+                            type: string
+                          categories:
+                            description: 'Categories stands for the artifact''s categories,
+                              such as: AI, Database, etc.'
+                            items:
+                              type: string
+                            type: array
+                          channel:
+                            description: Channel stands for the channel's name
+                            type: string
+                          default:
+                            description: Default stands for the artifact's default
+                              channel
+                            type: boolean
+                          description:
+                            description: Description stands for the channel's description
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          digest:
+                            description: Digest stands for the channel's digest
+                            type: string
+                          displayName:
+                            description: DisplayName stands for the artifact's display
+                              name
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          hidden:
+                            description: Hidden stands for the artifact is hidden
+                              on the Marketplace's page
+                            type: boolean
+                          packIgnore:
+                            description: PackIgnore indicates whether to skip packaging
+                            type: boolean
+                          provider:
+                            description: Provider stands for the artifact's provider
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          providerType:
+                            description: 'ProviderType stands for the artifact''s
+                              provider type, such as: platform, certified, custom,
+                              community'
+                            type: string
+                          repository:
+                            description: Repository stands for the channel's repository
+                            type: string
+                          supportedArchitectures:
+                            description: 'SupportedArchitectures stands for the supported
+                              architectures, such as: amd64, arm64, etc.'
+                            items:
+                              type: string
+                            type: array
+                          supportedPlatformVersions:
+                            description: 'SupportedPlatformVersions stands for the
+                              supported platform versions, such as: v4.0, v4.1, etc.'
+                            items:
+                              type: string
+                            type: array
+                          supportedProtocolStacks:
+                            description: 'SupportedProtocolStacks stands for the supported
+                              protocol stacks, such as: IPv4, IPv6, DualStack, etc.'
+                            items:
+                              type: string
+                            type: array
+                          tag:
+                            description: Tag stands for the channel's tag
+                            type: string
+                        required:
+                        - artifactStatus
+                        - channel
+                        - default
+                        - displayName
+                        - repository
+                        - tag
+                        type: object
+                      type: array
+                    name:
+                      description: Name stands for the artifact's name
+                      type: string
+                    packageType:
+                      description: PackageType stands for the artifact's package type
+                      type: string
+                  required:
+                  - channels
+                  - name
+                  - packageType
+                  type: object
+                type: array
+              base:
+                description: Base stands for the base component's status
+                properties:
+                  brief:
+                    description: Brief stands for the product's brief
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  deployStatus:
+                    description: DeployStatus stands for the deploy status
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    description: DeployTime stands for the timestamp to deploy this
+                      component
+                    format: date-time
+                    type: string
+                  description:
+                    description: Description stands for the product's description
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  displayName:
+                    description: DisplayName stands for the product's display name
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  entrypoint:
+                    description: Entrypoint is the entrypoint of this component
+                    type: string
+                  lastProbeTime:
+                    description: LastProbeTime stands for the timestamp to probe status
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: LastTransitionTime stands for the timestamp of the
+                      status changed
+                    format: date-time
+                    type: string
+                  logPath:
+                    description: LogPath stands for the path of log
+                    type: string
+                  logo:
+                    description: Logo stands for the product logo with base64 encoded
+                      data uri
+                    type: string
+                  message:
+                    description: Message contains the detail infomation why in current
+                      status
+                    type: string
+                  productType:
+                    description: ProdutctType stands for the product type
+                    type: string
+                  reason:
+                    description: Reason contains the reason why in current status
+                    type: string
+                  runningStatus:
+                    description: RunningStatus stands for the running status
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+              cloud:
+                description: Cloud stands for the cloud connecting status
+                properties:
+                  connectURL:
+                    description: ConnectURL stands for the connect url
+                    type: string
+                  message:
+                    description: Message stands for the connect message
+                    type: string
+                  phase:
+                    description: Phase stands for the connect phase
+                    enum:
+                    - ONLine
+                    - ConnectFailed
+                    - Connecting
+                    - OFFLine
+                    type: string
+                required:
+                - connectURL
+                - message
+                - phase
+                type: object
+              conditions:
+                description: Conditions contains this product's conditions
+                items:
+                  description: ProductBaseCondition ...
+                  properties:
+                    lastHeartbeatTime:
+                      description: LastHeartbeatTime stands for the timestamp to check
+                        Condition
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: LastTransitionTime stands for the timestamp of
+                        Condition's status changed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message stands for Condition's message
+                      type: string
+                    reason:
+                      description: Reason stands for Condition's reason
+                      type: string
+                    status:
+                      description: Status stands for Condition's status
+                      type: string
+                    type:
+                      description: Type stands for Condition's type
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              containerPlatform:
+                description: ContainerPlatform stands for the ContainerPlatform component's
+                  status
+                properties:
+                  brief:
+                    description: Brief stands for the product's brief
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  deployStatus:
+                    description: DeployStatus stands for the deploy status
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    description: DeployTime stands for the timestamp to deploy this
+                      component
+                    format: date-time
+                    type: string
+                  description:
+                    description: Description stands for the product's description
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  displayName:
+                    description: DisplayName stands for the product's display name
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  entrypoint:
+                    description: Entrypoint is the entrypoint of this component
+                    type: string
+                  lastProbeTime:
+                    description: LastProbeTime stands for the timestamp to probe status
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: LastTransitionTime stands for the timestamp of the
+                      status changed
+                    format: date-time
+                    type: string
+                  logPath:
+                    description: LogPath stands for the path of log
+                    type: string
+                  logo:
+                    description: Logo stands for the product logo with base64 encoded
+                      data uri
+                    type: string
+                  message:
+                    description: Message contains the detail infomation why in current
+                      status
+                    type: string
+                  productType:
+                    description: ProdutctType stands for the product type
+                    type: string
+                  reason:
+                    description: Reason contains the reason why in current status
+                    type: string
+                  runningStatus:
+                    description: RunningStatus stands for the running status
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+              dataServices:
+                description: DataServices stands for the DataServices component's
+                  status
+                properties:
+                  brief:
+                    description: Brief stands for the product's brief
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  deployStatus:
+                    description: DeployStatus stands for the deploy status
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    description: DeployTime stands for the timestamp to deploy this
+                      component
+                    format: date-time
+                    type: string
+                  description:
+                    description: Description stands for the product's description
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  displayName:
+                    description: DisplayName stands for the product's display name
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  entrypoint:
+                    description: Entrypoint is the entrypoint of this component
+                    type: string
+                  lastProbeTime:
+                    description: LastProbeTime stands for the timestamp to probe status
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: LastTransitionTime stands for the timestamp of the
+                      status changed
+                    format: date-time
+                    type: string
+                  logPath:
+                    description: LogPath stands for the path of log
+                    type: string
+                  logo:
+                    description: Logo stands for the product logo with base64 encoded
+                      data uri
+                    type: string
+                  message:
+                    description: Message contains the detail infomation why in current
+                      status
+                    type: string
+                  productType:
+                    description: ProdutctType stands for the product type
+                    type: string
+                  reason:
+                    description: Reason contains the reason why in current status
+                    type: string
+                  runningStatus:
+                    description: RunningStatus stands for the running status
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+              deletable:
+                description: Deletable tell if this product can be delete
+                type: boolean
+              devops:
+                description: Devops stands for the Devops component's status
+                properties:
+                  brief:
+                    description: Brief stands for the product's brief
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  deployStatus:
+                    description: DeployStatus stands for the deploy status
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    description: DeployTime stands for the timestamp to deploy this
+                      component
+                    format: date-time
+                    type: string
+                  description:
+                    description: Description stands for the product's description
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  displayName:
+                    description: DisplayName stands for the product's display name
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  entrypoint:
+                    description: Entrypoint is the entrypoint of this component
+                    type: string
+                  lastProbeTime:
+                    description: LastProbeTime stands for the timestamp to probe status
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: LastTransitionTime stands for the timestamp of the
+                      status changed
+                    format: date-time
+                    type: string
+                  logPath:
+                    description: LogPath stands for the path of log
+                    type: string
+                  logo:
+                    description: Logo stands for the product logo with base64 encoded
+                      data uri
+                    type: string
+                  message:
+                    description: Message contains the detail infomation why in current
+                      status
+                    type: string
+                  productType:
+                    description: ProdutctType stands for the product type
+                    type: string
+                  reason:
+                    description: Reason contains the reason why in current status
+                    type: string
+                  runningStatus:
+                    description: RunningStatus stands for the running status
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+              globalID:
+                description: GlobalID stands for the global Id
+                type: string
+              phase:
+                description: Phase stands for this product's phase
+                enum:
+                - Pending
+                - Provisioning
+                - Deleting
+                - Failed
+                - Running
+                type: string
+              productEntrypoint:
+                description: ProductEntrypoint stands for this product's entrypoint
+                type: string
+              progress:
+                description: Progress stands for the progress of this product
+                type: integer
+              replicas:
+                description: Replicas stands for the product workload replicas
+                type: integer
+              serviceMesh:
+                description: ServiceMesh stands for the ServiceMesh component's status
+                properties:
+                  brief:
+                    description: Brief stands for the product's brief
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  deployStatus:
+                    description: DeployStatus stands for the deploy status
+                    enum:
+                    - NotDeployed
+                    - Pending
+                    - Deploying
+                    - DeployFailed
+                    - Upgrading
+                    - UpgradeFailed
+                    - Completed
+                    type: string
+                  deployTime:
+                    description: DeployTime stands for the timestamp to deploy this
+                      component
+                    format: date-time
+                    type: string
+                  description:
+                    description: Description stands for the product's description
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  displayName:
+                    description: DisplayName stands for the product's display name
+                    properties:
+                      en:
+                        description: EN stands for text with English
+                        type: string
+                      zh:
+                        description: ZH stands for text with Simple Chinese
+                        type: string
+                    type: object
+                  entrypoint:
+                    description: Entrypoint is the entrypoint of this component
+                    type: string
+                  lastProbeTime:
+                    description: LastProbeTime stands for the timestamp to probe status
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: LastTransitionTime stands for the timestamp of the
+                      status changed
+                    format: date-time
+                    type: string
+                  logPath:
+                    description: LogPath stands for the path of log
+                    type: string
+                  logo:
+                    description: Logo stands for the product logo with base64 encoded
+                      data uri
+                    type: string
+                  message:
+                    description: Message contains the detail infomation why in current
+                      status
+                    type: string
+                  productType:
+                    description: ProdutctType stands for the product type
+                    type: string
+                  reason:
+                    description: Reason contains the reason why in current status
+                    type: string
+                  runningStatus:
+                    description: RunningStatus stands for the running status
+                    enum:
+                    - NotRunning
+                    - Healthy
+                    - Abnormal
+                    type: string
+                required:
+                - deployStatus
+                - runningStatus
+                type: object
+              version:
+                description: Version statnds for this product's current version
+                type: string
+            required:
+            - phase
+            - version
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ProductBase is the Schema for the productbases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProductBaseSpec defines the desired state of ProductBase
+            properties:
+              alternativeURLs:
+                description: AlternativeURLs is the platform's alternative urls
+                items:
+                  type: string
+                type: array
+              defaultAdmin:
+                description: DefaultAdmin stands for the admin's config
+                properties:
+                  account:
+                    description: Account stands for admin's account
+                    type: string
+                  email:
+                    description: Email stands for admin's email
+                    type: string
+                  hash:
+                    description: Hash stands for admin's password hash
+                    type: string
+                required:
+                - account
+                - email
+                type: object
+              defaultRedirectPath:
+                description: DefaultRedirectPath stands for the default redirect path
+                type: string
+              globalConfig:
+                description: GlobalConfig stands for the global config
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              http:
+                description: HTTP stands for the http config
+                properties:
+                  forceRedirectHttps:
+                    description: ForceRedirectHTTPS stands for if force redirect to
+                      https
+                    type: boolean
+                  httpPort:
+                    description: HTTPPort is the port of http
+                    type: integer
+                  httpsPort:
+                    description: HTTPPort is the port of https
+                    type: integer
+                  tls:
+                    description: TLS statnds for the server's TLS Certificate
+                    properties:
+                      secretRef:
+                        description: SecretRef is the reference for tls secret
+                        properties:
+                          name:
+                            description: Name is the name of secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                required:
+                - forceRedirectHttps
+                type: object
+              ingress:
+                description: Ingress stands for the ingress configs
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  controller:
+                    description: Controller stands for the ingress controller configs
+                    properties:
+                      install:
+                        description: Install stands for if install ingress controller
+                        type: boolean
+                      nodes:
+                        description: Nodes stands for the ingress controller's running
+                          node
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - install
+                    type: object
+                  host:
+                    description: Host stands for the host config in ingress
+                    type: string
+                  ingressClassName:
+                    description: IngressClassName stands for the ingressClassName
+                      of the ingress
+                    type: string
+                required:
+                - controller
+                - host
+                - ingressClassName
+                type: object
+              platformPublicURL:
+                description: PlatformPublicURL stands the platform's public url
+                type: string
+              platformURL:
+                description: PlatformURL is the platform's access url
+                type: string
+              productBrand:
+                description: 'ProductBrand values: TKE、ACP、Common'
+                type: string
+              registry:
+                description: Registry is Docker Registry's Config
+                properties:
+                  address:
+                    description: Address is Docker Registry's address
+                    type: string
+                  external:
+                    description: External stands for a external registry
+                    type: boolean
+                  preferPlatformURL:
+                    description: PreferPlatformURL stands for business cluster prefer
+                      platform URL as registry address
+                    type: boolean
+                  secretRef:
+                    description: SecretRef is the reference for  pullImageSecret
+                    properties:
+                      name:
+                        description: Name is the name of secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - address
+                - preferPlatformURL
+                type: object
+              replicas:
+                description: Replicas stands for the deploy replicas
+                type: integer
+              version:
+                description: Version stands for this product's version to deploy
+                type: string
+            required:
+            - defaultAdmin
+            - http
+            - platformURL
+            - registry
+            - version
+            type: object
+          status:
+            description: ProductBaseStatus defines the observed state of ProductBase
+            properties:
+              artifacts:
+                description: Artifacts stands for the product's artifacts
+                items:
+                  description: Artifact stands for the artifact's info
+                  properties:
+                    channels:
+                      description: Channels stands for the artifact's channels
+                      items:
+                        description: Channel stands for the artifact's channel
+                        properties:
+                          artifactStatus:
+                            description: ArtifactStatus stands for the channel's artifact
+                              status
+                            type: string
+                          brief:
+                            description: Brief stands for the artifact's brief
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          catalogSource:
+                            description: CatalogSource stands for the catalog source
+                              to get the operator bundle
+                            type: string
+                          categories:
+                            description: 'Categories stands for the artifact''s categories,
+                              such as: AI, Database, etc.'
+                            items:
+                              type: string
+                            type: array
+                          channel:
+                            description: Channel stands for the channel's name
+                            type: string
+                          default:
+                            description: Default stands for the artifact's default
+                              channel
+                            type: boolean
+                          description:
+                            description: Description stands for the channel's description
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          digest:
+                            description: Digest stands for the channel's digest
+                            type: string
+                          displayName:
+                            description: DisplayName stands for the artifact's display
+                              name
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          hidden:
+                            description: Hidden stands for the artifact is hidden
+                              on the Marketplace's page
+                            type: boolean
+                          packIgnore:
+                            description: PackIgnore indicates whether to skip packaging
+                            type: boolean
+                          provider:
+                            description: Provider stands for the artifact's provider
+                            properties:
+                              en:
+                                description: EN stands for text with English
+                                type: string
+                              zh:
+                                description: ZH stands for text with Simple Chinese
+                                type: string
+                            type: object
+                          providerType:
+                            description: 'ProviderType stands for the artifact''s
+                              provider type, such as: platform, certified, custom,
+                              community'
+                            type: string
+                          repository:
+                            description: Repository stands for the channel's repository
+                            type: string
+                          supportedArchitectures:
+                            description: 'SupportedArchitectures stands for the supported
+                              architectures, such as: amd64, arm64, etc.'
+                            items:
+                              type: string
+                            type: array
+                          supportedPlatformVersions:
+                            description: 'SupportedPlatformVersions stands for the
+                              supported platform versions, such as: v4.0, v4.1, etc.'
+                            items:
+                              type: string
+                            type: array
+                          supportedProtocolStacks:
+                            description: 'SupportedProtocolStacks stands for the supported
+                              protocol stacks, such as: IPv4, IPv6, DualStack, etc.'
+                            items:
+                              type: string
+                            type: array
+                          tag:
+                            description: Tag stands for the channel's tag
+                            type: string
+                        required:
+                        - artifactStatus
+                        - channel
+                        - default
+                        - displayName
+                        - repository
+                        - tag
+                        type: object
+                      type: array
+                    name:
+                      description: Name stands for the artifact's name
+                      type: string
+                    packageType:
+                      description: PackageType stands for the artifact's package type
+                      type: string
+                  required:
+                  - channels
+                  - name
+                  - packageType
+                  type: object
+                type: array
+              conditions:
+                description: Conditions contains this product's conditions
+                items:
+                  description: ProductBaseCondition ...
+                  properties:
+                    lastHeartbeatTime:
+                      description: LastHeartbeatTime stands for the timestamp to check
+                        Condition
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: LastTransitionTime stands for the timestamp of
+                        Condition's status changed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message stands for Condition's message
+                      type: string
+                    reason:
+                      description: Reason stands for Condition's reason
+                      type: string
+                    status:
+                      description: Status stands for Condition's status
+                      type: string
+                    type:
+                      description: Type stands for Condition's type
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              globalID:
+                description: GlobalID stands for the global Id
+                type: string
+              phase:
+                description: Phase stands for this product's phase
+                enum:
+                - Pending
+                - Provisioning
+                - Deleting
+                - Failed
+                - Running
+                type: string
+              replicas:
+                description: Replicas stands for the product workload replicas
+                type: integer
+              version:
+                description: Version statnds for this product's current version
+                type: string
+            required:
+            - phase
+            - version
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/docs/shared/crds/product-config.yaml
+++ b/docs/shared/crds/product-config.yaml
@@ -1,0 +1,343 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: productconfigs.alauda.io
+spec:
+  group: alauda.io
+  names:
+    kind: ProductConfig
+    listKind: ProductConfigList
+    plural: productconfigs
+    shortNames:
+      - prdc
+    singular: productconfig
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Status
+          type: string
+        - jsonPath: .spec.availableVersion
+          name: Version
+          type: string
+        - jsonPath: .spec.productResource.names.kind
+          name: Product-Kind
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ProductConfig is the Schema for the productconfigs API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ProductConfigSpec defines the desired state of ProductConfig
+              properties:
+                availableVersion:
+                  description: AvailableVersion stands for the available version to
+                    deploy
+                  type: string
+                brief:
+                  description: Brief stands for the product's brief
+                  properties:
+                    en:
+                      description: EN stands for text with English
+                      type: string
+                    zh:
+                      description: ZH stands for text with Simple Chinese
+                      type: string
+                  type: object
+                chartVersions:
+                  description: ChartVersions stands for the charts when deploying, they
+                    are optional and will be added to the Prouct CR
+                  items:
+                    description: ChartVersion stands for chart version
+                    properties:
+                      name:
+                        description: Name stands for the chart's name
+                        type: string
+                      version:
+                        description: Version stands for the chart's version
+                        type: string
+                    required:
+                      - name
+                      - version
+                    type: object
+                  type: array
+                commonConfigRef:
+                  description: CommonConfigRef stands for the reference from CommonConfig
+                    to Product CR
+                  items:
+                    description: KeysRef stands for key references with specified version
+                    properties:
+                      keys:
+                        description: Keys stands for a set of keys
+                        items:
+                          description: KeyRef stands for key reference
+                          properties:
+                            refKey:
+                              description: RefKey stands for source key
+                              type: string
+                            targetKey:
+                              description: TargetKey stands for target key
+                              type: string
+                          required:
+                            - refKey
+                            - targetKey
+                          type: object
+                        type: array
+                      versionMatch:
+                        description: VersionMatch stands for the target version
+                        type: string
+                    required:
+                      - keys
+                      - versionMatch
+                    type: object
+                  type: array
+                description:
+                  description: Description stands for the product's description
+                  properties:
+                    en:
+                      description: EN stands for text with English
+                      type: string
+                    zh:
+                      description: ZH stands for text with Simple Chinese
+                      type: string
+                  type: object
+                displayName:
+                  description: DisplayName stands for the product's display name
+                  properties:
+                    en:
+                      description: EN stands for text with English
+                      type: string
+                    zh:
+                      description: ZH stands for text with Simple Chinese
+                      type: string
+                  type: object
+                displayUIConfig:
+                  description: DisplayUIConfig stands for the web UI type when showing
+                    product's detail information
+                  properties:
+                    scheme:
+                      description: Scheme defines the dynamic form, used when Type is
+                        DynamicForm
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    type:
+                      description: Type defines the web UI type, [InUnderlord is DEPRECATED,
+                        use SubApp instead]
+                      enum:
+                        - None
+                        - DynamicForm
+                        - InUnderlord
+                        - SingleApp
+                        - SubApp
+                      type: string
+                  required:
+                    - type
+                  type: object
+                installUIConfig:
+                  description: InstallUIConfig stands for the web UI config when deploying
+                    product
+                  properties:
+                    scheme:
+                      description: Scheme defines the dynamic form, used when Type is
+                        DynamicForm
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    type:
+                      description: Type defines the web UI type, [InUnderlord is DEPRECATED,
+                        use SubApp instead]
+                      enum:
+                        - None
+                        - DynamicForm
+                        - InUnderlord
+                        - SingleApp
+                        - SubApp
+                      type: string
+                  required:
+                    - type
+                  type: object
+                isDisplay:
+                  description: IsDisplay stands for if the product displaying on the
+                    products list
+                  type: boolean
+                logo:
+                  description: Logo stands for the product logo with base64 encoded
+                    data uri
+                  type: string
+                platformVersionMatch:
+                  description: PlatformVersionMatch stands for the product need match
+                    the platform version
+                  type: string
+                productResource:
+                  description: ProductResource defines the target product CRD type
+                  properties:
+                    group:
+                      description: Group stands for the target product's CRD Group
+                      type: string
+                    names:
+                      description: Names stands for the target product's CRD's kind
+                        name
+                      properties:
+                        categories:
+                          description: categories is a list of grouped resources this
+                            custom resource belongs to (e.g. 'all'). This is published
+                            in API discovery documents, and used by clients to support
+                            invocations like `kubectl get all`.
+                          items:
+                            type: string
+                          type: array
+                        kind:
+                          description: kind is the serialized kind of the resource.
+                            It is normally CamelCase and singular. Custom resource instances
+                            will use this value as the `kind` attribute in API calls.
+                          type: string
+                        listKind:
+                          description: listKind is the serialized kind of the list for
+                            this resource. Defaults to "`kind`List".
+                          type: string
+                        plural:
+                          description: plural is the plural name of the resource to
+                            serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
+                            Must match the name of the CustomResourceDefinition (in
+                            the form `<names.plural>.<group>`). Must be all lowercase.
+                          type: string
+                        shortNames:
+                          description: shortNames are short names for the resource,
+                            exposed in API discovery documents, and used by clients
+                            to support invocations like `kubectl get <shortname>`. It
+                            must be all lowercase.
+                          items:
+                            type: string
+                          type: array
+                        singular:
+                          description: singular is the singular name of the resource.
+                            It must be all lowercase. Defaults to lowercased `kind`.
+                          type: string
+                      required:
+                        - kind
+                        - plural
+                      type: object
+                    version:
+                      description: Version stands for the target product's CRD version
+                      type: string
+                  required:
+                    - group
+                    - names
+                    - version
+                  type: object
+                singleApp:
+                  description: SingleAppConfig stands for the config for SignleApp type
+                  properties:
+                    entrypoint:
+                      description: Entrypoint stands for the entrypoint of standalone
+                        app
+                      type: string
+                  required:
+                    - entrypoint
+                  type: object
+                subApp:
+                  description: SubApp stands for the config for SubApp type
+                  properties:
+                    entrypoint:
+                      description: Entrypoint stands for the entrypoint of sub app
+                      type: string
+                    name:
+                      description: Name stands for the name of sub app
+                      type: string
+                  required:
+                    - entrypoint
+                    - name
+                  type: object
+                type:
+                  description: Type  stands for the product's type
+                  type: string
+                upgradeUIConfig:
+                  description: UpgradeUIConfig stands for the web UI config when upgrading
+                    product
+                  items:
+                    description: VersionedUIConfig stands for the web UI type with special
+                      version
+                    properties:
+                      scheme:
+                        description: Scheme defines the dynamic form, used when Type
+                          is DynamicForm
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      type:
+                        description: Type defines the web UI type, [InUnderlord is DEPRECATED,
+                          use SubApp instead]
+                        enum:
+                          - None
+                          - DynamicForm
+                          - InUnderlord
+                          - SingleApp
+                          - SubApp
+                        type: string
+                      versionMatch:
+                        description: VersionMatch stands for the target version
+                        type: string
+                    required:
+                      - type
+                      - versionMatch
+                    type: object
+                  type: array
+                upgradeableVersions:
+                  description: UpgradeableVersions stands for the versions can upgrade
+                    from
+                  items:
+                    type: string
+                  type: array
+              required:
+                - availableVersion
+                - brief
+                - description
+                - displayName
+                - displayUIConfig
+                - installUIConfig
+                - logo
+                - platformVersionMatch
+                - productResource
+                - type
+              type: object
+            status:
+              description: ProductConfigStatus defines the observed state of ProductConfig
+              properties:
+                message:
+                  description: Message contains the detail messages about the status
+                  type: string
+                phase:
+                  description: Phase stands for the ProductConfig's status
+                  enum:
+                    - Initializing
+                    - Ready
+                    - Terminating
+                  type: string
+                reason:
+                  description: Reason explain why the ProductCongfig in this status
+                  type: string
+              required:
+                - message
+                - phase
+                - reason
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/docs/shared/crds/product-config.yaml
+++ b/docs/shared/crds/product-config.yaml
@@ -33,14 +33,16 @@ spec:
           description: ProductConfig is the Schema for the productconfigs API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object

--- a/docs/shared/crds/product-upgrade.yaml
+++ b/docs/shared/crds/product-upgrade.yaml
@@ -1,0 +1,219 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: productupgrades.product.alauda.io
+spec:
+  group: product.alauda.io
+  names:
+    kind: ProductUpgrade
+    listKind: ProductUpgradeList
+    plural: productupgrades
+    shortNames:
+    - prdu
+    singular: productupgrade
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ProductUpgrade is the Schema for the productupgrades API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProductUpgradeSpec defines the desired state of ProductUpgrade
+            properties:
+              onlineUpgrade:
+                description: OnlineUpgrade is the online upgrade configuration
+                properties:
+                  checkFrequency:
+                    description: CheckFrequency is the frequency to check for new
+                      version
+                    type: integer
+                  enable:
+                    description: Enable is a flag to enable online upgrade
+                    type: boolean
+                  enableMsgNotify:
+                    description: EnableMsgNotify is a flag to enable message notification
+                    type: boolean
+                required:
+                - checkFrequency
+                - enable
+                - enableMsgNotify
+                type: object
+              pause:
+                description: Pause is a flag to pause the upgrade
+                type: boolean
+              targetArch:
+                description: TargetArch is the architecture of the product to upgrade
+                  to
+                type: string
+              targetVersion:
+                description: TargetVersion is the version of the product to upgrade
+                  to
+                type: string
+              type:
+                description: Type is the type of product upgrade
+                type: string
+              upgrade:
+                description: Upgrade is a flag of to do the upgrade
+                type: boolean
+            required:
+            - onlineUpgrade
+            type: object
+          status:
+            description: ProductUpgradeStatus defines the observed state of ProductUpgrade
+            properties:
+              lastCheckTimestamp:
+                description: LastCheckTimestamp is the last time the product upgrade
+                  was checked
+                format: date-time
+                type: string
+              message:
+                description: Message is the message of the product upgrade
+                type: string
+              phase:
+                description: Phase is the phase of the product upgrade
+                type: string
+              preheatVersions:
+                description: PreHeatVersions is the pre-heat histories of the product
+                  upgrade
+                items:
+                  description: PreheatHistory defines the pre-heat history
+                  properties:
+                    arch:
+                      description: Arch is the architecture of the new version
+                      type: string
+                    artifactsAll:
+                      description: ArtifactsAll is the number of artifacts
+                      type: integer
+                    artifactsSynced:
+                      description: ArtifactsSynced is the number of artifacts synced
+                      type: integer
+                    baseOperatorVer:
+                      description: BaseOperatorVer is the version of the base operator
+                      type: string
+                    preHeatEndTime:
+                      description: PreHeatEndTime is the end time of pre-heat
+                      format: date-time
+                      type: string
+                    preHeatStartTime:
+                      description: PreHeatStartTime is the start time of pre-heat
+                      format: date-time
+                      type: string
+                    progress:
+                      description: Progress is the progress of pre-heat
+                      type: integer
+                    status:
+                      description: PreHeatStatus is the pre-heat status
+                      type: string
+                    version:
+                      description: Version is the version of the product to upgrade
+                        to
+                      type: string
+                  required:
+                  - arch
+                  - status
+                  - version
+                  type: object
+                type: array
+              source:
+                description: OnlineUpgradeSource is the source of online upgrade
+                properties:
+                  envId:
+                    description: EnvId is the environment id
+                    type: integer
+                  insecure:
+                    description: Insecure is a flag to enable insecure registry
+                    type: boolean
+                  plainHttp:
+                    description: PlainHttp is a flag to enable plain http
+                    type: boolean
+                  registry:
+                    description: Registry is the cloud registry
+                    type: string
+                  tenantId:
+                    description: TenantId is the tenant id
+                    type: integer
+                required:
+                - registry
+                type: object
+              status:
+                description: Status is the status of the product upgrade
+                type: string
+              upgradable:
+                default: false
+                description: Upgradable is a flag to indicate whether the product
+                  is upgradable
+                type: boolean
+              upgradeBlockReason:
+                description: UpgradeBlockReason is the reason why the product is not
+                  upgradable
+                type: string
+              upgradePaths:
+                description: UpgradePaths is the upgrade paths of the product upgrade
+                items:
+                  description: UpgradePath defines the upgrade path
+                  properties:
+                    arches:
+                      description: Arches is the architectures of the new version
+                      items:
+                        type: string
+                      type: array
+                    release:
+                      description: Release is the release version of the product to
+                        upgrade to
+                      type: string
+                    sizes:
+                      description: Sizes is the architectures of the new version
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    tags:
+                      description: Tags is the tags of the new version
+                      items:
+                        type: string
+                      type: array
+                    version:
+                      description: Version is the version of the product to upgrade
+                        to
+                      type: string
+                  required:
+                  - arches
+                  - release
+                  - sizes
+                  - version
+                  type: object
+                type: array
+            required:
+            - phase
+            - source
+            - status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/docs/shared/crds/velero.io_backuprepositories.yaml
+++ b/docs/shared/crds/velero.io_backuprepositories.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: backuprepositories.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: BackupRepository
+    listKind: BackupRepositoryList
+    plural: backuprepositories
+    singular: backuprepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.repositoryType
+      name: Repository Type
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackupRepositorySpec is the specification for a BackupRepository.
+            properties:
+              backupStorageLocation:
+                description: |-
+                  BackupStorageLocation is the name of the BackupStorageLocation
+                  that should contain this repository.
+                type: string
+              maintenanceFrequency:
+                description: MaintenanceFrequency is how often maintenance should
+                  be run.
+                type: string
+              repositoryConfig:
+                additionalProperties:
+                  type: string
+                description: RepositoryConfig is for repository-specific configuration
+                  fields.
+                nullable: true
+                type: object
+              repositoryType:
+                description: RepositoryType indicates the type of the backend repository
+                enum:
+                - kopia
+                - restic
+                - ""
+                type: string
+              resticIdentifier:
+                description: |-
+                  ResticIdentifier is the full restic-compatible string for identifying
+                  this repository.
+                type: string
+              volumeNamespace:
+                description: |-
+                  VolumeNamespace is the namespace this backup repository contains
+                  pod volume backups for.
+                type: string
+            required:
+            - backupStorageLocation
+            - maintenanceFrequency
+            - resticIdentifier
+            - volumeNamespace
+            type: object
+          status:
+            description: BackupRepositoryStatus is the current status of a BackupRepository.
+            properties:
+              lastMaintenanceTime:
+                description: LastMaintenanceTime is the last time maintenance was
+                  run.
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: Message is a message about the current status of the
+                  BackupRepository.
+                type: string
+              phase:
+                description: Phase is the current state of the BackupRepository.
+                enum:
+                - New
+                - Ready
+                - NotReady
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/velero.io_backups.yaml
+++ b/docs/shared/crds/velero.io_backups.yaml
@@ -1,0 +1,660 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: backups.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    singular: backup
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Backup is a Velero resource that represents the capture of Kubernetes
+          cluster state at a point in time (API objects and associated volume state).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackupSpec defines the specification for a Velero backup.
+            properties:
+              csiSnapshotTimeout:
+                description: |-
+                  CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
+                  ReadyToUse during creation, before returning error as timeout.
+                  The default value is 10 minute.
+                type: string
+              datamover:
+                description: |-
+                  DataMover specifies the data mover to be used by the backup.
+                  If DataMover is "" or "velero", the built-in data mover will be used.
+                type: string
+              defaultVolumesToFsBackup:
+                description: |-
+                  DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
+                  for all volumes by default.
+                nullable: true
+                type: boolean
+              defaultVolumesToRestic:
+                description: |-
+                  DefaultVolumesToRestic specifies whether restic should be used to take a
+                  backup of all pod volumes by default.
+
+
+                  Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
+                nullable: true
+                type: boolean
+              excludedClusterScopedResources:
+                description: |-
+                  ExcludedClusterScopedResources is a slice of cluster-scoped
+                  resource type names to exclude from the backup.
+                  If set to "*", all cluster-scoped resource types are excluded.
+                  The default value is empty.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              excludedNamespaceScopedResources:
+                description: |-
+                  ExcludedNamespaceScopedResources is a slice of namespace-scoped
+                  resource type names to exclude from the backup.
+                  If set to "*", all namespace-scoped resource types are excluded.
+                  The default value is empty.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              excludedNamespaces:
+                description: |-
+                  ExcludedNamespaces contains a list of namespaces that are not
+                  included in the backup.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              excludedResources:
+                description: |-
+                  ExcludedResources is a slice of resource names that are not
+                  included in the backup.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              hooks:
+                description: Hooks represent custom behaviors that should be executed
+                  at different phases of the backup.
+                properties:
+                  resources:
+                    description: Resources are hooks that should be executed when
+                      backing up individual instances of a resource.
+                    items:
+                      description: |-
+                        BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
+                        the rules defined for namespaces, resources, and label selector.
+                      properties:
+                        excludedNamespaces:
+                          description: ExcludedNamespaces specifies the namespaces
+                            to which this hook spec does not apply.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        excludedResources:
+                          description: ExcludedResources specifies the resources to
+                            which this hook spec does not apply.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedNamespaces:
+                          description: |-
+                            IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                            to all namespaces.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedResources:
+                          description: |-
+                            IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                            to all resources.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        labelSelector:
+                          description: LabelSelector, if specified, filters the resources
+                            to which this hook spec applies.
+                          nullable: true
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        name:
+                          description: Name is the name of this hook.
+                          type: string
+                        post:
+                          description: |-
+                            PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
+                            These are executed after all "additional items" from item actions are processed.
+                          items:
+                            description: BackupResourceHook defines a hook for a resource.
+                            properties:
+                              exec:
+                                description: Exec defines an exec hook.
+                                properties:
+                                  command:
+                                    description: Command is the command and arguments
+                                      to execute.
+                                    items:
+                                      type: string
+                                    minItems: 1
+                                    type: array
+                                  container:
+                                    description: |-
+                                      Container is the container in the pod where the command should be executed. If not specified,
+                                      the pod's first container is used.
+                                    type: string
+                                  onError:
+                                    description: OnError specifies how Velero should
+                                      behave if it encounters an error executing this
+                                      hook.
+                                    enum:
+                                    - Continue
+                                    - Fail
+                                    type: string
+                                  timeout:
+                                    description: |-
+                                      Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                      considering the execution a failure.
+                                    type: string
+                                required:
+                                - command
+                                type: object
+                            required:
+                            - exec
+                            type: object
+                          type: array
+                        pre:
+                          description: |-
+                            PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
+                            These are executed before any "additional items" from item actions are processed.
+                          items:
+                            description: BackupResourceHook defines a hook for a resource.
+                            properties:
+                              exec:
+                                description: Exec defines an exec hook.
+                                properties:
+                                  command:
+                                    description: Command is the command and arguments
+                                      to execute.
+                                    items:
+                                      type: string
+                                    minItems: 1
+                                    type: array
+                                  container:
+                                    description: |-
+                                      Container is the container in the pod where the command should be executed. If not specified,
+                                      the pod's first container is used.
+                                    type: string
+                                  onError:
+                                    description: OnError specifies how Velero should
+                                      behave if it encounters an error executing this
+                                      hook.
+                                    enum:
+                                    - Continue
+                                    - Fail
+                                    type: string
+                                  timeout:
+                                    description: |-
+                                      Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                      considering the execution a failure.
+                                    type: string
+                                required:
+                                - command
+                                type: object
+                            required:
+                            - exec
+                            type: object
+                          type: array
+                      required:
+                      - name
+                      type: object
+                    nullable: true
+                    type: array
+                type: object
+              includeClusterResources:
+                description: |-
+                  IncludeClusterResources specifies whether cluster-scoped resources
+                  should be included for consideration in the backup.
+                nullable: true
+                type: boolean
+              includedClusterScopedResources:
+                description: |-
+                  IncludedClusterScopedResources is a slice of cluster-scoped
+                  resource type names to include in the backup.
+                  If set to "*", all cluster-scoped resource types are included.
+                  The default value is empty, which means only related
+                  cluster-scoped resources are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              includedNamespaceScopedResources:
+                description: |-
+                  IncludedNamespaceScopedResources is a slice of namespace-scoped
+                  resource type names to include in the backup.
+                  The default value is "*".
+                items:
+                  type: string
+                nullable: true
+                type: array
+              includedNamespaces:
+                description: |-
+                  IncludedNamespaces is a slice of namespace names to include objects
+                  from. If empty, all namespaces are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              includedResources:
+                description: |-
+                  IncludedResources is a slice of resource names to include
+                  in the backup. If empty, all resources are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              itemOperationTimeout:
+                description: |-
+                  ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
+                  The default value is 4 hour.
+                type: string
+              labelSelector:
+                description: |-
+                  LabelSelector is a metav1.LabelSelector to filter with
+                  when adding individual objects to the backup. If empty
+                  or nil, all objects are included. Optional.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              metadata:
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              orLabelSelectors:
+                description: |-
+                  OrLabelSelectors is list of metav1.LabelSelector to filter with
+                  when adding individual objects to the backup. If multiple provided
+                  they will be joined by the OR operator. LabelSelector as well as
+                  OrLabelSelectors cannot co-exist in backup request, only one of them
+                  can be used.
+                items:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                nullable: true
+                type: array
+              orderedResources:
+                additionalProperties:
+                  type: string
+                description: |-
+                  OrderedResources specifies the backup order of resources of specific Kind.
+                  The map key is the resource name and value is a list of object names separated by commas.
+                  Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
+                nullable: true
+                type: object
+              resourcePolicy:
+                description: ResourcePolicy specifies the referenced resource policies
+                  that backup should follow
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              snapshotMoveData:
+                description: SnapshotMoveData specifies whether snapshot data should
+                  be moved
+                nullable: true
+                type: boolean
+              snapshotVolumes:
+                description: |-
+                  SnapshotVolumes specifies whether to take snapshots
+                  of any PV's referenced in the set of objects included
+                  in the Backup.
+                nullable: true
+                type: boolean
+              storageLocation:
+                description: StorageLocation is a string containing the name of a
+                  BackupStorageLocation where the backup should be stored.
+                type: string
+              ttl:
+                description: |-
+                  TTL is a time.Duration-parseable string describing how long
+                  the Backup should be retained for.
+                type: string
+              uploaderConfig:
+                description: UploaderConfig specifies the configuration for the uploader.
+                nullable: true
+                properties:
+                  parallelFilesUpload:
+                    description: ParallelFilesUpload is the number of files parallel
+                      uploads to perform when using the uploader.
+                    type: integer
+                type: object
+              volumeSnapshotLocations:
+                description: VolumeSnapshotLocations is a list containing names of
+                  VolumeSnapshotLocations associated with this backup.
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: BackupStatus captures the current status of a Velero backup.
+            properties:
+              backupItemOperationsAttempted:
+                description: |-
+                  BackupItemOperationsAttempted is the total number of attempted
+                  async BackupItemAction operations for this backup.
+                type: integer
+              backupItemOperationsCompleted:
+                description: |-
+                  BackupItemOperationsCompleted is the total number of successfully completed
+                  async BackupItemAction operations for this backup.
+                type: integer
+              backupItemOperationsFailed:
+                description: |-
+                  BackupItemOperationsFailed is the total number of async
+                  BackupItemAction operations for this backup which ended with an error.
+                type: integer
+              completionTimestamp:
+                description: |-
+                  CompletionTimestamp records the time a backup was completed.
+                  Completion time is recorded even on failed backups.
+                  Completion time is recorded before uploading the backup object.
+                  The server's time is used for CompletionTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              csiVolumeSnapshotsAttempted:
+                description: |-
+                  CSIVolumeSnapshotsAttempted is the total number of attempted
+                  CSI VolumeSnapshots for this backup.
+                type: integer
+              csiVolumeSnapshotsCompleted:
+                description: |-
+                  CSIVolumeSnapshotsCompleted is the total number of successfully
+                  completed CSI VolumeSnapshots for this backup.
+                type: integer
+              errors:
+                description: |-
+                  Errors is a count of all error messages that were generated during
+                  execution of the backup.  The actual errors are in the backup's log
+                  file in object storage.
+                type: integer
+              expiration:
+                description: Expiration is when this Backup is eligible for garbage-collection.
+                format: date-time
+                nullable: true
+                type: string
+              failureReason:
+                description: FailureReason is an error that caused the entire backup
+                  to fail.
+                type: string
+              formatVersion:
+                description: FormatVersion is the backup format version, including
+                  major, minor, and patch version.
+                type: string
+              hookStatus:
+                description: HookStatus contains information about the status of the
+                  hooks.
+                nullable: true
+                properties:
+                  hooksAttempted:
+                    description: |-
+                      HooksAttempted is the total number of attempted hooks
+                      Specifically, HooksAttempted represents the number of hooks that failed to execute
+                      and the number of hooks that executed successfully.
+                    type: integer
+                  hooksFailed:
+                    description: HooksFailed is the total number of hooks which ended
+                      with an error
+                    type: integer
+                type: object
+              phase:
+                description: Phase is the current state of the Backup.
+                enum:
+                - New
+                - FailedValidation
+                - InProgress
+                - WaitingForPluginOperations
+                - WaitingForPluginOperationsPartiallyFailed
+                - Finalizing
+                - FinalizingPartiallyFailed
+                - Completed
+                - PartiallyFailed
+                - Failed
+                - Deleting
+                type: string
+              progress:
+                description: |-
+                  Progress contains information about the backup's execution progress. Note
+                  that this information is best-effort only -- if Velero fails to update it
+                  during a backup for any reason, it may be inaccurate/stale.
+                nullable: true
+                properties:
+                  itemsBackedUp:
+                    description: |-
+                      ItemsBackedUp is the number of items that have actually been written to the
+                      backup tarball so far.
+                    type: integer
+                  totalItems:
+                    description: |-
+                      TotalItems is the total number of items to be backed up. This number may change
+                      throughout the execution of the backup due to plugins that return additional related
+                      items to back up, the velero.io/exclude-from-backup label, and various other
+                      filters that happen as items are processed.
+                    type: integer
+                type: object
+              startTimestamp:
+                description: |-
+                  StartTimestamp records the time a backup was started.
+                  Separate from CreationTimestamp, since that value changes
+                  on restores.
+                  The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              validationErrors:
+                description: |-
+                  ValidationErrors is a slice of all validation errors (if
+                  applicable).
+                items:
+                  type: string
+                nullable: true
+                type: array
+              version:
+                description: |-
+                  Version is the backup format major version.
+                  Deprecated: Please see FormatVersion
+                type: integer
+              volumeSnapshotsAttempted:
+                description: |-
+                  VolumeSnapshotsAttempted is the total number of attempted
+                  volume snapshots for this backup.
+                type: integer
+              volumeSnapshotsCompleted:
+                description: |-
+                  VolumeSnapshotsCompleted is the total number of successfully
+                  completed volume snapshots for this backup.
+                type: integer
+              warnings:
+                description: |-
+                  Warnings is a count of all warning messages that were generated during
+                  execution of the backup. The actual warnings are in the backup's log
+                  file in object storage.
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/docs/shared/crds/velero.io_backupstoragelocations.yaml
+++ b/docs/shared/crds/velero.io_backupstoragelocations.yaml
@@ -1,0 +1,188 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: backupstoragelocations.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: BackupStorageLocation
+    listKind: BackupStorageLocationList
+    plural: backupstoragelocations
+    shortNames:
+    - bsl
+    singular: backupstoragelocation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Backup Storage Location status such as Available/Unavailable
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: LastValidationTime is the last time the backup store location was
+        validated
+      jsonPath: .status.lastValidationTime
+      name: Last Validated
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Default backup storage location
+      jsonPath: .spec.default
+      name: Default
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: BackupStorageLocation is a location where Velero stores backup
+          objects
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackupStorageLocationSpec defines the desired state of a
+              Velero BackupStorageLocation
+            properties:
+              accessMode:
+                description: AccessMode defines the permissions for the backup storage
+                  location.
+                enum:
+                - ReadOnly
+                - ReadWrite
+                type: string
+              backupSyncPeriod:
+                description: BackupSyncPeriod defines how frequently to sync backup
+                  API objects from object storage. A value of 0 disables sync.
+                nullable: true
+                type: string
+              config:
+                additionalProperties:
+                  type: string
+                description: Config is for provider-specific configuration fields.
+                type: object
+              credential:
+                description: Credential contains the credential information intended
+                  to be used with this location
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              default:
+                description: Default indicates this location is the default backup
+                  storage location.
+                type: boolean
+              objectStorage:
+                description: ObjectStorageLocation specifies the settings necessary
+                  to connect to a provider's object storage.
+                properties:
+                  bucket:
+                    description: Bucket is the bucket to use for object storage.
+                    type: string
+                  caCert:
+                    description: CACert defines a CA bundle to use when verifying
+                      TLS connections to the provider.
+                    format: byte
+                    type: string
+                  prefix:
+                    description: Prefix is the path inside a bucket to use for Velero
+                      storage. Optional.
+                    type: string
+                required:
+                - bucket
+                type: object
+              provider:
+                description: Provider is the provider of the backup storage.
+                type: string
+              validationFrequency:
+                description: ValidationFrequency defines how frequently to validate
+                  the corresponding object storage. A value of 0 disables validation.
+                nullable: true
+                type: string
+            required:
+            - objectStorage
+            - provider
+            type: object
+          status:
+            description: BackupStorageLocationStatus defines the observed state of
+              BackupStorageLocation
+            properties:
+              accessMode:
+                description: |-
+                  AccessMode is an unused field.
+
+
+                  Deprecated: there is now an AccessMode field on the Spec and this field
+                  will be removed entirely as of v2.0.
+                enum:
+                - ReadOnly
+                - ReadWrite
+                type: string
+              lastSyncedRevision:
+                description: |-
+                  LastSyncedRevision is the value of the `metadata/revision` file in the backup
+                  storage location the last time the BSL's contents were synced into the cluster.
+
+
+                  Deprecated: this field is no longer updated or used for detecting changes to
+                  the location's contents and will be removed entirely in v2.0.
+                type: string
+              lastSyncedTime:
+                description: |-
+                  LastSyncedTime is the last time the contents of the location were synced into
+                  the cluster.
+                format: date-time
+                nullable: true
+                type: string
+              lastValidationTime:
+                description: |-
+                  LastValidationTime is the last time the backup store location was validated
+                  the cluster.
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: Message is a message about the backup storage location's
+                  status.
+                type: string
+              phase:
+                description: Phase is the current state of the BackupStorageLocation.
+                enum:
+                - Available
+                - Unavailable
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/velero.io_datadownloads.yaml
+++ b/docs/shared/crds/velero.io_datadownloads.yaml
@@ -1,0 +1,189 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: datadownloads.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: DataDownload
+    listKind: DataDownloadList
+    plural: datadownloads
+    singular: datadownload
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: DataDownload status such as New/InProgress
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Time duration since this DataDownload was started
+      jsonPath: .status.startTimestamp
+      name: Started
+      type: date
+    - description: Completed bytes
+      format: int64
+      jsonPath: .status.progress.bytesDone
+      name: Bytes Done
+      type: integer
+    - description: Total bytes
+      format: int64
+      jsonPath: .status.progress.totalBytes
+      name: Total Bytes
+      type: integer
+    - description: Name of the Backup Storage Location where the backup data is stored
+      jsonPath: .spec.backupStorageLocation
+      name: Storage Location
+      type: string
+    - description: Time duration since this DataDownload was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Name of the node where the DataDownload is processed
+      jsonPath: .status.node
+      name: Node
+      type: string
+    name: v2alpha1
+    schema:
+      openAPIV3Schema:
+        description: DataDownload acts as the protocol between data mover plugins
+          and data mover controller for the datamover restore operation
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DataDownloadSpec is the specification for a DataDownload.
+            properties:
+              backupStorageLocation:
+                description: |-
+                  BackupStorageLocation is the name of the backup storage location
+                  where the backup repository is stored.
+                type: string
+              cancel:
+                description: |-
+                  Cancel indicates request to cancel the ongoing DataDownload. It can be set
+                  when the DataDownload is in InProgress phase
+                type: boolean
+              dataMoverConfig:
+                additionalProperties:
+                  type: string
+                description: DataMoverConfig is for data-mover-specific configuration
+                  fields.
+                type: object
+              datamover:
+                description: |-
+                  DataMover specifies the data mover to be used by the backup.
+                  If DataMover is "" or "velero", the built-in data mover will be used.
+                type: string
+              operationTimeout:
+                description: |-
+                  OperationTimeout specifies the time used to wait internal operations,
+                  before returning error as timeout.
+                type: string
+              snapshotID:
+                description: SnapshotID is the ID of the Velero backup snapshot to
+                  be restored from.
+                type: string
+              sourceNamespace:
+                description: |-
+                  SourceNamespace is the original namespace where the volume is backed up from.
+                  It may be different from SourcePVC's namespace if namespace is remapped during restore.
+                type: string
+              targetVolume:
+                description: TargetVolume is the information of the target PVC and
+                  PV.
+                properties:
+                  namespace:
+                    description: Namespace is the target namespace
+                    type: string
+                  pv:
+                    description: PV is the name of the target PV that is created by
+                      Velero restore
+                    type: string
+                  pvc:
+                    description: PVC is the name of the target PVC that is created
+                      by Velero restore
+                    type: string
+                required:
+                - namespace
+                - pv
+                - pvc
+                type: object
+            required:
+            - backupStorageLocation
+            - operationTimeout
+            - snapshotID
+            - sourceNamespace
+            - targetVolume
+            type: object
+          status:
+            description: DataDownloadStatus is the current status of a DataDownload.
+            properties:
+              completionTimestamp:
+                description: |-
+                  CompletionTimestamp records the time a restore was completed.
+                  Completion time is recorded even on failed restores.
+                  The server's time is used for CompletionTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: Message is a message about the DataDownload's status.
+                type: string
+              node:
+                description: Node is name of the node where the DataDownload is processed.
+                type: string
+              phase:
+                description: Phase is the current state of the DataDownload.
+                enum:
+                - New
+                - Accepted
+                - Prepared
+                - InProgress
+                - Canceling
+                - Canceled
+                - Completed
+                - Failed
+                type: string
+              progress:
+                description: |-
+                  Progress holds the total number of bytes of the snapshot and the current
+                  number of restored bytes. This can be used to display progress information
+                  about the restore operation.
+                properties:
+                  bytesDone:
+                    format: int64
+                    type: integer
+                  totalBytes:
+                    format: int64
+                    type: integer
+                type: object
+              startTimestamp:
+                description: |-
+                  StartTimestamp records the time a restore was started.
+                  The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/velero.io_datauploads.yaml
+++ b/docs/shared/crds/velero.io_datauploads.yaml
@@ -1,0 +1,214 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: datauploads.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: DataUpload
+    listKind: DataUploadList
+    plural: datauploads
+    singular: dataupload
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: DataUpload status such as New/InProgress
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Time duration since this DataUpload was started
+      jsonPath: .status.startTimestamp
+      name: Started
+      type: date
+    - description: Completed bytes
+      format: int64
+      jsonPath: .status.progress.bytesDone
+      name: Bytes Done
+      type: integer
+    - description: Total bytes
+      format: int64
+      jsonPath: .status.progress.totalBytes
+      name: Total Bytes
+      type: integer
+    - description: Name of the Backup Storage Location where this backup should be
+        stored
+      jsonPath: .spec.backupStorageLocation
+      name: Storage Location
+      type: string
+    - description: Time duration since this DataUpload was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Name of the node where the DataUpload is processed
+      jsonPath: .status.node
+      name: Node
+      type: string
+    name: v2alpha1
+    schema:
+      openAPIV3Schema:
+        description: DataUpload acts as the protocol between data mover plugins and
+          data mover controller for the datamover backup operation
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DataUploadSpec is the specification for a DataUpload.
+            properties:
+              backupStorageLocation:
+                description: |-
+                  BackupStorageLocation is the name of the backup storage location
+                  where the backup repository is stored.
+                type: string
+              cancel:
+                description: |-
+                  Cancel indicates request to cancel the ongoing DataUpload. It can be set
+                  when the DataUpload is in InProgress phase
+                type: boolean
+              csiSnapshot:
+                description: If SnapshotType is CSI, CSISnapshot provides the information
+                  of the CSI snapshot.
+                nullable: true
+                properties:
+                  snapshotClass:
+                    description: SnapshotClass is the name of the snapshot class that
+                      the volume snapshot is created with
+                    type: string
+                  storageClass:
+                    description: StorageClass is the name of the storage class of
+                      the PVC that the volume snapshot is created from
+                    type: string
+                  volumeSnapshot:
+                    description: VolumeSnapshot is the name of the volume snapshot
+                      to be backed up
+                    type: string
+                required:
+                - storageClass
+                - volumeSnapshot
+                type: object
+              dataMoverConfig:
+                additionalProperties:
+                  type: string
+                description: DataMoverConfig is for data-mover-specific configuration
+                  fields.
+                nullable: true
+                type: object
+              datamover:
+                description: |-
+                  DataMover specifies the data mover to be used by the backup.
+                  If DataMover is "" or "velero", the built-in data mover will be used.
+                type: string
+              operationTimeout:
+                description: |-
+                  OperationTimeout specifies the time used to wait internal operations,
+                  before returning error as timeout.
+                type: string
+              snapshotType:
+                description: SnapshotType is the type of the snapshot to be backed
+                  up.
+                type: string
+              sourceNamespace:
+                description: |-
+                  SourceNamespace is the original namespace where the volume is backed up from.
+                  It is the same namespace for SourcePVC and CSI namespaced objects.
+                type: string
+              sourcePVC:
+                description: SourcePVC is the name of the PVC which the snapshot is
+                  taken for.
+                type: string
+            required:
+            - backupStorageLocation
+            - operationTimeout
+            - snapshotType
+            - sourceNamespace
+            - sourcePVC
+            type: object
+          status:
+            description: DataUploadStatus is the current status of a DataUpload.
+            properties:
+              completionTimestamp:
+                description: |-
+                  CompletionTimestamp records the time a backup was completed.
+                  Completion time is recorded even on failed backups.
+                  Completion time is recorded before uploading the backup object.
+                  The server's time is used for CompletionTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              dataMoverResult:
+                additionalProperties:
+                  type: string
+                description: DataMoverResult stores data-mover-specific information
+                  as a result of the DataUpload.
+                nullable: true
+                type: object
+              message:
+                description: Message is a message about the DataUpload's status.
+                type: string
+              node:
+                description: Node is name of the node where the DataUpload is processed.
+                type: string
+              path:
+                description: Path is the full path of the snapshot volume being backed
+                  up.
+                type: string
+              phase:
+                description: Phase is the current state of the DataUpload.
+                enum:
+                - New
+                - Accepted
+                - Prepared
+                - InProgress
+                - Canceling
+                - Canceled
+                - Completed
+                - Failed
+                type: string
+              progress:
+                description: |-
+                  Progress holds the total number of bytes of the volume and the current
+                  number of backed up bytes. This can be used to display progress information
+                  about the backup operation.
+                properties:
+                  bytesDone:
+                    format: int64
+                    type: integer
+                  totalBytes:
+                    format: int64
+                    type: integer
+                type: object
+              snapshotID:
+                description: SnapshotID is the identifier for the snapshot in the
+                  backup repository.
+                type: string
+              startTimestamp:
+                description: |-
+                  StartTimestamp records the time a backup was started.
+                  Separate from CreationTimestamp, since that value changes
+                  on restores.
+                  The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/velero.io_deletebackuprequests.yaml
+++ b/docs/shared/crds/velero.io_deletebackuprequests.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: deletebackuprequests.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: DeleteBackupRequest
+    listKind: DeleteBackupRequestList
+    plural: deletebackuprequests
+    singular: deletebackuprequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The name of the backup to be deleted
+      jsonPath: .spec.backupName
+      name: BackupName
+      type: string
+    - description: The status of the deletion request
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: DeleteBackupRequest is a request to delete one or more backups.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DeleteBackupRequestSpec is the specification for which backups
+              to delete.
+            properties:
+              backupName:
+                type: string
+            required:
+            - backupName
+            type: object
+          status:
+            description: DeleteBackupRequestStatus is the current status of a DeleteBackupRequest.
+            properties:
+              errors:
+                description: Errors contains any errors that were encountered during
+                  the deletion process.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              phase:
+                description: Phase is the current state of the DeleteBackupRequest.
+                enum:
+                - New
+                - InProgress
+                - Processed
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/velero.io_downloadrequests.yaml
+++ b/docs/shared/crds/velero.io_downloadrequests.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: downloadrequests.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: DownloadRequest
+    listKind: DownloadRequestList
+    plural: downloadrequests
+    singular: downloadrequest
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          DownloadRequest is a request to download an artifact from backup object storage, such as a backup
+          log file.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DownloadRequestSpec is the specification for a download request.
+            properties:
+              target:
+                description: Target is what to download (e.g. logs for a backup).
+                properties:
+                  kind:
+                    description: Kind is the type of file to download.
+                    enum:
+                    - BackupLog
+                    - BackupContents
+                    - BackupVolumeSnapshots
+                    - BackupItemOperations
+                    - BackupResourceList
+                    - BackupResults
+                    - RestoreLog
+                    - RestoreResults
+                    - RestoreResourceList
+                    - RestoreItemOperations
+                    - CSIBackupVolumeSnapshots
+                    - CSIBackupVolumeSnapshotContents
+                    - BackupVolumeInfos
+                    - RestoreVolumeInfo
+                    type: string
+                  name:
+                    description: Name is the name of the Kubernetes resource with
+                      which the file is associated.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+            required:
+            - target
+            type: object
+          status:
+            description: DownloadRequestStatus is the current status of a DownloadRequest.
+            properties:
+              downloadURL:
+                description: DownloadURL contains the pre-signed URL for the target
+                  file.
+                type: string
+              expiration:
+                description: Expiration is when this DownloadRequest expires and can
+                  be deleted by the system.
+                format: date-time
+                nullable: true
+                type: string
+              phase:
+                description: Phase is the current state of the DownloadRequest.
+                enum:
+                - New
+                - Processed
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/docs/shared/crds/velero.io_podvolumebackups.yaml
+++ b/docs/shared/crds/velero.io_podvolumebackups.yaml
@@ -1,0 +1,223 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: podvolumebackups.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: PodVolumeBackup
+    listKind: PodVolumeBackupList
+    plural: podvolumebackups
+    singular: podvolumebackup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Pod Volume Backup status such as New/InProgress
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Time when this backup was started
+      jsonPath: .status.startTimestamp
+      name: Created
+      type: date
+    - description: Namespace of the pod containing the volume to be backed up
+      jsonPath: .spec.pod.namespace
+      name: Namespace
+      type: string
+    - description: Name of the pod containing the volume to be backed up
+      jsonPath: .spec.pod.name
+      name: Pod
+      type: string
+    - description: Name of the volume to be backed up
+      jsonPath: .spec.volume
+      name: Volume
+      type: string
+    - description: The type of the uploader to handle data transfer
+      jsonPath: .spec.uploaderType
+      name: Uploader Type
+      type: string
+    - description: Name of the Backup Storage Location where this backup should be
+        stored
+      jsonPath: .spec.backupStorageLocation
+      name: Storage Location
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PodVolumeBackupSpec is the specification for a PodVolumeBackup.
+            properties:
+              backupStorageLocation:
+                description: |-
+                  BackupStorageLocation is the name of the backup storage location
+                  where the backup repository is stored.
+                type: string
+              node:
+                description: Node is the name of the node that the Pod is running
+                  on.
+                type: string
+              pod:
+                description: Pod is a reference to the pod containing the volume to
+                  be backed up.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              repoIdentifier:
+                description: RepoIdentifier is the backup repository identifier.
+                type: string
+              tags:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Tags are a map of key-value pairs that should be applied to the
+                  volume backup as tags.
+                type: object
+              uploaderSettings:
+                additionalProperties:
+                  type: string
+                description: |-
+                  UploaderSettings are a map of key-value pairs that should be applied to the
+                  uploader configuration.
+                nullable: true
+                type: object
+              uploaderType:
+                description: UploaderType is the type of the uploader to handle the
+                  data transfer.
+                enum:
+                - kopia
+                - restic
+                - ""
+                type: string
+              volume:
+                description: |-
+                  Volume is the name of the volume within the Pod to be backed
+                  up.
+                type: string
+            required:
+            - backupStorageLocation
+            - node
+            - pod
+            - repoIdentifier
+            - volume
+            type: object
+          status:
+            description: PodVolumeBackupStatus is the current status of a PodVolumeBackup.
+            properties:
+              completionTimestamp:
+                description: |-
+                  CompletionTimestamp records the time a backup was completed.
+                  Completion time is recorded even on failed backups.
+                  Completion time is recorded before uploading the backup object.
+                  The server's time is used for CompletionTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: Message is a message about the pod volume backup's status.
+                type: string
+              path:
+                description: Path is the full path within the controller pod being
+                  backed up.
+                type: string
+              phase:
+                description: Phase is the current state of the PodVolumeBackup.
+                enum:
+                - New
+                - InProgress
+                - Completed
+                - Failed
+                type: string
+              progress:
+                description: |-
+                  Progress holds the total number of bytes of the volume and the current
+                  number of backed up bytes. This can be used to display progress information
+                  about the backup operation.
+                properties:
+                  bytesDone:
+                    format: int64
+                    type: integer
+                  totalBytes:
+                    format: int64
+                    type: integer
+                type: object
+              snapshotID:
+                description: SnapshotID is the identifier for the snapshot of the
+                  pod volume.
+                type: string
+              startTimestamp:
+                description: |-
+                  StartTimestamp records the time a backup was started.
+                  Separate from CreationTimestamp, since that value changes
+                  on restores.
+                  The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/velero.io_podvolumerestores.yaml
+++ b/docs/shared/crds/velero.io_podvolumerestores.yaml
@@ -1,0 +1,209 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: podvolumerestores.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: PodVolumeRestore
+    listKind: PodVolumeRestoreList
+    plural: podvolumerestores
+    singular: podvolumerestore
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Namespace of the pod containing the volume to be restored
+      jsonPath: .spec.pod.namespace
+      name: Namespace
+      type: string
+    - description: Name of the pod containing the volume to be restored
+      jsonPath: .spec.pod.name
+      name: Pod
+      type: string
+    - description: The type of the uploader to handle data transfer
+      jsonPath: .spec.uploaderType
+      name: Uploader Type
+      type: string
+    - description: Name of the volume to be restored
+      jsonPath: .spec.volume
+      name: Volume
+      type: string
+    - description: Pod Volume Restore status such as New/InProgress
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Pod Volume Restore status such as New/InProgress
+      format: int64
+      jsonPath: .status.progress.totalBytes
+      name: TotalBytes
+      type: integer
+    - description: Pod Volume Restore status such as New/InProgress
+      format: int64
+      jsonPath: .status.progress.bytesDone
+      name: BytesDone
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PodVolumeRestoreSpec is the specification for a PodVolumeRestore.
+            properties:
+              backupStorageLocation:
+                description: |-
+                  BackupStorageLocation is the name of the backup storage location
+                  where the backup repository is stored.
+                type: string
+              pod:
+                description: Pod is a reference to the pod containing the volume to
+                  be restored.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              repoIdentifier:
+                description: RepoIdentifier is the backup repository identifier.
+                type: string
+              snapshotID:
+                description: SnapshotID is the ID of the volume snapshot to be restored.
+                type: string
+              sourceNamespace:
+                description: SourceNamespace is the original namespace for namaspace
+                  mapping.
+                type: string
+              uploaderSettings:
+                additionalProperties:
+                  type: string
+                description: |-
+                  UploaderSettings are a map of key-value pairs that should be applied to the
+                  uploader configuration.
+                nullable: true
+                type: object
+              uploaderType:
+                description: UploaderType is the type of the uploader to handle the
+                  data transfer.
+                enum:
+                - kopia
+                - restic
+                - ""
+                type: string
+              volume:
+                description: Volume is the name of the volume within the Pod to be
+                  restored.
+                type: string
+            required:
+            - backupStorageLocation
+            - pod
+            - repoIdentifier
+            - snapshotID
+            - sourceNamespace
+            - volume
+            type: object
+          status:
+            description: PodVolumeRestoreStatus is the current status of a PodVolumeRestore.
+            properties:
+              completionTimestamp:
+                description: |-
+                  CompletionTimestamp records the time a restore was completed.
+                  Completion time is recorded even on failed restores.
+                  The server's time is used for CompletionTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: Message is a message about the pod volume restore's status.
+                type: string
+              phase:
+                description: Phase is the current state of the PodVolumeRestore.
+                enum:
+                - New
+                - InProgress
+                - Completed
+                - Failed
+                type: string
+              progress:
+                description: |-
+                  Progress holds the total number of bytes of the snapshot and the current
+                  number of restored bytes. This can be used to display progress information
+                  about the restore operation.
+                properties:
+                  bytesDone:
+                    format: int64
+                    type: integer
+                  totalBytes:
+                    format: int64
+                    type: integer
+                type: object
+              startTimestamp:
+                description: |-
+                  StartTimestamp records the time a restore was started.
+                  The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/velero.io_restores.yaml
+++ b/docs/shared/crds/velero.io_restores.yaml
@@ -1,0 +1,556 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: restores.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: Restore
+    listKind: RestoreList
+    plural: restores
+    singular: restore
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Restore is a Velero resource that represents the application of
+          resources from a Velero backup to a target Kubernetes cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RestoreSpec defines the specification for a Velero restore.
+            properties:
+              backupName:
+                description: |-
+                  BackupName is the unique name of the Velero backup to restore
+                  from.
+                type: string
+              excludedNamespaces:
+                description: |-
+                  ExcludedNamespaces contains a list of namespaces that are not
+                  included in the restore.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              excludedResources:
+                description: |-
+                  ExcludedResources is a slice of resource names that are not
+                  included in the restore.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              existingResourcePolicy:
+                description: ExistingResourcePolicy specifies the restore behavior
+                  for the Kubernetes resource to be restored
+                nullable: true
+                type: string
+              hooks:
+                description: Hooks represent custom behaviors that should be executed
+                  during or post restore.
+                properties:
+                  resources:
+                    items:
+                      description: |-
+                        RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on
+                        the rules defined for namespaces, resources, and label selector.
+                      properties:
+                        excludedNamespaces:
+                          description: ExcludedNamespaces specifies the namespaces
+                            to which this hook spec does not apply.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        excludedResources:
+                          description: ExcludedResources specifies the resources to
+                            which this hook spec does not apply.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedNamespaces:
+                          description: |-
+                            IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                            to all namespaces.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        includedResources:
+                          description: |-
+                            IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                            to all resources.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        labelSelector:
+                          description: LabelSelector, if specified, filters the resources
+                            to which this hook spec applies.
+                          nullable: true
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        name:
+                          description: Name is the name of this hook.
+                          type: string
+                        postHooks:
+                          description: PostHooks is a list of RestoreResourceHooks
+                            to execute during and after restoring a resource.
+                          items:
+                            description: RestoreResourceHook defines a restore hook
+                              for a resource.
+                            properties:
+                              exec:
+                                description: Exec defines an exec restore hook.
+                                properties:
+                                  command:
+                                    description: Command is the command and arguments
+                                      to execute from within a container after a pod
+                                      has been restored.
+                                    items:
+                                      type: string
+                                    minItems: 1
+                                    type: array
+                                  container:
+                                    description: |-
+                                      Container is the container in the pod where the command should be executed. If not specified,
+                                      the pod's first container is used.
+                                    type: string
+                                  execTimeout:
+                                    description: |-
+                                      ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                      considering the execution a failure.
+                                    type: string
+                                  onError:
+                                    description: OnError specifies how Velero should
+                                      behave if it encounters an error executing this
+                                      hook.
+                                    enum:
+                                    - Continue
+                                    - Fail
+                                    type: string
+                                  waitForReady:
+                                    description: WaitForReady ensures command will
+                                      be launched when container is Ready instead
+                                      of Running.
+                                    nullable: true
+                                    type: boolean
+                                  waitTimeout:
+                                    description: |-
+                                      WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready
+                                      before attempting to run the command.
+                                    type: string
+                                required:
+                                - command
+                                type: object
+                              init:
+                                description: Init defines an init restore hook.
+                                properties:
+                                  initContainers:
+                                    description: InitContainers is list of init containers
+                                      to be added to a pod during its restore.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  timeout:
+                                    description: Timeout defines the maximum amount
+                                      of time Velero should wait for the initContainers
+                                      to complete.
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              includeClusterResources:
+                description: |-
+                  IncludeClusterResources specifies whether cluster-scoped resources
+                  should be included for consideration in the restore. If null, defaults
+                  to true.
+                nullable: true
+                type: boolean
+              includedNamespaces:
+                description: |-
+                  IncludedNamespaces is a slice of namespace names to include objects
+                  from. If empty, all namespaces are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              includedResources:
+                description: |-
+                  IncludedResources is a slice of resource names to include
+                  in the restore. If empty, all resources in the backup are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              itemOperationTimeout:
+                description: |-
+                  ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations
+                  The default value is 4 hour.
+                type: string
+              labelSelector:
+                description: |-
+                  LabelSelector is a metav1.LabelSelector to filter with
+                  when restoring individual objects from the backup. If empty
+                  or nil, all objects are included. Optional.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              namespaceMapping:
+                additionalProperties:
+                  type: string
+                description: |-
+                  NamespaceMapping is a map of source namespace names
+                  to target namespace names to restore into. Any source
+                  namespaces not included in the map will be restored into
+                  namespaces of the same name.
+                type: object
+              orLabelSelectors:
+                description: |-
+                  OrLabelSelectors is list of metav1.LabelSelector to filter with
+                  when restoring individual objects from the backup. If multiple provided
+                  they will be joined by the OR operator. LabelSelector as well as
+                  OrLabelSelectors cannot co-exist in restore request, only one of them
+                  can be used
+                items:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                nullable: true
+                type: array
+              preserveNodePorts:
+                description: PreserveNodePorts specifies whether to restore old nodePorts
+                  from backup.
+                nullable: true
+                type: boolean
+              resourceModifier:
+                description: ResourceModifier specifies the reference to JSON resource
+                  patches that should be applied to resources before restoration.
+                nullable: true
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              restorePVs:
+                description: |-
+                  RestorePVs specifies whether to restore all included
+                  PVs from snapshot
+                nullable: true
+                type: boolean
+              restoreStatus:
+                description: |-
+                  RestoreStatus specifies which resources we should restore the status
+                  field. If nil, no objects are included. Optional.
+                nullable: true
+                properties:
+                  excludedResources:
+                    description: ExcludedResources specifies the resources to which
+                      will not restore the status.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  includedResources:
+                    description: |-
+                      IncludedResources specifies the resources to which will restore the status.
+                      If empty, it applies to all resources.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
+              scheduleName:
+                description: |-
+                  ScheduleName is the unique name of the Velero schedule to restore
+                  from. If specified, and BackupName is empty, Velero will restore
+                  from the most recent successful backup created from this schedule.
+                type: string
+              uploaderConfig:
+                description: UploaderConfig specifies the configuration for the restore.
+                nullable: true
+                properties:
+                  parallelFilesDownload:
+                    description: ParallelFilesDownload is the concurrency number setting
+                      for restore.
+                    type: integer
+                  writeSparseFiles:
+                    description: WriteSparseFiles is a flag to indicate whether write
+                      files sparsely or not.
+                    nullable: true
+                    type: boolean
+                type: object
+            type: object
+          status:
+            description: RestoreStatus captures the current status of a Velero restore
+            properties:
+              completionTimestamp:
+                description: |-
+                  CompletionTimestamp records the time the restore operation was completed.
+                  Completion time is recorded even on failed restore.
+                  The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              errors:
+                description: |-
+                  Errors is a count of all error messages that were generated during
+                  execution of the restore. The actual errors are stored in object storage.
+                type: integer
+              failureReason:
+                description: FailureReason is an error that caused the entire restore
+                  to fail.
+                type: string
+              hookStatus:
+                description: HookStatus contains information about the status of the
+                  hooks.
+                nullable: true
+                properties:
+                  hooksAttempted:
+                    description: |-
+                      HooksAttempted is the total number of attempted hooks
+                      Specifically, HooksAttempted represents the number of hooks that failed to execute
+                      and the number of hooks that executed successfully.
+                    type: integer
+                  hooksFailed:
+                    description: HooksFailed is the total number of hooks which ended
+                      with an error
+                    type: integer
+                type: object
+              phase:
+                description: Phase is the current state of the Restore
+                enum:
+                - New
+                - FailedValidation
+                - InProgress
+                - WaitingForPluginOperations
+                - WaitingForPluginOperationsPartiallyFailed
+                - Completed
+                - PartiallyFailed
+                - Failed
+                - Finalizing
+                - FinalizingPartiallyFailed
+                type: string
+              progress:
+                description: |-
+                  Progress contains information about the restore's execution progress. Note
+                  that this information is best-effort only -- if Velero fails to update it
+                  during a restore for any reason, it may be inaccurate/stale.
+                nullable: true
+                properties:
+                  itemsRestored:
+                    description: ItemsRestored is the number of items that have actually
+                      been restored so far
+                    type: integer
+                  totalItems:
+                    description: |-
+                      TotalItems is the total number of items to be restored. This number may change
+                      throughout the execution of the restore due to plugins that return additional related
+                      items to restore
+                    type: integer
+                type: object
+              restoreItemOperationsAttempted:
+                description: |-
+                  RestoreItemOperationsAttempted is the total number of attempted
+                  async RestoreItemAction operations for this restore.
+                type: integer
+              restoreItemOperationsCompleted:
+                description: |-
+                  RestoreItemOperationsCompleted is the total number of successfully completed
+                  async RestoreItemAction operations for this restore.
+                type: integer
+              restoreItemOperationsFailed:
+                description: |-
+                  RestoreItemOperationsFailed is the total number of async
+                  RestoreItemAction operations for this restore which ended with an error.
+                type: integer
+              startTimestamp:
+                description: |-
+                  StartTimestamp records the time the restore operation was started.
+                  The server's time is used for StartTimestamps
+                format: date-time
+                nullable: true
+                type: string
+              validationErrors:
+                description: |-
+                  ValidationErrors is a slice of all validation errors (if
+                  applicable)
+                items:
+                  type: string
+                nullable: true
+                type: array
+              warnings:
+                description: |-
+                  Warnings is a count of all warning messages that were generated during
+                  execution of the restore. The actual warnings are stored in object storage.
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/docs/shared/crds/velero.io_schedules.yaml
+++ b/docs/shared/crds/velero.io_schedules.yaml
@@ -1,0 +1,597 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: schedules.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: Schedule
+    listKind: ScheduleList
+    plural: schedules
+    singular: schedule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Status of the schedule
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: A Cron expression defining when to run the Backup
+      jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - description: The last time a Backup was run for this schedule
+      jsonPath: .status.lastBackup
+      name: LastBackup
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.paused
+      name: Paused
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Schedule is a Velero resource that represents a pre-scheduled or
+          periodic Backup that should be run.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScheduleSpec defines the specification for a Velero schedule
+            properties:
+              paused:
+                description: Paused specifies whether the schedule is paused or not
+                type: boolean
+              schedule:
+                description: |-
+                  Schedule is a Cron expression defining when to run
+                  the Backup.
+                type: string
+              skipImmediately:
+                description: |-
+                  SkipImmediately specifies whether to skip backup if schedule is due immediately from `schedule.status.lastBackup` timestamp when schedule is unpaused or if schedule is new.
+                  If true, backup will be skipped immediately when schedule is unpaused if it is due based on .Status.LastBackupTimestamp or schedule is new, and will run at next schedule time.
+                  If false, backup will not be skipped immediately when schedule is unpaused, but will run at next schedule time.
+                  If empty, will follow server configuration (default: false).
+                type: boolean
+              template:
+                description: |-
+                  Template is the definition of the Backup to be run
+                  on the provided schedule
+                properties:
+                  csiSnapshotTimeout:
+                    description: |-
+                      CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
+                      ReadyToUse during creation, before returning error as timeout.
+                      The default value is 10 minute.
+                    type: string
+                  datamover:
+                    description: |-
+                      DataMover specifies the data mover to be used by the backup.
+                      If DataMover is "" or "velero", the built-in data mover will be used.
+                    type: string
+                  defaultVolumesToFsBackup:
+                    description: |-
+                      DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
+                      for all volumes by default.
+                    nullable: true
+                    type: boolean
+                  defaultVolumesToRestic:
+                    description: |-
+                      DefaultVolumesToRestic specifies whether restic should be used to take a
+                      backup of all pod volumes by default.
+
+
+                      Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
+                    nullable: true
+                    type: boolean
+                  excludedClusterScopedResources:
+                    description: |-
+                      ExcludedClusterScopedResources is a slice of cluster-scoped
+                      resource type names to exclude from the backup.
+                      If set to "*", all cluster-scoped resource types are excluded.
+                      The default value is empty.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  excludedNamespaceScopedResources:
+                    description: |-
+                      ExcludedNamespaceScopedResources is a slice of namespace-scoped
+                      resource type names to exclude from the backup.
+                      If set to "*", all namespace-scoped resource types are excluded.
+                      The default value is empty.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  excludedNamespaces:
+                    description: |-
+                      ExcludedNamespaces contains a list of namespaces that are not
+                      included in the backup.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  excludedResources:
+                    description: |-
+                      ExcludedResources is a slice of resource names that are not
+                      included in the backup.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  hooks:
+                    description: Hooks represent custom behaviors that should be executed
+                      at different phases of the backup.
+                    properties:
+                      resources:
+                        description: Resources are hooks that should be executed when
+                          backing up individual instances of a resource.
+                        items:
+                          description: |-
+                            BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
+                            the rules defined for namespaces, resources, and label selector.
+                          properties:
+                            excludedNamespaces:
+                              description: ExcludedNamespaces specifies the namespaces
+                                to which this hook spec does not apply.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            excludedResources:
+                              description: ExcludedResources specifies the resources
+                                to which this hook spec does not apply.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            includedNamespaces:
+                              description: |-
+                                IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                                to all namespaces.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            includedResources:
+                              description: |-
+                                IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                                to all resources.
+                              items:
+                                type: string
+                              nullable: true
+                              type: array
+                            labelSelector:
+                              description: LabelSelector, if specified, filters the
+                                resources to which this hook spec applies.
+                              nullable: true
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            name:
+                              description: Name is the name of this hook.
+                              type: string
+                            post:
+                              description: |-
+                                PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
+                                These are executed after all "additional items" from item actions are processed.
+                              items:
+                                description: BackupResourceHook defines a hook for
+                                  a resource.
+                                properties:
+                                  exec:
+                                    description: Exec defines an exec hook.
+                                    properties:
+                                      command:
+                                        description: Command is the command and arguments
+                                          to execute.
+                                        items:
+                                          type: string
+                                        minItems: 1
+                                        type: array
+                                      container:
+                                        description: |-
+                                          Container is the container in the pod where the command should be executed. If not specified,
+                                          the pod's first container is used.
+                                        type: string
+                                      onError:
+                                        description: OnError specifies how Velero
+                                          should behave if it encounters an error
+                                          executing this hook.
+                                        enum:
+                                        - Continue
+                                        - Fail
+                                        type: string
+                                      timeout:
+                                        description: |-
+                                          Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                          considering the execution a failure.
+                                        type: string
+                                    required:
+                                    - command
+                                    type: object
+                                required:
+                                - exec
+                                type: object
+                              type: array
+                            pre:
+                              description: |-
+                                PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
+                                These are executed before any "additional items" from item actions are processed.
+                              items:
+                                description: BackupResourceHook defines a hook for
+                                  a resource.
+                                properties:
+                                  exec:
+                                    description: Exec defines an exec hook.
+                                    properties:
+                                      command:
+                                        description: Command is the command and arguments
+                                          to execute.
+                                        items:
+                                          type: string
+                                        minItems: 1
+                                        type: array
+                                      container:
+                                        description: |-
+                                          Container is the container in the pod where the command should be executed. If not specified,
+                                          the pod's first container is used.
+                                        type: string
+                                      onError:
+                                        description: OnError specifies how Velero
+                                          should behave if it encounters an error
+                                          executing this hook.
+                                        enum:
+                                        - Continue
+                                        - Fail
+                                        type: string
+                                      timeout:
+                                        description: |-
+                                          Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                          considering the execution a failure.
+                                        type: string
+                                    required:
+                                    - command
+                                    type: object
+                                required:
+                                - exec
+                                type: object
+                              type: array
+                          required:
+                          - name
+                          type: object
+                        nullable: true
+                        type: array
+                    type: object
+                  includeClusterResources:
+                    description: |-
+                      IncludeClusterResources specifies whether cluster-scoped resources
+                      should be included for consideration in the backup.
+                    nullable: true
+                    type: boolean
+                  includedClusterScopedResources:
+                    description: |-
+                      IncludedClusterScopedResources is a slice of cluster-scoped
+                      resource type names to include in the backup.
+                      If set to "*", all cluster-scoped resource types are included.
+                      The default value is empty, which means only related
+                      cluster-scoped resources are included.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  includedNamespaceScopedResources:
+                    description: |-
+                      IncludedNamespaceScopedResources is a slice of namespace-scoped
+                      resource type names to include in the backup.
+                      The default value is "*".
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  includedNamespaces:
+                    description: |-
+                      IncludedNamespaces is a slice of namespace names to include objects
+                      from. If empty, all namespaces are included.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  includedResources:
+                    description: |-
+                      IncludedResources is a slice of resource names to include
+                      in the backup. If empty, all resources are included.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  itemOperationTimeout:
+                    description: |-
+                      ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
+                      The default value is 4 hour.
+                    type: string
+                  labelSelector:
+                    description: |-
+                      LabelSelector is a metav1.LabelSelector to filter with
+                      when adding individual objects to the backup. If empty
+                      or nil, all objects are included. Optional.
+                    nullable: true
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  metadata:
+                    properties:
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  orLabelSelectors:
+                    description: |-
+                      OrLabelSelectors is list of metav1.LabelSelector to filter with
+                      when adding individual objects to the backup. If multiple provided
+                      they will be joined by the OR operator. LabelSelector as well as
+                      OrLabelSelectors cannot co-exist in backup request, only one of them
+                      can be used.
+                    items:
+                      description: |-
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    nullable: true
+                    type: array
+                  orderedResources:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      OrderedResources specifies the backup order of resources of specific Kind.
+                      The map key is the resource name and value is a list of object names separated by commas.
+                      Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
+                    nullable: true
+                    type: object
+                  resourcePolicy:
+                    description: ResourcePolicy specifies the referenced resource
+                      policies that backup should follow
+                    properties:
+                      apiGroup:
+                        description: |-
+                          APIGroup is the group for the resource being referenced.
+                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                          For any other third-party types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  snapshotMoveData:
+                    description: SnapshotMoveData specifies whether snapshot data
+                      should be moved
+                    nullable: true
+                    type: boolean
+                  snapshotVolumes:
+                    description: |-
+                      SnapshotVolumes specifies whether to take snapshots
+                      of any PV's referenced in the set of objects included
+                      in the Backup.
+                    nullable: true
+                    type: boolean
+                  storageLocation:
+                    description: StorageLocation is a string containing the name of
+                      a BackupStorageLocation where the backup should be stored.
+                    type: string
+                  ttl:
+                    description: |-
+                      TTL is a time.Duration-parseable string describing how long
+                      the Backup should be retained for.
+                    type: string
+                  uploaderConfig:
+                    description: UploaderConfig specifies the configuration for the
+                      uploader.
+                    nullable: true
+                    properties:
+                      parallelFilesUpload:
+                        description: ParallelFilesUpload is the number of files parallel
+                          uploads to perform when using the uploader.
+                        type: integer
+                    type: object
+                  volumeSnapshotLocations:
+                    description: VolumeSnapshotLocations is a list containing names
+                      of VolumeSnapshotLocations associated with this backup.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              useOwnerReferencesInBackup:
+                description: |-
+                  UseOwnerReferencesBackup specifies whether to use
+                  OwnerReferences on backups created by this Schedule.
+                nullable: true
+                type: boolean
+            required:
+            - schedule
+            - template
+            type: object
+          status:
+            description: ScheduleStatus captures the current state of a Velero schedule
+            properties:
+              lastBackup:
+                description: |-
+                  LastBackup is the last time a Backup was run for this
+                  Schedule schedule
+                format: date-time
+                nullable: true
+                type: string
+              lastSkipped:
+                description: LastSkipped is the last time a Schedule was skipped
+                format: date-time
+                nullable: true
+                type: string
+              phase:
+                description: Phase is the current phase of the Schedule
+                enum:
+                - New
+                - Enabled
+                - FailedValidation
+                type: string
+              validationErrors:
+                description: |-
+                  ValidationErrors is a slice of all validation errors (if
+                  applicable)
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/velero.io_serverstatusrequests.yaml
+++ b/docs/shared/crds/velero.io_serverstatusrequests.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: serverstatusrequests.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: ServerStatusRequest
+    listKind: ServerStatusRequestList
+    plural: serverstatusrequests
+    shortNames:
+    - ssr
+    singular: serverstatusrequest
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ServerStatusRequest is a request to access current status information about
+          the Velero server.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServerStatusRequestSpec is the specification for a ServerStatusRequest.
+            type: object
+          status:
+            description: ServerStatusRequestStatus is the current status of a ServerStatusRequest.
+            properties:
+              phase:
+                description: Phase is the current lifecycle phase of the ServerStatusRequest.
+                enum:
+                - New
+                - Processed
+                type: string
+              plugins:
+                description: Plugins list information about the plugins running on
+                  the Velero server
+                items:
+                  description: PluginInfo contains attributes of a Velero plugin
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                nullable: true
+                type: array
+              processedTimestamp:
+                description: |-
+                  ProcessedTimestamp is when the ServerStatusRequest was processed
+                  by the ServerStatusRequestController.
+                format: date-time
+                nullable: true
+                type: string
+              serverVersion:
+                description: ServerVersion is the Velero server version.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/docs/shared/crds/velero.io_volumesnapshotlocations.yaml
+++ b/docs/shared/crds/velero.io_volumesnapshotlocations.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: volumesnapshotlocations.velero.io
+spec:
+  group: velero.io
+  names:
+    kind: VolumeSnapshotLocation
+    listKind: VolumeSnapshotLocationList
+    plural: volumesnapshotlocations
+    shortNames:
+    - vsl
+    singular: volumesnapshotlocation
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: VolumeSnapshotLocation is a location where Velero stores volume
+          snapshots.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeSnapshotLocationSpec defines the specification for
+              a Velero VolumeSnapshotLocation.
+            properties:
+              config:
+                additionalProperties:
+                  type: string
+                description: Config is for provider-specific configuration fields.
+                type: object
+              credential:
+                description: Credential contains the credential information intended
+                  to be used with this location
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              provider:
+                description: Provider is the provider of the volume storage.
+                type: string
+            required:
+            - provider
+            type: object
+          status:
+            description: VolumeSnapshotLocationStatus describes the current status
+              of a Velero VolumeSnapshotLocation.
+            properties:
+              phase:
+                description: VolumeSnapshotLocationPhase is the lifecycle phase of
+                  a Velero VolumeSnapshotLocation.
+                enum:
+                - Available
+                - Unavailable
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
## Summary

This PR adds the ACP-side standard Kubernetes API references required by AIT-68181.

The ACP docs side intentionally covers ACP platform-level APIs and keeps Cluster API / UPI lifecycle APIs in Immutable Infrastructure docs. The Cluster Overview page now points users who want to create User-Provisioned Infrastructure clusters through APIs to the stable Immutable Infrastructure API Reference entry, then directs them to **Provider APIs > User-Provisioned Infrastructure Provider APIs**.

## API coverage added

- Backup / Velero APIs:
  - `Backup`, `Restore`, `Schedule`, `BackupStorageLocation`, `VolumeSnapshotLocation`
  - `BackupRepository`, `DeleteBackupRequest`, `DownloadRequest`, `PodVolumeBackup`, `PodVolumeRestore`, `ServerStatusRequest`
  - `DataUpload`, `DataDownload`
- etcd Operator:
  - `EtcdCluster`
- Marketplace APIs:
  - `Artifact`, `ArtifactVersion`, `Library`, `ChartRepo`, `Chart`, `HelmRequest`, `ImageWhiteList`
- OLM / Operator APIs surfaced through Marketplace:
  - `CatalogSource`, `ClusterServiceVersion`, `InstallPlan`, `OLMConfig`, `OperatorCondition`, `OperatorGroup`, `Subscription`
- Platform Base APIs:
  - `CommonConfig`, `ProductBase`, `ProductConfig`, `ProductUpgrade`, `ClusterModule`
- Platform Cluster APIs from chart-base-init:
  - `AlertRule`, `Dashboard`, `GrafanaDashboard`, `MonitorDashboard`
  - `AlaudaFeatureGate`, `ClusterAlaudaFeatureGate`, `Feature`, `ImageVersion`
  - `ProductEntry`, `DisableToken`, `DisableUser`, `Project`, `User`, `UserBinding`
- Security API:
  - `EtcdEncryptionConfig`

## Important decisions

- Cluster API, Kubeadm provider APIs, UPI creation APIs, infrastructure providers, Hosted Control Plane, and Machine Configuration are not duplicated in `acp-docs`; their canonical API reference belongs to `immutable-infra-docs`.
- The UPI link in `docs/en/configure/clusters/overview.mdx` uses the stable Immutable Infrastructure API Reference entry rather than a deep provider-page URL.
- New API directories use underscore names, following the current documentation governance rule for new paths.
- New API pages include `weight` and English `queries` metadata for navigation and retrieval.
- CRDs from `chart-base-init` that are installed only on the global cluster include an explicit note:
  - `This API is installed only when the chart is deployed for the global cluster. It is not available on workload clusters.`
- `MonitorDashboard` includes an explicit installer-condition note because the source CRD is guarded by a lookup check.

## Source and filtering notes

- CRDs were collected from the backend repositories recorded in the AIT-68181 source mapping.
- Third-party/test/support CRDs were not blindly imported. Gateway API, Prometheus Operator, VictoriaMetrics, and other dependency CRDs were excluded unless they were explicitly part of the required standard API set.
- `AppRelease` was not added because no standalone CRD was found in the provided Central Base sources.

## Validation

- CRD YAML parsing passed with the same YAML parser used by Doom.
- `<K8sAPI />` references match available CRD files, except existing OpenAPI-backed built-ins.
- `git diff --check` passed before staging.
- `yarn lint` passed with 0 errors and 0 warnings.
- `yarn dev` was started successfully and completed the initial build after normalizing multi-line CRD descriptions that Doom could not parse as single-quoted scalars.

Note: lint prints the existing environment warning that Node.js `22.11.0` is outside Rspack's recommended range (`20.19+` or `22.12+`), but lint completed successfully.
