### PR TITLE
docs: sync ac whoami description

### DIFF
--- a/docs/en/ui/cli_tools/ac/developer-command-reference.md
+++ b/docs/en/ui/cli_tools/ac/developer-command-reference.md
@@ -221,7 +221,9 @@ ac auth reconcile -f my-rbac-rules.yaml
 
 ## ac auth whoami
 
-Experimental: Check self subject attributes
+Display the current ACP CLI login identity and kubeconfig context.
+
+Use this command after `ac login`, cluster switching, or kubeconfig troubleshooting to confirm which user, cluster, namespace, and authentication method are currently active. This command reports the current session context from kubeconfig; it does not issue or print a temporary access token.
 
 ### Example usage
 
@@ -232,6 +234,14 @@ ac auth whoami
 # Get your subject attributes in JSON format
 ac auth whoami -o json
 ```
+
+The command output includes:
+
+- Current user
+- Active context
+- Current cluster and API server address
+- Current namespace, when set
+- Authentication method
 
 ## ac autoscale
 


### PR DESCRIPTION
## Summary
Clarify the `ac auth whoami` command description for the master docs line.

## Changes
- explain that `ac auth whoami` is used to confirm the current ACP CLI login identity and kubeconfig context
- document the expected output items: current user, active context, cluster and API server, namespace when set, and authentication method
- state the boundary explicitly: this command does not issue or print a temporary access token

## Validation
- `git diff --check`
- `PATH="/Users/changjia/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" yarn build`
- local `yarn lint` under the default Node runtime is blocked by repo tooling requiring Node 20.19+ or 22.12+, while the machine default is 22.11.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced developer command reference with improved documentation for the `ac auth whoami` command, including detailed descriptions of its purpose, functionality, and command output. Added examples demonstrating both standard and JSON output formats, along with a comprehensive breakdown of output fields including user identity, context, cluster/API server, namespace, and authentication method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->