### PR TITLE
docs: backport etcd-sync guidance to release-4.3

### DIFF
--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -148,13 +148,6 @@ Refer to the following documentation to complete installation:
 4. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, and configure these parameters:
 
    <Tabs>
-     <Tab label="4.3.0">
-
-       * When not forwarding port `2379` through the load balancer, configure **Active Global Cluster ETCD Endpoints** correctly.
-       * Use the default value of **Data Check Interval**.
-       * Leave **Print detail logs** disabled unless troubleshooting.
-
-     </Tab>
      <Tab label="4.3.1+">
 
        Before installing the plugin, get the bearer token for accessing the active global cluster API server from the active global cluster. Copy the command output and use it when creating the `etcd-sync-active-cluster-token` Secret in the standby global cluster under the `cpaas-system` namespace. The Secret stores the token under the data key `token`.
@@ -192,6 +185,13 @@ Refer to the following documentation to complete installation:
        kubectl get certificate -n cpaas-system remote-etcd-client
        kubectl get secret -n cpaas-system remote-etcd-client
        ```
+
+     </Tab>
+     <Tab label="4.3.0">
+
+       * When not forwarding port `2379` through the load balancer, configure **Active Global Cluster ETCD Endpoints** correctly.
+       * Use the default value of **Data Check Interval**.
+       * Leave **Print detail logs** disabled unless troubleshooting.
 
      </Tab>
    </Tabs>

--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -150,7 +150,7 @@ Refer to the following documentation to complete installation:
    <Tabs>
      <Tab label="4.3.1+">
 
-       Before installing the plugin, get the bearer token for accessing the active global cluster API server from the active global cluster. Copy the command output and use it when creating the `etcd-sync-active-cluster-token` Secret in the standby global cluster under the `cpaas-system` namespace. The Secret stores the token under the data key `token`.
+       **Prerequisite (4.3.1+ only):** Create the `etcd-sync-active-cluster-token` Secret on the standby global cluster. First, get the bearer token for accessing the active global cluster API server from the active global cluster. Then copy the command output and use it when creating the Secret. The Secret stores the token under the data key `token`.
 
        ```bash
        # Run this command on the active cluster.
@@ -195,6 +195,8 @@ Refer to the following documentation to complete installation:
 
      </Tab>
    </Tabs>
+
+Wait until `kubectl get lease -n cpaas-system etcd-sync-mirror -o jsonpath='{.spec.holderIdentity}'` returns a non-empty value before continuing.
 
 Verify the sync Pods are running on the standby cluster and identify the current leader:
 

--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -180,21 +180,21 @@ Refer to the following documentation to complete installation:
        * Use the default value of **Data Check Interval**.
        * Leave **Print detail logs** disabled unless troubleshooting.
 
+       During installation, the system runs the `etcd-sync-bootstrap` Job before the `etcd-sync` Deployment starts. The plugin installation continues only after the Job prepares `remote-etcd-ca`, `remote-etcd-issuer`, and `remote-etcd-client`.
+
+       Verify the bootstrap Job and runtime resources:
+
+       ```bash
+       kubectl get job -n cpaas-system etcd-sync-bootstrap
+       kubectl logs -n cpaas-system job/etcd-sync-bootstrap
+       kubectl get secret -n cpaas-system remote-etcd-ca
+       kubectl get issuer -n cpaas-system remote-etcd-issuer
+       kubectl get certificate -n cpaas-system remote-etcd-client
+       kubectl get secret -n cpaas-system remote-etcd-client
+       ```
+
      </Tab>
    </Tabs>
-
-During installation, the system runs the `etcd-sync-bootstrap` Job before the `etcd-sync` Deployment starts. The plugin installation continues only after the Job prepares `remote-etcd-ca`, `remote-etcd-issuer`, and `remote-etcd-client`.
-
-Verify the bootstrap Job and runtime resources:
-
-```bash
-kubectl get job -n cpaas-system etcd-sync-bootstrap
-kubectl logs -n cpaas-system job/etcd-sync-bootstrap
-kubectl get secret -n cpaas-system remote-etcd-ca
-kubectl get issuer -n cpaas-system remote-etcd-issuer
-kubectl get certificate -n cpaas-system remote-etcd-client
-kubectl get secret -n cpaas-system remote-etcd-client
-```
 
 Verify the sync Pods are running on the standby cluster and identify the current leader:
 

