### PR TITLE
docs: add install guide for new web console (Preview)

### DIFF
--- a/docs/en/ui/new_web_console/index.mdx
+++ b/docs/en/ui/new_web_console/index.mdx
@@ -1,0 +1,22 @@
+---
+weight: 15
+i18n:
+  title:
+    en: New Web Console (Preview)
+queries:
+  - new web console preview
+  - next-gen console overview
+  - acp new console plugin
+---
+
+# New Web Console (Preview)
+
+The new web console is the next-generation web console for <Term name="product" />.
+It is delivered as cluster plugins rather than as part of the platform core, and
+runs in parallel with the existing web console during the Preview phase.
+
+This section explains how to install the framework plugins and access the new web
+console. The existing web console is documented under
+[Web Console](../web_console/index.mdx).
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/ui/new_web_console/install.mdx
+++ b/docs/en/ui/new_web_console/install.mdx
@@ -1,0 +1,211 @@
+---
+weight: 20
+i18n:
+  title:
+    en: Installing and Accessing the New Web Console
+queries:
+  - install new web console plugin
+  - Web Console Base Collector install
+  - access preview next-gen console
+  - uninstall new web console plugin
+---
+
+# Installing and Accessing the New Web Console
+
+## Introduction
+
+This page explains how to install the framework plugins required by the new web
+console and how to access the new web console afterwards. After completing this
+flow, an entry called **Preview Next-Gen Console** appears in the existing web
+console and opens the new web console in a separate browser tab.
+
+The new web console is in Preview during this release. Only a small set of
+feature plugins has been migrated so far; for any specific feature, refer to
+that plugin's own documentation.
+
+## Framework plugins
+
+Two cluster plugins make up the new web console framework. Both must be
+installed manually through Marketplace; neither is installed automatically.
+
+| Plugin (Marketplace display name) | Where to install | Role |
+| :--- | :--- | :--- |
+| **Alauda Container Platform Web Console Base** | `global` cluster only | Hosts the new web console frontend and the cross-cluster aggregation backend. Cluster affinity restricts this plugin to the `global` cluster. |
+| **Alauda Container Platform Web Console Collector** | `global` cluster plus every workload cluster whose plugin UIs should appear in the new web console | Exposes the cluster-local plugin resources to the **Web Console Base** for aggregation. A cluster whose plugin UIs need to be visible in the new web console must run this plugin. |
+
+The **Web Console Base** plugin must also be installed on the `global` cluster
+for the **Preview Next-Gen Console** entry to appear in the existing web
+console.
+
+<Directive type="info" title="Why install the Collector on the global cluster">
+The `global` cluster also hosts user-installed plugins. To expose those plugins
+to the new web console, install the **Web Console Collector** on `global` in
+addition to the **Web Console Base**.
+</Directive>
+
+## Prerequisites
+
+Before starting the installation, ensure the following requirements are met:
+
+- The `global` cluster runs an <Term name="product" /> version that ships the
+  new web console preview.
+- You have access to the <Term name="company" /> Customer Portal to download
+  cluster plugin packages, or you have obtained the plugin packages through
+  technical support.
+- The `violet` command-line tool is available. See
+  [Violet](../cli_tools/violet.mdx) for installation and usage instructions.
+- You have administrator permission to install cluster plugins through
+  Marketplace.
+- For each workload cluster whose plugin UIs you want to expose in the new web
+  console, the workload cluster is already managed by the `global` cluster.
+
+## Installation overview
+
+The installation flow has four steps:
+
+1. Download the **Web Console Base** and **Web Console Collector** plugin
+   packages.
+2. Upload both packages to the platform.
+3. Install **Web Console Base** on the `global` cluster.
+4. Install **Web Console Collector** on the `global` cluster and on every
+   workload cluster whose plugin UIs should appear in the new web console.
+
+## Step 1: Download the plugin packages
+
+1. Visit the <Term name="company" /> Customer Portal.
+2. Locate the cluster plugin packages with the following display names and
+   download them:
+   - **Alauda Container Platform Web Console Base**
+   - **Alauda Container Platform Web Console Collector**
+3. If you do not have access to the Customer Portal, contact technical support
+   to obtain both packages.
+
+For general guidance on downloading plugin packages, see
+[Downloading a Plugin Package](../../extend/download_package.mdx).
+
+## Step 2: Upload the packages to the platform
+
+Use the `violet` tool to publish both downloaded packages to the platform. For
+general guidance on uploading plugin packages, see
+[Uploading a Plugin Package](../../extend/upload_package.mdx).
+
+After upload completes, verify that both plugins are available:
+
+1. Sign in to the existing web console and switch to the **Administrator**
+   view.
+2. Navigate to **Marketplace** > **Cluster Plugins**.
+3. Confirm that both **Alauda Container Platform Web Console Base** and
+   **Alauda Container Platform Web Console Collector** are listed.
+
+## Step 3: Install Web Console Base on the global cluster
+
+1. In the **Administrator** view, navigate to **Marketplace** > **Cluster
+   Plugins**.
+2. Locate **Alauda Container Platform Web Console Base**.
+3. Click **Install** and select the `global` cluster as the target cluster.
+4. Wait for the plugin to reach a ready state.
+
+<Directive type="info" title="Cluster affinity">
+**Web Console Base** can only be installed on the `global` cluster. The plugin
+declares a cluster affinity that restricts it to clusters labeled
+`is-global: "true"`.
+</Directive>
+
+For the generic cluster plugin installation flow, see
+[Cluster Plugin](../../extend/cluster_plugin.mdx).
+
+## Step 4: Install Web Console Collector
+
+Install **Web Console Collector** on each cluster whose plugin UIs need to be
+visible in the new web console. At minimum, install it on the `global` cluster.
+
+For each target cluster:
+
+1. In the **Administrator** view, navigate to **Marketplace** > **Cluster
+   Plugins**.
+2. Locate **Alauda Container Platform Web Console Collector**.
+3. Click **Install** and select the target cluster.
+4. Wait for the plugin to reach a ready state.
+5. Repeat the previous steps for each additional workload cluster that needs
+   to expose its plugin UIs.
+
+<Directive type="info" title="Which clusters need the Collector">
+Install the **Web Console Collector** on every cluster whose plugin UIs need
+to be visible in the new web console. A workload cluster that does not have
+the **Web Console Collector** will not have its plugin UIs aggregated into the
+new web console.
+</Directive>
+
+## Accessing the new web console
+
+After the **Web Console Base** plugin is installed and ready on the `global`
+cluster:
+
+1. Sign in to the existing web console.
+2. Switch to the **Container Platform** view or the **Administrator** view.
+3. In the top navigation bar, click **Preview Next-Gen Console**.
+4. The new web console opens in a separate browser tab.
+
+The new web console is served at the platform URL with the path
+`/console-acp-new/`.
+
+<Directive type="info" title="Which views show the entry">
+The **Preview Next-Gen Console** entry appears in the **Container Platform**
+view and the **Administrator** view. It is visible to any signed-in user who
+has access to these views. The entry does not appear in other views.
+</Directive>
+
+<Directive type="info" title="When the entry does not appear">
+If the **Preview Next-Gen Console** entry is missing from the top navigation
+bar:
+
+- Confirm that **Web Console Base** is installed on the `global` cluster and
+  shows a ready state.
+- Refresh the existing web console page after the plugin finishes installing.
+- Confirm that you are in the **Container Platform** view or the
+  **Administrator** view. The entry does not appear in other views.
+</Directive>
+
+## Installing migrated feature plugins
+
+The framework plugins above only provide the navigation, aggregation, and
+runtime needed by the new web console. Each migrated feature is delivered as
+its own plugin and must be installed separately.
+
+To install a migrated feature plugin:
+
+1. Identify the feature plugin you want to use, and refer to that plugin's own
+   product documentation.
+2. Follow the plugin-specific installation instructions, which generally
+   follow the standard cluster plugin install flow described in
+   [Cluster Plugin](../../extend/cluster_plugin.mdx).
+3. Install the plugin on the target clusters required by the plugin's own
+   documentation.
+4. Confirm that the **Web Console Collector** is installed on each cluster
+   where the feature plugin is installed, so the feature plugin's UI is
+   aggregated into the new web console.
+
+The set of migrated feature plugins available in the new web console grows
+across releases. Refer to each plugin's own documentation for current
+availability.
+
+## Uninstalling the new web console
+
+The new web console can be removed at any time by uninstalling the framework
+plugins through Marketplace. No additional cleanup is required.
+
+1. To remove the new web console entirely:
+   - Uninstall **Web Console Base** from the `global` cluster.
+   - Uninstall **Web Console Collector** from every cluster where it is
+     installed.
+2. To remove the new web console only from a specific workload cluster:
+   - Uninstall **Web Console Collector** from that workload cluster. Plugin
+     UIs from that cluster will no longer be aggregated into the new web
+     console.
+
+After **Web Console Base** is uninstalled from the `global` cluster, the
+**Preview Next-Gen Console** entry in the existing web console disappears
+automatically. No further action is needed.
+
+Migrated feature plugins are independent of the framework plugins. Uninstall
+each feature plugin separately, following its own documentation.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "update-ac-manual": "node scripts/update-ac-manual.js"
   },
   "dependencies": {
-    "@alauda/doom": "^2.5.0"
+    "@alauda/doom": "^2.5.1"
   },
   "devDependencies": {
     "prettier": "^3.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,9 +27,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alauda/doom@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "@alauda/doom@npm:2.5.0"
+"@alauda/doom@npm:^2.5.1":
+  version: 2.5.1
+  resolution: "@alauda/doom@npm:2.5.1"
   dependencies:
     "@alauda/doc-stream-sdk": "npm:0.1.0"
     "@alauda/doom-export": "npm:^0.4.1"
@@ -105,7 +105,7 @@ __metadata:
     yoctocolors: "npm:^2.1.2"
   bin:
     doom: lib/cli/index.js
-  checksum: 10c0/d25344789d93f9e59a98d162b674b37fb11a31ccb52fc2365b3a602f507edef5bdb5193386419da6545acf8ec91aa13f3bae45c865a7fbcacafbacb0239d40f9
+  checksum: 10c0/c7f317b39f2d58aac13ff7cfefab8873b5ba59a5449600df141b584a38957ac146e5aaae2188a64b31a733c98dc1146c2bc0d3bd460c087ee4906800f9257b51
   languageName: node
   linkType: hard
 
@@ -3188,7 +3188,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "acp-docs@workspace:."
   dependencies:
-    "@alauda/doom": "npm:^2.5.0"
+    "@alauda/doom": "npm:^2.5.1"
     prettier: "npm:^3.8.3"
     prettier-plugin-pkg: "npm:^0.22.1"
     simple-git-hooks: "npm:^2.13.1"


### PR DESCRIPTION
## Summary
- Add `docs/en/ui/new_web_console/` with an install + access + uninstall guide for the new web console framework plugins (Web Console Base + Web Console Collector).
- Keep `docs/en/ui/web_console/` untouched so old-console-only guidance does not get mistakenly applied to the new web console during the Preview phase.
- Bump `@alauda/doom` from `^2.5.0` to `^2.5.1` for local preview parity.

## Coverage
- Two framework plugins, install targets and roles
- `global` cluster needs **both** Base and Collector (so global-installed plugin UIs are aggregated)
- Workload clusters need Collector only if their plugin UIs should appear in the new web console
- Preview Next-Gen Console entry appears in **Container Platform** and **Administrator** views, removed automatically when Web Console Base is uninstalled
- New web console served at `/console-acp-new/`
- Uninstall flow (per cluster and complete removal)

## Test plan
- [ ] `yarn dev` renders `docs/en/ui/new_web_console/` index and install pages without errors
- [ ] All 5 cross-doc links resolve (`web_console/index.mdx`, `cli_tools/violet.mdx`, `extend/download_package.mdx`, `extend/upload_package.mdx`, `extend/cluster_plugin.mdx`)
- [ ] `<Term name="product" />` / `<Term name="company" />` / `<Directive>` render as on neighbor pages
- [ ] Doom lint passes (verified locally on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added New Web Console (Preview) documentation, introducing the feature and providing comprehensive installation and setup guidance

* **Chores**
  * Updated framework dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/acp-docs/pull/788)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->