### PR TITLE
docs: backport Immutable Infrastructure path-selection banners to release-4.3

### DIFF
--- a/docs/en/configure/clusters/immutable-infra.mdx
+++ b/docs/en/configure/clusters/immutable-infra.mdx
@@ -1,10 +1,37 @@
 ---
 weight: 20
 title: Immutable Infrastructure
+queries:
+  - immutable infrastructure overview
+  - microos cluster path
+  - immutable infra entry point
+  - global cluster on immutable infrastructure
 ---
 
 # About Immutable Infrastructure
 
 Immutable Infrastructure uses an immutable operating system to provision Kubernetes clusters. Unlike traditional OS-based clusters, all node configurations are baked into images and remain unchanged after deployment. Cluster upgrades and configuration changes are applied by replacing nodes with new images, ensuring consistency, reliability, and simplified operations throughout the cluster lifecycle.
 
-<ExternalSite name="immutable-infra" />
+<Term name="productShort" /> supports Immutable Infrastructure on the following providers: Huawei DCS, VMware vSphere, and Huawei Cloud Stack. Bare-metal support is planned.
+
+For the full Immutable Infrastructure documentation set, see <ExternalSiteLink name="immutable-infra" href="/index.html" children="Immutable Infrastructure documentation" />.
+
+## Tasks
+
+The following scenarios cover Immutable Infrastructure across the cluster lifecycle.
+
+| Scenario | Documentation |
+|----------|---------------|
+| Install the `global` cluster | <ExternalSiteLink name="immutable-infra" href="/global/install.html" children="Installing the global Cluster on Immutable Infrastructure" /> |
+| Upgrade the `global` cluster | <ExternalSiteLink name="immutable-infra" href="/global/upgrade.html" children="Upgrading the global Cluster on Immutable Infrastructure" /> |
+| Plan disaster recovery for the `global` cluster | <ExternalSiteLink name="immutable-infra" href="/global/disaster_recovery.html" children="Global Cluster Disaster Recovery on Immutable Infrastructure" /> |
+| Install provider plugins | <ExternalSiteLink name="immutable-infra" href="/install/index.html" children="Installation" /> |
+| Configure infrastructure resources | <ExternalSiteLink name="immutable-infra" href="/infrastructure/index.html" children="Infrastructure Resources" /> |
+| Create workload clusters | <ExternalSiteLink name="immutable-infra" href="/create-cluster/index.html" children="Creating Clusters" /> |
+| Upgrade workload clusters | <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/index.html" children="Upgrading Clusters" /> |
+| Manage cluster nodes | <ExternalSiteLink name="immutable-infra" href="/manage-nodes/index.html" children="Managing Nodes" /> |
+| Configure machines (OS or kernel level) | <ExternalSiteLink name="immutable-infra" href="/machine-configuration/index.html" children="Machine Configuration" /> |
+
+## API Reference
+
+For Cluster API and provider CRD references, see <ExternalSiteLink name="immutable-infra" href="/apis/index.html" children="API Reference" />.

--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -4,6 +4,10 @@ weight: 40
 
 # Global Cluster Disaster Recovery
 
+<Directive type="info" title="Disaster Recovery Path">
+This page documents disaster recovery for `global` clusters running on a **traditional operating system**. Disaster recovery for `global` clusters on Immutable Infrastructure is in development; see <ExternalSiteLink name="immutable-infra" href="/global/disaster_recovery.html" children="Global Cluster Disaster Recovery on Immutable Infrastructure" />.
+</Directive>
+
 ## Overview
 
 This solution is designed for disaster recovery scenarios involving the `global` cluster. The `global` cluster serves as the control plane of the platform and is responsible for managing other clusters. To ensure continuous platform service availability when the `global` cluster fails, this solution deploys two `global` clusters: a Primary Cluster and a Standby Cluster.

--- a/docs/en/install/index.mdx
+++ b/docs/en/install/index.mdx
@@ -6,4 +6,8 @@ weight: 20
 
 This document will provide all the information regarding the installation of <Term name="productShort" />.
 
+<Directive type="info" title="Installation Path Selection">
+This section documents installation onto a **traditional operating system** such as Ubuntu or RHEL. If your environment runs on Immutable Infrastructure (MicroOS on Huawei DCS, VMware vSphere, or Huawei Cloud Stack), see <ExternalSiteLink name="immutable-infra" href="/global/install.html" children="Installing the global Cluster on Immutable Infrastructure" /> instead.
+</Directive>
+
 <Overview overviewHeaders={[]} />

--- a/docs/en/install/installing.mdx
+++ b/docs/en/install/installing.mdx
@@ -6,6 +6,10 @@ weight: 30
 
 This section describes the specific steps for installing the `global` cluster.
 
+<Directive type="info" title="Installation Path">
+This page documents the **traditional operating system** installation path. If your environment runs on Immutable Infrastructure (MicroOS on Huawei DCS, VMware vSphere, or Huawei Cloud Stack), see <ExternalSiteLink name="immutable-infra" href="/global/install.html" children="Installing the global Cluster on Immutable Infrastructure" /> instead.
+</Directive>
+
 Before starting the installation, please ensure that you have completed the prerequisite checks, installation package download and verification, node preprocessing, and other preparatory work.
 
 ## Process

