### PR TITLE
docs: address violet review feedback

### DIFF
--- a/docs/en/extend/upload_package.mdx
+++ b/docs/en/extend/upload_package.mdx
@@ -72,7 +72,7 @@ mv -f violet_darwin_arm64 /usr/bin/violet && chmod +x /usr/bin/violet
 
 **Permission requirements**
 
-* You must provide a valid platform user account (username and password).
+* You must provide valid platform credentials, either a username and password or a platform token.
 * The account must have the role property set to **`System`** and the role name must be **`platform-admin-system`**.
 
 > **Note:** If the role property of your account is set to `Custom`, you cannot use this tool.
@@ -89,7 +89,11 @@ Several `violet` commands accept the following parameters. Refer to individual c
 --platform-address <platform access URL>     # The access URL of the platform, e.g., "https://example.com"
 --platform-username <platform user>          # The username of the platform user
 --platform-password <platform password>      # The password of the platform user
+--platform-token <platform token>            # The platform access token; cannot be used together with username/password
+--client-id <OAuth client ID>                # OAuth client ID for username/password login; ignored when --platform-token is set. Override "alauda-auth" only for custom OAuth clients.
 ```
+
+To create or manage platform tokens, sign in to the platform Web Console, open **Profile** > **API Tokens**, and create a token with an appropriate expiration. For details, see [API Authentication](../apis/overview/intro.mdx).
 
 #### Image Registry Parameters
 
@@ -130,16 +134,137 @@ RelateImages: [harbor.demo.io/acp/topolvm-operator:v3.11.0 harbor.demo.io/acp/to
 
 ### violet list \{#violet_list_usage}
 
-When upgrading the platform, you can list all plugins that have been uploaded to the platform and export the result to a file.
-The generated file can then be uploaded to Alauda Cloud so that the required plugin packages can be downloaded.
+When upgrading the platform, use `violet list` to list installed extensions and export the result to a YAML file. The generated file can then be uploaded to Alauda Cloud so that the required extension packages can be downloaded.
+
+`violet list` covers extensions with the **Aligned** or **Agnostic** life cycle. **Core** plugins follow the cluster upgrade and are not managed through `violet list`.
+
+The command lists the following application types:
+
+* **ModulePlugin** — cluster plugins whose lifecycle type is `aligned` or `agnostic`.
+* **OperatorBundle** — installed operators.
+* **Chart** — Helm chart applications created from chart references.
+
+By default, the command prints the YAML content to stdout and writes it to `apps.yaml` in the current directory.
+
+```bash
+violet list \
+  --platform-address "https://example.com" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>"
+```
+
+You can also authenticate with a platform token instead of username and password:
+
+```bash
+violet list \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>"
+```
+
+To export only applications installed in specific clusters, specify multiple cluster names separated by commas:
+
+```bash
+violet list \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>" \
+  --clusters "global,region1" \
+  --output-file "./apps.yaml"
+```
+
+Example output:
+
+```yaml
+applications:
+  topolvm-operator:
+    displayName: NativeStor
+    type: OperatorBundle
+    installed:
+      - clusterName: global
+        version: 2.3.0
+  log-center:
+    displayName: Log Center
+    type: ModulePlugin
+    installed:
+      - clusterName: region1
+        version: v1.2.0
+```
 
 #### Optional Flags
 ```
 --output-file <output file>                  # The path of the output plugin list file
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
 
+
+### violet gc \{#violet_gc_usage}
+
+Use `violet gc` to clean up uninstalled Operator and Cluster Plugin resources whose life cycle is **Aligned** or **Agnostic**. The command deletes resources that are no longer installed or no longer match the installed version.
+
+The command can delete the following resource types:
+
+* **Artifact** — artifacts for uninstalled operators.
+* **ArtifactVersion** — old artifact versions for installed operators. The currently installed CSV or version is kept.
+* **ModulePlugin** — cluster plugins that are not installed in any cluster.
+* **ModuleConfig** — obsolete cluster plugin configuration records.
+
+`violet gc` determines cleanup candidates by checking `OperatorView` and `ModulePluginView` records in the global cluster.
+
+:::danger
+`violet gc` deletes resources from the global cluster and does not provide a dry-run mode or undo operation. Run it only during a documented maintenance window and verify the target clusters before using `--clusters`.
+:::
+
+By default, the command scans all clusters visible to the platform user and prints a summary of deleted resources.
+
+```bash
+violet gc \
+  --platform-address "https://example.com" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>"
+```
+
+You can also authenticate with a platform token instead of username and password:
+
+```bash
+violet gc \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>"
+```
+
+To clean up resources related to specific clusters only, specify multiple cluster names separated by commas:
+
+```bash
+violet gc \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>" \
+  --clusters "global,region1"
+```
+
+Example output:
+
+```text
+GC Summary:
+TYPE                 NAME                                               CLUSTER
+------------------------------------------------------------------------------------------
+Artifact             opensearch-operator                                region1
+ArtifactVersion      opensearch-operator.v2.8.0                         region1
+ModuleConfig         log-center-default                                 global
+```
+
+If no resources are deleted, the command prints:
+
+```text
+No resources were deleted.
+```
+
+#### Optional Flags
+
+```
+--clusters <cluster names>                   # Limit cleanup to the specified clusters, separated by commas
+--debug                                      # Use debug log level
+```
+
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
 
 ### violet verify \{#violet_verify_usage}
 
@@ -192,10 +317,16 @@ The following examples illustrate common usage scenarios.
 
 For platform connection and image registry parameters, see [Common Parameters](#common-parameters).
 
+For non-interactive use, prefer `--platform-token` over `--platform-password`. See [Common Parameters](#common-parameters).
+
 #### Optional Flags
 
 ```
 --clusters <cluster names>                   # Specify target clusters, separated by commas (e.g., region1,region2)
+--target-catalog-source <catalog source>     # Target CatalogSource for operators: "platform", "system", or a custom CatalogSource name (default: "platform")
+--target-chartrepo <chart repository>        # Target chart repository for Helm charts (default: "public-charts", the platform-managed Helm repository)
+--skip-crs                                   # Skip creating custom resources in the cluster
+--skip-push                                  # Skip pushing images and artifacts to the registry
 ```
 
 When `--dest-repo` is specified, either the authentication info of the image registry or `--no-auth` MUST be provided.

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -45,17 +45,11 @@ If you want to upgrade cluster **Extensions** during the upgrade, follow these s
    ```bash
    violet list \
      --platform-address "https://<your-platform-domain>" \
-     --platform-username "<platform_user>" \
-     --platform-password "<platform_password>" \
+     --platform-token "<platform_token>" \
      --output-file "./apps.yaml"
    ```
 
-   :::warning
-   Passing `--platform-password` on the command line records the password in
-   shell history and process listings (`ps aux`). If your environment supports
-   reading the password from stdin or an environment variable, prefer that
-   path; run `violet list --help` to see available alternatives.
-   :::
+   Prefer `--platform-token` over `--platform-password` to avoid exposing passwords in shell history and process listings (`ps aux`).
 
 3. Import the exported `apps.yaml` file into the **<Term name="company" /> Customer Portal** to align the extension list.
 
@@ -69,6 +63,8 @@ violet push <path/to/directory/only_put_topolvm_plugin_here> \
   --platform-username "<platform_user>" \
   --platform-password "<platform_password>" \
   --clusters "<cluster_name>"
+  --platform-token "<platform_token>" \
+  --clusters "cluster-a,cluster-b"
 ```
 :::
 


### PR DESCRIPTION
Clarify token-based authentication guidance and cleanup warnings so the violet command docs match the reviewed upgrade flow.