--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -143,25 +143,73 @@ Refer to the following documentation to complete installation:
     If direct access from the standby cluster to the active global cluster is available, specify the etcd addresses via **Active Global Cluster ETCD Endpoints**.
     :::
 
-2. Access the **standby global cluster** Web Console using its VIP, and switch to **Administrator** view;
-3. Navigate to **Marketplace > Cluster Plugins**, select the `global` cluster;
-4. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, configure parameters:
+2. Access the **standby global cluster** Web Console using its VIP, and switch to **Administrator** view.
+3. Navigate to **Marketplace > Cluster Plugins**, select the `global` cluster.
+4. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, and configure these parameters:
 
-   * When not forwarding port `2379` through load balancer, its required to configure **Active Global Cluster ETCD Endpoints** correctly;
-   * Use the default value of **Data Check Interval**;
-   * Leave **Print detail logs** switch disabled unless troubleshooting.
+   <Tabs>
+     <Tab label="4.3.0">
 
-Verify the sync Pod is running on the standby cluster:
+       * When not forwarding port `2379` through the load balancer, configure **Active Global Cluster ETCD Endpoints** correctly.
+       * Use the default value of **Data Check Interval**.
+       * Leave **Print detail logs** disabled unless troubleshooting.
+
+     </Tab>
+     <Tab label="4.3.1+">
+
+       Before installing the plugin, get the bearer token for accessing the active global cluster API server from the active global cluster. Copy the command output and use it when creating the `etcd-sync-active-cluster-token` Secret in the standby global cluster under the `cpaas-system` namespace. The Secret stores the token under the data key `token`.
+
+       ```bash
+       # Run this command on the active cluster.
+       kubectl -n cpaas-system get secret k8sadmin -o jsonpath='{.data.token}' | base64 -d
+       ```
+
+       Copy the output value, then run this command on the standby cluster:
+
+       ```bash
+       ACTIVE_CLUSTER_TOKEN='<paste-the-token-from-the-active-cluster>'
+       kubectl -n cpaas-system create secret generic etcd-sync-active-cluster-token \
+         --from-literal=token="${ACTIVE_CLUSTER_TOKEN}" \
+         --dry-run=client -o yaml | kubectl apply -f -
+       ```
+
+       * Set **Active Global Cluster VIP** to the VIP of the active global cluster.
+       * When not forwarding port `2379` through the load balancer, configure **Active Global Cluster ETCD Endpoints** correctly.
+       * Set **Standby Cluster ETCD Endpoints** to the standby cluster etcd address. Use the default value unless the local etcd service is exposed through a different endpoint.
+       * Set **Active Global Cluster Token Secret** to `etcd-sync-active-cluster-token`.
+       * Use the default value of **Data Check Interval**.
+       * Leave **Print detail logs** disabled unless troubleshooting.
+
+     </Tab>
+   </Tabs>
+
+During installation, the system runs the `etcd-sync-bootstrap` Job before the `etcd-sync` Deployment starts. The plugin installation continues only after the Job prepares `remote-etcd-ca`, `remote-etcd-issuer`, and `remote-etcd-client`.
+
+Verify the bootstrap Job and runtime resources:
+
+```bash
+kubectl get job -n cpaas-system etcd-sync-bootstrap
+kubectl logs -n cpaas-system job/etcd-sync-bootstrap
+kubectl get secret -n cpaas-system remote-etcd-ca
+kubectl get issuer -n cpaas-system remote-etcd-issuer
+kubectl get certificate -n cpaas-system remote-etcd-client
+kubectl get secret -n cpaas-system remote-etcd-client
+```
+
+Verify the sync Pods are running on the standby cluster and identify the current leader:
 
 ```bash
 kubectl get po -n cpaas-system -l app=etcd-sync
-kubectl logs -n cpaas-system $(kubectl get po -n cpaas-system -l app=etcd-sync --no-headers | head -1) | grep -i "Start Sync update"
+kubectl get lease -n cpaas-system etcd-sync-mirror
+leader_pod=$(kubectl get lease -n cpaas-system etcd-sync-mirror -o jsonpath='{.spec.holderIdentity}')
+kubectl logs -n cpaas-system "$leader_pod" | grep -E "Acquired leader lease|Start Sync update"
 ```
 
