### PR TITLE
docs: add MetalLB monitoring guidance

### DIFF
--- a/docs/en/configure/networking/functions/configure_metallb.mdx
+++ b/docs/en/configure/networking/functions/configure_metallb.mdx
@@ -50,6 +50,9 @@ Please ensure that you have read the [Installation](../../../networking/operator
 
 5. Click **Create**.
 
+> Note:
+> When you use BGP mode, allow TCP port 179 between each BGP peer and the MetalLB speaker nodes. If you configure a custom peer port, allow the configured port instead.
+
 ## Configure an External IP Address Pool with L2Advertisement or BGPAdvertisement by using the CLI
 
 ```yaml
@@ -113,6 +116,82 @@ spec:
 ```shell
 kubectl apply -f ippool-with-L2advertisement.yaml -f ippool-with-bgpadvertisement.yaml
 ```
+
+## Monitor MetalLB
+
+After you configure MetalLB, you can use the built-in dashboard and Prometheus metrics to observe IP address allocation and BGP session status.
+
+### View the built-in MetalLB dashboard
+
+1. Go to **Operations Center**.
+
+2. In the left navigation bar, click **Monitoring** > **Monitoring Dashboards**.
+
+3. Search for **MetalLB**, and then open the dashboard.
+
+The built-in MetalLB dashboard includes the following panels:
+
+| Panel | Description |
+| --- | --- |
+| **Exposed Services** | The number of LoadBalancer Services currently announced by MetalLB. |
+| **Available IPs** | The number of IP addresses still available across all address pools. |
+| **Established BGP Sessions** | The number of BGP sessions that are currently established. |
+| **Advertised Prefixes** | The number of BGP prefixes currently advertised by MetalLB. |
+| **Pool Usage Trend** | The IP address usage trend for selected address pools. |
+| **Selected Pool Capacity** | The used and available IP address capacity for selected address pools. |
+
+### View MetalLB metrics in Prometheus
+
+The MetalLB dashboard uses metrics from the platform monitoring data source. You can also query MetalLB metrics directly from Prometheus by using the platform metrics API.
+
+Run the following command to list MetalLB metrics stored in Prometheus:
+
+```bash
+curl -k -X 'GET' \
+  -H 'Authorization: Bearer <Your token>' \
+  'https://<Your platform access address>/v2/metrics/<Your cluster name>/prometheus/label/__name__/values' \
+  | grep '^ *"metallb_'
+```
+
+You can use these metrics in PromQL queries when creating custom dashboards or troubleshooting MetalLB.
+
+### Access the MetalLB metrics endpoint
+
+MetalLB components expose metrics through the `/metrics` endpoint. You can access the endpoint from inside the cluster to confirm whether metrics are exposed correctly.
+
+1. Check the MetalLB Pods and Services:
+
+   ```bash
+   kubectl get pods,svc -n metallb-system
+   ```
+
+2. Find the metrics port of the MetalLB controller or speaker Pod.
+
+3. Forward the metrics port to your local environment:
+
+   ```bash
+   kubectl -n metallb-system port-forward pod/<metallb-pod-name> <local-port>:<metrics-port>
+   ```
+
+4. Query the metrics endpoint:
+
+   ```bash
+   curl -s http://127.0.0.1:<local-port>/metrics | grep '^metallb_'
+   ```
+
+If the command returns MetalLB metrics, metrics are available from the component.
+
+### MetalLB metrics reference
+
+The built-in MetalLB dashboard uses the following metrics:
+
+| Metric | Source component | Description | Usage scenario |
+| --- | --- | --- | --- |
+| `metallb_speaker_announced` | Speaker | Indicates whether a LoadBalancer Service is announced by MetalLB. | Count exposed LoadBalancer Services. |
+| `metallb_allocator_addresses_total` | Controller | Total number of IP addresses in address pools. | Calculate total pool capacity and available IPs. |
+| `metallb_allocator_addresses_in_use_total` | Controller | Number of IP addresses already allocated from address pools. | Calculate used IPs and pool usage trend. |
+| `metallb_bgp_session_up` | Speaker / BGP exporter | Indicates whether BGP sessions are established. | Check BGP session health. |
+| `metallb_bgp_announced_prefixes_total` | Speaker / BGP exporter | Number of BGP prefixes announced by MetalLB. | Check route advertisement status. |
 
 ## Troubleshooting MetalLB
 


### PR DESCRIPTION
## Summary
- Add BGP TCP 179 network requirement for MetalLB BGP mode.
- Document how to view the built-in MetalLB dashboard.
- Add Prometheus metric query, metrics endpoint access, and metric reference guidance.

## Test plan
- [x] Ran `git diff --check` for the updated MDX file.