### PR TITLE
docs: address violet review feedback

### DIFF
--- a/docs/en/extend/upload_package.mdx
+++ b/docs/en/extend/upload_package.mdx
@@ -72,12 +72,46 @@ mv -f violet_darwin_arm64 /usr/bin/violet && chmod +x /usr/bin/violet
 
 **Permission requirements**
 
-* You must provide a valid platform user account (username and password).
+* You must provide valid platform credentials, either a username and password or a platform token.
 * The account must have the role property set to **`System`** and the role name must be **`platform-admin-system`**.
 
 > **Note:** If the role property of your account is set to `Custom`, you cannot use this tool.
 
 ## Usage
+
+### Common Parameters \{#common-parameters}
+
+Several `violet` commands accept the following parameters. Refer to individual command sections for specific usage.
+
+#### Platform Connection Parameters
+
+```
+--platform-address <platform access URL>     # The access URL of the platform, e.g., "https://example.com"
+--platform-username <platform user>          # The username of the platform user
+--platform-password <platform password>      # The password of the platform user
+--platform-token <platform token>            # The platform access token; cannot be used together with username/password
+--client-id <OAuth client ID>                # OAuth client ID for username/password login; ignored when --platform-token is set. Override "alauda-auth" only for custom OAuth clients.
+```
+
+To create or manage platform tokens, sign in to the platform Web Console, open **Profile** > **API Tokens**, and create a token with an appropriate expiration. For details, see [API Authentication](../apis/overview/intro.mdx).
+
+#### Image Registry Parameters
+
+```
+--dest-repo <image repository address>       # Specify the destination image repository address, e.g., "harbor.demo.io"
+--username <registry user>                   # The username of the specified image registry
+--password <registry password>               # The password of the specified image registry
+--no-auth                                    # Specify if the image registry does not require authentication
+--plain                                      # Specify if the image registry uses HTTP instead of HTTPS
+```
+
+:::warning
+**IPv6 Address Limitation**
+
+For `--platform-address` and `--dest-repo` parameters:
+* If using an IP address (rather than a domain name), **IPv6 format is NOT supported**
+* Only IPv4 addresses or domain names are supported
+:::
 
 ### violet show
 
@@ -99,28 +133,205 @@ Artifact: harbor.demo.io/acp/topolvm-operator-bundle:v3.11.0
 RelateImages: [harbor.demo.io/acp/topolvm-operator:v3.11.0 harbor.demo.io/acp/topolvm:v3.11.0 harbor.demo.io/3rdparty/k8scsi/csi-provisioner:v3.00 ...]
 ```
 
+### violet list \{#violet_list_usage}
+
+When upgrading the platform, use `violet list` to list installed extensions and export the result to a YAML file. The generated file can then be uploaded to Alauda Cloud so that the required extension packages can be downloaded.
+
+`violet list` covers extensions with the **Aligned** or **Agnostic** life cycle. **Core** plugins follow the cluster upgrade and are not managed through `violet list`.
+
+The command lists the following application types:
+
+* **ModulePlugin** — cluster plugins whose lifecycle type is `aligned` or `agnostic`.
+* **OperatorBundle** — installed operators.
+* **Chart** — Helm chart applications created from chart references.
+
+By default, the command prints the YAML content to stdout and writes it to `apps.yaml` in the current directory.
+
+```bash
+violet list \
+  --platform-address "https://example.com" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>"
+```
+
+You can also authenticate with a platform token instead of username and password:
+
+```bash
+violet list \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>"
+```
+
+To export only applications installed in specific clusters, specify multiple cluster names separated by commas:
+
+```bash
+violet list \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>" \
+  --clusters "global,region1" \
+  --output-file "./apps.yaml"
+```
+
+Example output:
+
+```yaml
+applications:
+  topolvm-operator:
+    displayName: NativeStor
+    type: OperatorBundle
+    installed:
+      - clusterName: global
+        version: 2.3.0
+  log-center:
+    displayName: Log Center
+    type: ModulePlugin
+    installed:
+      - clusterName: region1
+        version: v1.2.0
+```
+
+#### Optional Flags
+```
+--output-file <output file>                  # The path of the output plugin list file
+```
+
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
+
+
+### violet gc \{#violet_gc_usage}
+
+Use `violet gc` to clean up uninstalled Operator and Cluster Plugin resources whose life cycle is **Aligned** or **Agnostic**. The command deletes resources that are no longer installed or no longer match the installed version.
+
+The command can delete the following resource types:
+
+* **Artifact** — artifacts for uninstalled operators.
+* **ArtifactVersion** — old artifact versions for installed operators. The currently installed CSV or version is kept.
+* **ModulePlugin** — cluster plugins that are not installed in any cluster.
+* **ModuleConfig** — obsolete cluster plugin configuration records.
+
+`violet gc` determines cleanup candidates by checking `OperatorView` and `ModulePluginView` records in the global cluster.
+
+:::danger
+`violet gc` deletes resources from the global cluster and does not provide a dry-run mode or undo operation. Run it only during a documented maintenance window and verify the target clusters before using `--clusters`.
+:::
+
+By default, the command scans all clusters visible to the platform user and prints a summary of deleted resources.
+
+```bash
+violet gc \
+  --platform-address "https://example.com" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>"
+```
+
+You can also authenticate with a platform token instead of username and password:
+
+```bash
+violet gc \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>"
+```
+
+To clean up resources related to specific clusters only, specify multiple cluster names separated by commas:
+
+```bash
+violet gc \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>" \
+  --clusters "global,region1"
+```
+
+Example output:
+
+```text
+GC Summary:
+TYPE                 NAME                                               CLUSTER
+------------------------------------------------------------------------------------------
+Artifact             opensearch-operator                                region1
+ArtifactVersion      opensearch-operator.v2.8.0                         region1
+ModuleConfig         log-center-default                                 global
+```
+
+If no resources are deleted, the command prints:
+
+```text
+No resources were deleted.
+```
+
+#### Optional Flags
+
+```
+--clusters <cluster names>                   # Limit cleanup to the specified clusters, separated by commas
+--debug                                      # Use debug log level
+```
+
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
+
+### violet verify \{#violet_verify_usage}
+
+Use the `violet verify` command to verify the signature of one or more packages before uploading them.
+Two verification methods are supported: **checksum** and **GPG**.
+The package (`.tgz`) and its corresponding signature file must be located in the same directory.
+
+```bash
+violet verify example.tgz
+# or verify all packages within a directory
+violet verify packages_dir_name
+```
+
+Example output:
+
+```
+verify path: /path/to/packages
+====== Verification Summary ======
+Verified successfully with GPG: 2 file(s)
+  - /path/to/packages/redis-operator.tgz
+  - /path/to/packages/mysql-operator.tgz
+
+Verified successfully with checksum: 1 file(s)
+  - /path/to/packages/nginx-controller.tgz
+
+Verification failed: 1 file(s)
+  - /path/to/packages/etcd-operator.tgz
+
+No verification file found: 1 file(s)
+  - /path/to/packages/demo-plugin.tgz
+```
+
+**Explanation:**
+
+* **Verified successfully with GPG** — The listed files have been successfully verified using **GPG signature files** (with `.sig` extension).
+* **Verified successfully with checksum** — Files verified using checksum files (e.g., `.sha256`) passed the integrity check.
+* **Verification failed** — The listed files failed verification due to mismatched or invalid signatures.
+* **No verification file found** — No corresponding `.sig` (GPG) or checksum file was found in the directory.
+
+#### Optional Flags
+
+```
+--debug       Use debug log level.
+-h, --help    Display help information for the verify command.
+```
+
 ### violet push \{#violet_push_usage}
 
 The following examples illustrate common usage scenarios.
-Before digging into the examples, here are some common OPTIONAL parameters used in the commands:
+
+For platform connection and image registry parameters, see [Common Parameters](#common-parameters).
+
+For non-interactive use, prefer `--platform-token` over `--platform-password`. See [Common Parameters](#common-parameters).
+
+#### Optional Flags
 
 ```