-Once “Start Sync update” appears, recreate one of the pods to re-trigger sync of resources with ownerReference dependencies:
+If resources with `ownerReference` dependencies need to be resynchronized, recreate the current leader Pod after `Start Sync update` appears:
 
 ```bash
-kubectl delete po -n cpaas-system $(kubectl get po -n cpaas-system -l app=etcd-sync --no-headers | head -1)
+leader_pod=$(kubectl get lease -n cpaas-system etcd-sync-mirror -o jsonpath='{.spec.holderIdentity}')
+kubectl delete po -n cpaas-system "$leader_pod"
 ```
 
 Check sync status:
@@ -170,17 +218,17 @@ Check sync status:
 mirror_svc=$(kubectl get svc -n cpaas-system etcd-sync-monitor -o jsonpath='{.spec.clusterIP}')
 ipv6_regex="^[0-9a-fA-F:]+$"
 if [[ $mirror_svc =~ $ipv6_regex ]]; then
-  export mirror_new_svc="[$mirror_svc]"
+  mirror_host="[$mirror_svc]"
 else
-  export mirror_new_svc=$mirror_svc
+  mirror_host="$mirror_svc"
 fi
-curl $mirror_new_svc/check
+curl -g "http://${mirror_host}/check"
 ```
 
-**Output explanation:**
+**Output interpretation:**
 
-* `LOCAL ETCD missed keys`: Keys exist in the Primary but are missing from the standby. Often caused by GC due to resource order during sync. Restart one etcd-sync Pod to fix;
-* `LOCAL ETCD surplus keys`: Extra keys exist only in the standby cluster. Confirm with ops team before deleting these keys from the standby.
+- `LOCAL ETCD missed keys`: Keys exist in the primary global cluster but are missing from the standby. This often resolves after restarting the current `etcd-sync` leader Pod.
+- `LOCAL ETCD surplus keys`: Keys exist in the standby global cluster but not in the primary. Review these with your operations team before deleting them.
 
 If the following components are installed, restart their services:
 

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -335,19 +335,6 @@ Before reinstalling the plugin, verify that port `2379` is forwarded correctly f
 To reinstall the plugin:
 
 <Tabs>
-  <Tab label="4.3.0">
-
-  1. Access the **standby global cluster** Web Console through its VIP and switch to **Administrator** view.
-  2. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.
-  3. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, and configure the required parameters.
-
-  When you configure the plugin:
-
-  - When port `2379` is not forwarded through a load balancer, set **Active Global Cluster ETCD Endpoints** correctly.
-  - Use the default value of **Data Check Interval**.
-  - Leave **Print detail logs** disabled unless you are troubleshooting.
-
-  </Tab>
   <Tab label="4.3.1+">
 
   Before reinstalling the plugin, get the bearer token for accessing the active global cluster API server from the active global cluster. Copy the command output and use it when creating or updating the `etcd-sync-active-cluster-token` Secret in `cpaas-system`. The Secret stores the token under the data key `token`. Use this Secret through **Active Global Cluster Token Secret**. Legacy plain-token configuration remains only as a compatibility fallback and is not the recommended operational path.
@@ -391,6 +378,19 @@ To reinstall the plugin:
   kubectl get certificate -n cpaas-system remote-etcd-client
   kubectl get secret -n cpaas-system remote-etcd-client
   ```
