### PR TITLE
docs(api): remove app.k8s.io api from lifecycle documentation

### DIFF
--- a/docs/en/apis/advanced_apis/application/lifecycle.mdx
+++ b/docs/en/apis/advanced_apis/application/lifecycle.mdx
@@ -15,7 +15,6 @@ This section describes the APIs for managing the lifecycle of applications in th
     '/acp/v1/kubernetes/{cluster_name}/namespaces/{namespace}/applications/{name}',
     '/acp/v1/kubernetes/{cluster_name}/namespaces/{namespace}/applications/{name}/rollback',
     '/acp/v1/kubernetes/{cluster_name}/namespaces/{namespace}/applications/{name}/start',
-    '/acp/v1/kubernetes/{cluster_name}/namespaces/{namespace}/applications/{name}/stop',
-    '/kubernetes/{cluster_name}/apis/app.k8s.io/v1beta1/namespaces/{namespace}/applications/{name}'
+    '/acp/v1/kubernetes/{cluster_name}/namespaces/{namespace}/applications/{name}/stop'
   ]}
 />


### PR DESCRIPTION
Remove the deprecated app.k8s.io/v1beta1 API reference from the application lifecycle documentation as part of the effort to clean up Kubernetes-style resource definitions.