### PR TITLE
doc: add cmd ac download-os

### DIFF
--- a/docs/en/extend/download_package.mdx
+++ b/docs/en/extend/download_package.mdx
@@ -179,6 +179,32 @@ violet ac download-app --arch=amd64 --appID=<app-id> --appVersion=<app-version1>
 About `scenario`, if not configured, all packages are downloaded.
 :::
 
+### violet ac download-os
+
+Download OS packages from the AC Marketplace OS page. Use `--list` first to inspect available platform versions, architectures, and operating systems, then download the matching OS package and checksum file.
+
+```bash
+# List all available OS package filters
+violet ac download-os --list
+# List OS packages for a specific platform version
+violet ac download-os --platformVersion=v4.1.0 --list
+# Download matching OS packages
+violet ac download-os --platformVersion=v4.1.0 --arch=x86_64 --operatingSystem=os
+```
+
+#### Optional Flags
+
+```
+--platformVersion    target platform version
+--arch               target architecture
+--operatingSystem    target operating system
+--list               list matching OS packages without downloading (default: `false`)
+```
+
+:::info Note
+When downloading, `--platformVersion`, `--arch`, and `--operatingSystem` are required. The `--list` option can be used with fewer filters to find valid values.
+:::
+
 ### violet ac import-yaml
 
 Read a local YAML file (default `./apps.yaml`, `violet list` export) containing an `applications` map, send it to the AC scenario-check endpoint, and display validation results. Optionally download validated packages.
@@ -227,6 +253,13 @@ violet ac import-yaml --arch=amd64 --platformVersion=v4.1.3 --download=true
 
    ```bash
    violet ac download-app --arch=amd64 --platformVersion=v4.1.0 --scenario=my-scenario --check=true
+   ```
+
+ - List and download OS packages:
+
+   ```bash
+   violet ac download-os --platformVersion=v4.1.0 --list
+   violet ac download-os --platformVersion=v4.1.0 --arch=x86_64 --operatingSystem=os
    ```
 
  - Validate an applications YAML and download validated packages:

--- a/docs/en/extend/download_package.mdx
+++ b/docs/en/extend/download_package.mdx
@@ -189,20 +189,20 @@ violet ac download-os --list
 # List OS packages for a specific platform version
 violet ac download-os --platformVersion=v4.1.0 --list
 # Download matching OS packages
-violet ac download-os --platformVersion=v4.1.0 --arch=x86_64 --operatingSystem=os
+violet ac download-os --platformVersion=v4.1.0 --arch=x86_64 --operatingSystem=ubuntu
 ```
 
-#### Optional Flags
+#### Flags
 
 ```
---platformVersion    target platform version
---arch               target architecture
---operatingSystem    target operating system
+--platformVersion    target platform version (required when downloading)
+--arch               target architecture (required when downloading)
+--operatingSystem    target operating system (required when downloading)
 --list               list matching OS packages without downloading (default: `false`)
 ```
 
 :::info Note
-When downloading, `--platformVersion`, `--arch`, and `--operatingSystem` are required. The `--list` option can be used with fewer filters to find valid values.
+Use `--list` with fewer filters to discover valid `platformVersion`, `arch`, and `operatingSystem` values before downloading.
 :::
 
 ### violet ac import-yaml
@@ -259,7 +259,7 @@ violet ac import-yaml --arch=amd64 --platformVersion=v4.1.3 --download=true
 
    ```bash
    violet ac download-os --platformVersion=v4.1.0 --list
-   violet ac download-os --platformVersion=v4.1.0 --arch=x86_64 --operatingSystem=os
+   violet ac download-os --platformVersion=v4.1.0 --arch=x86_64 --operatingSystem=ubuntu
    ```
 
  - Validate an applications YAML and download validated packages:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user documentation for the new CLI workflow: `violet ac download-os`. Covers how to list available OS package filters, query OS packages for a given platform version, and download matching packages. Clarifies which flags are required vs optional for each operation and includes practical command examples to demonstrate listing and downloading workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/acp-docs/pull/796?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->