### PR TITLE
docs: sync ac whoami description

### DIFF
--- a/docs/en/ui/cli_tools/ac/developer-command-reference.md
+++ b/docs/en/ui/cli_tools/ac/developer-command-reference.md
@@ -221,7 +221,9 @@ ac auth reconcile -f my-rbac-rules.yaml
 
 ## ac auth whoami
 
-Experimental: Check self subject attributes
+Display the current ACP CLI login identity and kubeconfig context.
+
+Use this command after `ac login`, cluster switching, or kubeconfig troubleshooting to confirm which user, cluster, namespace, and authentication method are currently active. This command reports the current session context from kubeconfig; it does not issue or print a temporary access token.
 
 ### Example usage
 
@@ -232,6 +234,14 @@ ac auth whoami
 # Get your subject attributes in JSON format
 ac auth whoami -o json
 ```
+
+The command output includes:
+
+- Current user
+- Active context
+- Current cluster and API server address
+- Current namespace, when set
+- Authentication method
 
 ## ac autoscale
 


### PR DESCRIPTION
## Summary
Backport the `ac auth whoami` description clarification to the `release-4.3` docs line.

## Changes
- explain that `ac auth whoami` is used to confirm the current ACP CLI login identity and kubeconfig context
- document the expected output items: current user, active context, cluster and API server, namespace when set, and authentication method
- state the boundary explicitly: this command does not issue or print a temporary access token

## Validation
- `git diff --check`
- workspace clone for this backport branch does not have dependencies installed, so repo lint/build was not run in that clone
- content was synchronized from the validated master-line doc change