### PR TITLE
docs: add ac whoami command reference

### DIFF
--- a/docs/en/ui/cli_tools/ac/developer-command-reference.md
+++ b/docs/en/ui/cli_tools/ac/developer-command-reference.md
@@ -2001,3 +2001,23 @@ ac wait --for=create secret/busybox1 --timeout=30s
 ac delete pod/busybox1
 ac wait --for=delete pod/busybox1 --timeout=60s
 ```
+
+## ac whoami
+
+Show information about the current session
+
+### Example usage
+
+```bash
+# Display the currently authenticated user
+ac whoami
+
+# Print the current user context name
+ac whoami -c
+
+# Print the current server's REST API URL
+ac whoami --show-server
+
+# Print the token the current session is using
+ac whoami -t
+```

--- a/docs/en/ui/cli_tools/ac/developer-command-reference.md
+++ b/docs/en/ui/cli_tools/ac/developer-command-reference.md
@@ -2020,4 +2020,5 @@ ac whoami --show-server
 
 # Print the token the current session is using
 ac whoami -t
+# Caution: the token printed by ac whoami -t is sensitive; do not expose it in logs, shell history, screenshots, or shared output.
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the developer command reference with comprehensive documentation for the `ac whoami` command, including usage examples for displaying the currently authenticated user, context details, server API URL, and authentication token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->