+
+  </Tab>
+  <Tab label="4.3.0">
+
+  1. Access the **standby global cluster** Web Console through its VIP and switch to **Administrator** view.
+  2. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.
+  3. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, and configure the required parameters.
+
+  When you configure the plugin:
+
+  - When port `2379` is not forwarded through a load balancer, set **Active Global Cluster ETCD Endpoints** correctly.
+  - Use the default value of **Data Check Interval**.
+  - Leave **Print detail logs** disabled unless you are troubleshooting.
 
   </Tab>
 </Tabs>

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -379,21 +379,21 @@ To reinstall the plugin:
   - Use the default value of **Data Check Interval**.
   - Leave **Print detail logs** disabled unless you are troubleshooting.
 
+  During reinstallation, the system runs the `etcd-sync-bootstrap` Job before the `etcd-sync` Deployment starts. The release continues only after the Job prepares `remote-etcd-ca`, `remote-etcd-issuer`, and `remote-etcd-client`.
+
+  Verify the bootstrap Job and runtime resources:
+
+  ```bash
+  kubectl get job -n cpaas-system etcd-sync-bootstrap
+  kubectl logs -n cpaas-system job/etcd-sync-bootstrap
+  kubectl get secret -n cpaas-system remote-etcd-ca
+  kubectl get issuer -n cpaas-system remote-etcd-issuer
+  kubectl get certificate -n cpaas-system remote-etcd-client
+  kubectl get secret -n cpaas-system remote-etcd-client
+  ```
+
   </Tab>
 </Tabs>
-
-During reinstallation, the system runs the `etcd-sync-bootstrap` Job before the `etcd-sync` Deployment starts. The release continues only after the Job prepares `remote-etcd-ca`, `remote-etcd-issuer`, and `remote-etcd-client`.
-
-Verify the bootstrap Job and runtime resources:
-
-```bash
-kubectl get job -n cpaas-system etcd-sync-bootstrap
-kubectl logs -n cpaas-system job/etcd-sync-bootstrap
-kubectl get secret -n cpaas-system remote-etcd-ca
-kubectl get issuer -n cpaas-system remote-etcd-issuer
-kubectl get certificate -n cpaas-system remote-etcd-client
-kubectl get secret -n cpaas-system remote-etcd-client
-```
 
 Verify the sync Pods are running on the standby global cluster and identify the current leader:
 

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -337,7 +337,7 @@ To reinstall the plugin:
 <Tabs>
   <Tab label="4.3.1+">
 
-  Before reinstalling the plugin, get the bearer token for accessing the active global cluster API server from the active global cluster. Copy the command output and use it when creating or updating the `etcd-sync-active-cluster-token` Secret in `cpaas-system`. The Secret stores the token under the data key `token`. Use this Secret through **Active Global Cluster Token Secret**. Legacy plain-token configuration remains only as a compatibility fallback and is not the recommended operational path.
+  1. Create or update the `etcd-sync-active-cluster-token` Secret in `cpaas-system`. First, get the bearer token for accessing the active global cluster API server from the active global cluster. Then copy the command output and use it when creating the Secret. The Secret stores the token under the data key `token`. Use this Secret through **Active Global Cluster Token Secret**. Legacy plain-token configuration remains only as a compatibility fallback and is not the recommended operational path.
 
   ```bash
   # Run this command on the active cluster.
@@ -353,9 +353,9 @@ To reinstall the plugin:
     --dry-run=client -o yaml | kubectl apply -f -
   ```
 
-  1. Access the **standby global cluster** Web Console through its VIP and switch to **Administrator** view.
-  2. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.
-  3. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, and configure the required parameters.
+  2. Access the **standby global cluster** Web Console through its VIP and switch to **Administrator** view.
+  3. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.
+  4. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, and configure the required parameters.
 
   When you configure the plugin:
 
@@ -394,6 +394,8 @@ To reinstall the plugin:
 
   </Tab>
 </Tabs>
+
+Wait until `kubectl get lease -n cpaas-system etcd-sync-mirror -o jsonpath='{.spec.holderIdentity}'` returns a non-empty value before continuing.
 
 Verify the sync Pods are running on the standby global cluster and identify the current leader:
 

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -334,29 +334,81 @@ Before reinstalling the plugin, verify that port `2379` is forwarded correctly f
 
 To reinstall the plugin:
 