---platform-address <platform access URL>     # The access URL of the platform, e.g., "https://example.com"
---platform-username <platform user>          # The username of the platform user
---platform-password <platform password>      # The password of the platform user
 --clusters <cluster names>                   # Specify target clusters, separated by commas (e.g., region1,region2)
-
---dest-repo <image repository URL>           # Specify the destination image repository URL. MUST be specified when uploading extensions to a standby cluster.
-                                                 When `--dest-repo` is specified, either the authentication info of the image registry or `--no-auth` MUST be provided.
---username <registry user>                   # The username of the specified image registry.
---password <registry password>               # The password of the specified image registry.
---no-auth                                    # Specify if the image registry does not require authentication.
---plain                                      # Specify if the image registry uses HTTP instead of HTTPS.
-
+--target-catalog-source <catalog source>     # Target CatalogSource for operators: "platform", "system", or a custom CatalogSource name (default: "platform")
+--target-chartrepo <chart repository>        # Target chart repository for Helm charts (default: "public-charts", the platform-managed Helm repository)
 --skip-crs                                   # Skip creating `Artifact` and `ArtifactVersion` resources, only push images.
                                                  This prevents Operators or Cluster Plugins from being updated prematurely during the <Term name="productShort" /> upgrade process.
 --skip-push                                  # Only create `Artifact` and `ArtifactVersion` resources, while images are not pushed.
 ```
+
+When uploading extensions to a standby cluster, specify `--dest-repo`. When `--dest-repo` is specified, either the image registry authentication information or `--no-auth` must be provided. See [Common Parameters](#common-parameters).
 
 #### Upload an Operator to Multiple Clusters
 

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -61,17 +61,11 @@ If you want to upgrade cluster **Extensions** during the upgrade, follow these s
    ```bash
    violet list \
      --platform-address "https://<your-platform-domain>" \
-     --platform-username "<platform_user>" \
-     --platform-password "<platform_password>" \
+     --platform-token "<platform_token>" \
      --output-file "./apps.yaml"
    ```
 
-   :::warning
-   Passing `--platform-password` on the command line records the password in
-   shell history and process listings (`ps aux`). If your environment supports
-   reading the password from stdin or an environment variable, prefer that
-   path; run `violet list --help` to see available alternatives.
-   :::
+   Prefer `--platform-token` over `--platform-password` to avoid exposing passwords in shell history and process listings (`ps aux`).
 
 3. Import the exported `apps.yaml` file into the **<Term name="company" /> Customer Portal** to align the extension list.
 


### PR DESCRIPTION
Clarify token-based authentication guidance and cleanup warnings so the violet command docs match the reviewed upgrade flow.