--- a/docs/en/install/overview.mdx
+++ b/docs/en/install/overview.mdx
@@ -18,6 +18,10 @@ The following content covers platform architecture design, installation methods,
 
 ## Installation Method
 
+<Directive type="info" title="Installation Path">
+The procedure described in this section installs the `global` cluster onto a **traditional operating system** such as Ubuntu or RHEL. If you want the `global` cluster to run on Immutable Infrastructure (MicroOS on Huawei DCS, VMware vSphere, or Huawei Cloud Stack), see <ExternalSiteLink name="immutable-infra" href="/global/install.html" children="Installing the global Cluster on Immutable Infrastructure" /> instead.
+</Directive>
+
 The installation process of the `global` cluster is mainly divided into three stages:
 
 1.  **Preparation Stage**

--- a/docs/en/upgrade/index.mdx
+++ b/docs/en/upgrade/index.mdx
@@ -6,4 +6,11 @@ weight: 20
 
 This document will provide all the information regarding the upgrading of <Term name="productShort" />.
 
+<Directive type="info" title="Upgrade Path Selection">
+This section documents upgrades for environments running on a **traditional operating system**. If your environment runs on Immutable Infrastructure (MicroOS on Huawei DCS, VMware vSphere, or Huawei Cloud Stack):
+
+- Upgrade the `global` cluster: <ExternalSiteLink name="immutable-infra" href="/global/upgrade.html" children="Upgrading the global Cluster on Immutable Infrastructure" />
+- Upgrade workload clusters: <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/index.html" children="Upgrading Clusters on Immutable Infrastructure" />
+</Directive>
+
 <Overview overviewHeaders={[]} />

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -4,6 +4,10 @@ weight: 30
 
 # Upgrade the global cluster
 
+<Directive type="info" title="Upgrade Path">
+This page documents the **traditional operating system** upgrade path for the `global` cluster. If your `global` cluster runs on Immutable Infrastructure (MicroOS on Huawei DCS, VMware vSphere, or Huawei Cloud Stack), see <ExternalSiteLink name="immutable-infra" href="/global/upgrade.html" children="Upgrading the global Cluster on Immutable Infrastructure" /> instead.
+</Directive>
+
 :::warning MySQL-PXC Removed in Alauda Database Service for MySQL v4.3.0
 Upgrading the global cluster will also upgrade the MySQL operator. If you have PXC instances, they will become unmanaged after the operator upgrade. See <ExternalSiteLink name="mysql-mgr" href="/upgrade" children="MySQL Operator Upgrade Guide" /> for migration instructions before upgrading.
 :::

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -4,6 +4,10 @@ weight: 30
 
 # Upgrade Workload Clusters
 
+<Directive type="info" title="Upgrade Path">
+This page documents the **traditional operating system** upgrade path for workload clusters. For workload clusters that run on Immutable Infrastructure (MicroOS on Huawei DCS, VMware vSphere, or Huawei Cloud Stack), see <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/index.html" children="Upgrading Clusters on Immutable Infrastructure" /> instead.
+</Directive>
+
 :::warning MySQL-PXC Removed in Alauda Database Service for MySQL v4.3.0
 **MySQL-PXC is removed** starting from Alauda Database Service for MySQL v4.3.0. Existing PXC instances will no longer be managed by the MySQL operator after upgrading to ACP v4.3.0 or later. See <ExternalSiteLink name="mysql-mgr" href="/upgrade" children="MySQL Operator Upgrade Guide" /> for migration instructions before upgrading.
 :::


### PR DESCRIPTION
## Summary

Backports the Immutable Infrastructure path-selection banners from master (#760) to `release-4.3` so the GA documentation site catches up with the actually-shipped ACP 4.3 capability (MicroOS-on-`global` on Huawei DCS / VMware vSphere / Huawei Cloud Stack).

## What's included

- 7 banner edits: `install/index.mdx`, `install/overview.mdx`, `install/installing.mdx`, `install/global_dr.mdx`, `upgrade/index.mdx`, `upgrade/upgrade_global_cluster.mdx`, `upgrade/upgrade_workload_cluster.mdx`
- 1 stub-to-landing rewrite: `configure/clusters/immutable-infra.mdx` (curated table linking to nine scenario pages on immutable-infra-docs)
- "CentOS or RHEL" -> "Ubuntu or RHEL" (CentOS is EOL, K8s 1.35 dropped CentOS support)

## Backport-specific changes

- `upgrade_global_cluster.mdx` and `upgrade_workload_cluster.mdx` had merge conflicts: release-4.3 carries a `:::warning MySQL-PXC Removed in Alauda Database Service for MySQL v4.3.0` block that master no longer carries. Both blocks are kept; the new path-selection `<Directive>` is placed **before** the MySQL warning so readers on Immutable Infrastructure can bail out before reading the MySQL note.

## Validation

- [x] `yarn install` succeeded against the release-4.3 lockfile
- [x] `yarn lint` passes (0 errors / 0 warnings)
- [ ] Reviewer: confirm banner rendering and table layout via `yarn dev`

## Master PR

alauda/acp-docs#760 (merged)

## Companion backport

immutable-infra-docs Global Cluster section to release-1.0: alauda/immutable-infra-docs#63

Refs: AIT-66126