-1. Access the **standby global cluster** Web Console through its VIP and switch to **Administrator** view.
-2. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.
-3. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, and configure the required parameters.
+<Tabs>
+  <Tab label="4.3.0">
 
-When you configure the plugin:
+  1. Access the **standby global cluster** Web Console through its VIP and switch to **Administrator** view.
+  2. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.
+  3. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, and configure the required parameters.
 
-- When port `2379` is not forwarded through a load balancer, set **Active Global Cluster ETCD Endpoints** correctly.
-- Use the default value of **Data Check Interval**.
-- Leave **Print detail logs** disabled unless you are troubleshooting.
+  When you configure the plugin:
 
-Verify the sync Pod is running on the standby global cluster:
+  - When port `2379` is not forwarded through a load balancer, set **Active Global Cluster ETCD Endpoints** correctly.
+  - Use the default value of **Data Check Interval**.
+  - Leave **Print detail logs** disabled unless you are troubleshooting.
+
+  </Tab>
+  <Tab label="4.3.1+">
+
+  Before reinstalling the plugin, get the bearer token for accessing the active global cluster API server from the active global cluster. Copy the command output and use it when creating or updating the `etcd-sync-active-cluster-token` Secret in `cpaas-system`. The Secret stores the token under the data key `token`. Use this Secret through **Active Global Cluster Token Secret**. Legacy plain-token configuration remains only as a compatibility fallback and is not the recommended operational path.
+
+  ```bash
+  # Run this command on the active cluster.
+  kubectl -n cpaas-system get secret k8sadmin -o jsonpath='{.data.token}' | base64 -d
+  ```
+
+  Copy the output value, then run this command on the standby cluster:
+
+  ```bash
+  ACTIVE_CLUSTER_TOKEN='<paste-the-token-from-the-active-cluster>'
+  kubectl -n cpaas-system create secret generic etcd-sync-active-cluster-token \
+    --from-literal=token="${ACTIVE_CLUSTER_TOKEN}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  ```
+
+  1. Access the **standby global cluster** Web Console through its VIP and switch to **Administrator** view.
+  2. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.
+  3. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, and configure the required parameters.
+
+  When you configure the plugin:
+
+  - Set **Active Global Cluster VIP** to the VIP of the active global cluster.
+  - When port `2379` is not forwarded through a load balancer, set **Active Global Cluster ETCD Endpoints** correctly.
+  - Set **Standby Cluster ETCD Endpoints** to the standby cluster etcd address. Use the default value unless the local etcd service is exposed through a different endpoint.
+  - Set **Active Global Cluster Token Secret** to `etcd-sync-active-cluster-token`.
+  - Use the default value of **Data Check Interval**.
+  - Leave **Print detail logs** disabled unless you are troubleshooting.
+
+  </Tab>
+</Tabs>
+
+During reinstallation, the system runs the `etcd-sync-bootstrap` Job before the `etcd-sync` Deployment starts. The release continues only after the Job prepares `remote-etcd-ca`, `remote-etcd-issuer`, and `remote-etcd-client`.
+
+Verify the bootstrap Job and runtime resources:
+
+```bash
+kubectl get job -n cpaas-system etcd-sync-bootstrap
+kubectl logs -n cpaas-system job/etcd-sync-bootstrap
+kubectl get secret -n cpaas-system remote-etcd-ca
+kubectl get issuer -n cpaas-system remote-etcd-issuer
+kubectl get certificate -n cpaas-system remote-etcd-client
+kubectl get secret -n cpaas-system remote-etcd-client
+```
+
+Verify the sync Pods are running on the standby global cluster and identify the current leader:
 
 ```bash
 kubectl get po -n cpaas-system -l app=etcd-sync
-etcd_sync_pod=$(kubectl get po -n cpaas-system -l app=etcd-sync -o jsonpath='{.items[0].metadata.name}')
-kubectl logs -n cpaas-system "$etcd_sync_pod" | grep -i "Start Sync update"
+kubectl get lease -n cpaas-system etcd-sync-mirror
+leader_pod=$(kubectl get lease -n cpaas-system etcd-sync-mirror -o jsonpath='{.spec.holderIdentity}')
+kubectl logs -n cpaas-system "$leader_pod" | grep -E "Acquired leader lease|Start Sync update"
 ```
 
