### PR TITLE
docs: register cnpg subsite

### DIFF
--- a/.cspell/brands.txt
+++ b/.cspell/brands.txt
@@ -3,3 +3,5 @@ multus
 tekton
 topolvm
 cpaas
+cnpg
+cloudnativepg

--- a/docs/en/appservice/postgresql/cnpg.mdx
+++ b/docs/en/appservice/postgresql/cnpg.mdx
@@ -1,0 +1,13 @@
+---
+weight: 71
+i18n:
+  title:
+    zh: 关于 Alauda support for CloudNativePG
+title: About Alauda support for CloudNativePG
+---
+
+Alauda support for CloudNativePG packages the upstream CloudNativePG (CNCF Sandbox) operator for Alauda Container Platform. Unlike older PostgreSQL operators that wrap Patroni and depend on a separate distributed consensus store (etcd, ZooKeeper), CNPG implements primary/standby coordination directly using Kubernetes primitives, significantly reducing failover time and removing an external dependency. PostgreSQL versions 14 through 18 are supported, with `standard` and `minimal` container variants for both amd64 and arm64.
+
+The Alauda distribution adds air-gapped operation (mirror-registry images for the operator, PostgreSQL containers, extensions, and PgBouncer), image-rewrite tolerance for ACP's admission rewriting, ACP-aligned L5 RBAC, and packaging via `violet push` to the platform OLM catalog source.
+
+<ExternalSite name="cnpg" href="/intro" />

--- a/sites.yaml
+++ b/sites.yaml
@@ -103,6 +103,13 @@
   base: /postgresql
   version: "4.3"
   repo: https://github.com/alauda/pg-docs
+- name: cnpg
+  displayName:
+    en: Alauda support for CloudNativePG
+    zh: Alauda support for CloudNativePG
+  base: /cnpg
+  version: "4.3"
+  repo: https://github.com/alauda/cnpg-docs
 - name: costmanagement
   displayName:
     en: Alauda Cost Management


### PR DESCRIPTION
Adds **Alauda support for CloudNativePG** as a subsite at `/cnpg` under the ACP product docs umbrella.

CNPG is the second PostgreSQL-track product shipped on ACP — it co-exists with the existing Zalando-based pg-docs at `/postgresql`. The two stay independent because the operator code, CRD schemas, and lifecycle policies differ substantially. Customers choose one or the other based on requirements (CNPG: Kubernetes-native HA, no Patroni/etcd, declarative logical replication; Zalando: existing fleet alignment, more mature ACP integration).

## Changes

- **`sites.yaml`**: register `cnpg` subsite, placed adjacent to `postgresql` for grouping. Same version (`4.3`) and convention.
- **`docs/en/appservice/postgresql/cnpg.mdx`** (new): about-page following the established pattern in this directory (alongside `pg.mdx`). Brief positioning paragraph + `<ExternalSite name="cnpg" href="/intro" />`.
- **`.cspell/brands.txt`**: add `cnpg` and `cloudnativepg` to the brand wordlist (caught by the `prepare_push.sh` lint hook).

## Companion changes (already on `alauda/cnpg-docs` main)

- `.builds/doc-build.yaml` + `.builds/doc-pr-build.yaml` with `doc-base: cnpg` (mirrors pg-docs exactly, just swapped doc-base).
- Initial content sections: intro, installation, architecture, upgrade, release_notes (5 of 10 planned). Pending: lifecycle_policy, functions/, how_to/, trouble_shooting/, apis/.

## Verification

- `yarn doom lint` passes after adding cnpg/cloudnativepg to brands.txt.
- Followed the procedure in https://product-doc-guide.alauda.cn/guide/register_subsite.html.
- Step 3 (`.builds/doc-build-config.yaml`) skipped because cnpg-docs is in `github.com/alauda/<name>` (the standard, non-special location).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Alauda support of the CloudNativePG PostgreSQL operator, covering operator features and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->