-Once `Start Sync update` appears, recreate one of the Pods to trigger synchronization of resources with ownerReference dependencies:
+If resources with `ownerReference` dependencies need to be resynchronized, recreate the current leader Pod after `Start Sync update` appears:
 
 ```bash
-etcd_sync_pod=$(kubectl get po -n cpaas-system -l app=etcd-sync -o jsonpath='{.items[0].metadata.name}')
-kubectl delete po -n cpaas-system "$etcd_sync_pod"
+leader_pod=$(kubectl get lease -n cpaas-system etcd-sync-mirror -o jsonpath='{.spec.holderIdentity}')
+kubectl delete po -n cpaas-system "$leader_pod"
 ```
 
 Check sync status:
@@ -374,7 +426,7 @@ curl -g "http://${mirror_host}/check"
 
 Output interpretation:
 
-- `LOCAL ETCD missed keys`: Keys exist in the primary global cluster but are missing from the standby. This often resolves after restarting one `etcd-sync` Pod.
+- `LOCAL ETCD missed keys`: Keys exist in the primary global cluster but are missing from the standby. This often resolves after restarting the current `etcd-sync` leader Pod.
 - `LOCAL ETCD surplus keys`: Keys exist in the standby global cluster but not in the primary. Review these with your operations team before deleting them.
 
 </Steps>

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -339,19 +339,19 @@ To reinstall the plugin:
 
   1. Create or update the `etcd-sync-active-cluster-token` Secret in `cpaas-system`. First, get the bearer token for accessing the active global cluster API server from the active global cluster. Then copy the command output and use it when creating the Secret. The Secret stores the token under the data key `token`. Use this Secret through **Active Global Cluster Token Secret**. Legacy plain-token configuration remains only as a compatibility fallback and is not the recommended operational path.
 
-  ```bash
-  # Run this command on the active cluster.
-  kubectl -n cpaas-system get secret k8sadmin -o jsonpath='{.data.token}' | base64 -d
-  ```
+     ```bash
+     # Run this command on the active cluster.
+     kubectl -n cpaas-system get secret k8sadmin -o jsonpath='{.data.token}' | base64 -d
+     ```
 
-  Copy the output value, then run this command on the standby cluster:
+     Copy the output value, then run this command on the standby cluster:
 
-  ```bash
-  ACTIVE_CLUSTER_TOKEN='<paste-the-token-from-the-active-cluster>'
-  kubectl -n cpaas-system create secret generic etcd-sync-active-cluster-token \
-    --from-literal=token="${ACTIVE_CLUSTER_TOKEN}" \
-    --dry-run=client -o yaml | kubectl apply -f -
-  ```
+     ```bash
+     ACTIVE_CLUSTER_TOKEN='<paste-the-token-from-the-active-cluster>'
+     kubectl -n cpaas-system create secret generic etcd-sync-active-cluster-token \
+       --from-literal=token="${ACTIVE_CLUSTER_TOKEN}" \
+       --dry-run=client -o yaml | kubectl apply -f -
+     ```
 
   2. Access the **standby global cluster** Web Console through its VIP and switch to **Administrator** view.
   3. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.


### PR DESCRIPTION
## Summary
- backport the etcd-sync install and upgrade guidance from #675 onto `release-4.3`
- keep `4.3.0` and `4.3.1+` in local Tabs for the token and plugin-setting differences
- align the verification flow with the newer bootstrap, leader-aware, and IPv4/IPv6-safe checks
- clarify the `4.3.1+` token Secret prerequisite and wait for a non-empty lease holder before running leader-aware verification

## Relation to #675
- #763 is the `release-4.3` follow-up to #675
- it carries over the same etcd-sync install and upgrade guidance updates
- it keeps the `release-4.3` doc usable for both `4.3.0` and `4.3.1+` by splitting only the version-specific steps into Tabs

## Testing
- `git diff --check`
- `yarn lint`