### PR TITLE
docs(upgrade): upgrade.sh timeline restructure + violet token cleanup

### DIFF
--- a/docs/en/extend/upload_package.mdx
+++ b/docs/en/extend/upload_package.mdx
@@ -89,11 +89,8 @@ Several `violet` commands accept the following parameters. Refer to individual c
 --platform-address <platform access URL>     # The access URL of the platform, e.g., "https://example.com"
 --platform-username <platform user>          # The username of the platform user
 --platform-password <platform password>      # The password of the platform user
---platform-token <platform token>            # The platform access token; cannot be used together with username/password
---client-id <OAuth client ID>                # OAuth client ID for username/password login; ignored when --platform-token is set. Override "alauda-auth" only for custom OAuth clients.
+--client-id <OAuth client ID>                # OAuth client ID for username/password login. Override "alauda-auth" only for custom OAuth clients.
 ```
-
-To create or manage platform tokens, sign in to the platform Web Console, open **Profile** > **API Tokens**, and create a token with an appropriate expiration. For details, see [API Authentication](../apis/overview/intro.mdx).
 
 #### Image Registry Parameters
 
@@ -154,20 +151,13 @@ violet list \
   --platform-password "<platform_password>"
 ```
 
-You can also authenticate with a platform token instead of username and password:
-
-```bash
-violet list \
-  --platform-address "https://example.com" \
-  --platform-token "<platform_token>"
-```
-
 To export only applications installed in specific clusters, specify multiple cluster names separated by commas:
 
 ```bash
 violet list \
   --platform-address "https://example.com" \
-  --platform-token "<platform_token>" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>" \
   --clusters "global,region1" \
   --output-file "./apps.yaml"
 ```
@@ -198,7 +188,7 @@ applications:
 --debug                                      # Use debug log level
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--client-id`), see [Common Parameters](#common-parameters).
 
 
 ### violet gc \{#violet_gc_usage}
@@ -227,20 +217,13 @@ violet gc \
   --platform-password "<platform_password>"
 ```
 
-You can also authenticate with a platform token instead of username and password:
-
-```bash
-violet gc \
-  --platform-address "https://example.com" \
-  --platform-token "<platform_token>"
-```
-
 To clean up resources related to specific clusters only, specify multiple cluster names separated by commas:
 
 ```bash
 violet gc \
   --platform-address "https://example.com" \
-  --platform-token "<platform_token>" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>" \
   --clusters "global,region1"
 ```
 
@@ -268,7 +251,7 @@ No resources were deleted.
 --debug                                      # Use debug log level
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--client-id`), see [Common Parameters](#common-parameters).
 
 
 ### violet verify \{#violet_verify_usage}
@@ -321,8 +304,6 @@ No verification file found: 1 file(s)
 The following examples illustrate common usage scenarios.
 
 For platform connection and image registry parameters, see [Common Parameters](#common-parameters).
-
-For non-interactive use, prefer `--platform-token` over `--platform-password`. See [Common Parameters](#common-parameters).
 
 #### Optional Flags
 

--- a/docs/en/upgrade/overview.mdx
+++ b/docs/en/upgrade/overview.mdx
@@ -20,7 +20,7 @@ A workload cluster can be upgraded only to a Distribution Version that the globa
 - **Distribution Version**: The ACP version currently reached by a cluster. A workload cluster can be upgraded only to a Distribution Version that the global tier has already reached.
 - **Preflight**: Validation checks that run before the upgrade starts applying the target version. For workload clusters, review preflight results from the upgrade status output after the upgrade request is submitted.
 - **Available upgrade targets**: The upgrade versions that are currently offered for a cluster. In the Web Console, the target version for the current upgrade flow is determined by the platform.
-- **upgrade.sh**: The preparation script that uploads artifacts and deploys or updates the cluster version operator before the upgrade proceeds.
+- **upgrade.sh**: The preparation script for global cluster upgrades. Artifact synchronization and preflight checks can be run ahead of the maintenance window; the cluster version operator is deployed inside the window, just before the upgrade is requested.
 - **Global DR environment**: An environment with both a primary global cluster and a standby global cluster.
 - **Primary global cluster**: The global cluster that the platform access domain currently resolves to.
 - **Standby global cluster**: The other global cluster in the DR pair. After a failover, the roles of the two clusters are swapped.

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -53,7 +53,7 @@ Prefer `--platform-token` over `--platform-password` to avoid exposing passwords
 
 Import the exported `apps.yaml` file into the **<Term name="company" /> Customer Portal** to align the package list with what your clusters currently run. The portal then exposes the matching target-version packages — Core, Aligned plugins, and the Agnostic plugins your clusters use — for download.
 
-Download every package you will need so they are all available locally before the upgrade window starts. The next page, [Upgrade the global cluster](./upgrade_global_cluster.mdx), describes how `upgrade.sh` and `violet` push these packages into the platform.
+Download every package you will need so they are all available locally before the upgrade window starts. The next page, [Upgrade the global cluster](./upgrade_global_cluster.mdx), describes how `upgrade.sh` and `violet` push these packages into the platform — that push uploads artifacts to the registry only and can be completed any time before the maintenance window.
 
 :::warning
 If you are upgrading **from ACP 4.0 to ACP 4.3** and **<Term name="company" /> Build of TopoLVM** is installed on any target clusters, upload the TopoLVM package to those clusters before you proceed with the upgrade. This step is not required when upgrading from ACP 4.1 or ACP 4.2. You can specify multiple target clusters in `--clusters`, separated by commas.

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -43,11 +43,10 @@ On any machine with network access to the **<Term name="company" />** platform e
 ```bash
 violet list \
   --platform-address "https://<your-platform-domain>" \
-  --platform-token "<platform_token>" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>" \
   --output-file "./apps.yaml"
 ```
-
-Prefer `--platform-token` over `--platform-password` to avoid exposing passwords in shell history and process listings (`ps aux`).
 
 ### Step 3: Align the Customer Portal package list
 
@@ -62,7 +61,8 @@ If you are upgrading **from ACP 4.0 to ACP 4.3** and **<Term name="company" /> B
 violet push <path/to/directory/only_put_topolvm_plugin_here> \
   --target-catalog-source "platform" \
   --platform-address "https://example.com" \
-  --platform-token "<platform_token>" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>" \
   --clusters "cluster-a,cluster-b"
 ```
 :::

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -69,13 +69,15 @@ bash upgrade.sh --only-sync-image
 violet push <path/to/aligned-cluster-plugin-package> \
   --target-catalog-source "platform" \
   --platform-address "https://<your-platform-domain>" \
-  --platform-token "<platform_token>"
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>"
 
 # Push Aligned or Agnostic operators — to global, and to each workload cluster that runs the operator
 violet push <path/to/operator-package> \
   --target-catalog-source "platform" \
   --platform-address "https://<your-platform-domain>" \
-  --platform-token "<platform_token>" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>" \
   --clusters "global,<workload-cluster-1>,<workload-cluster-2>"
 ```
 

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -25,13 +25,31 @@ If the environment uses **global DR**, follow the [Global DR Procedure](#global-
 
 ## Standard Workflow
 
+A global cluster upgrade is staged across a timeline. Most of the work is completed **before** the maintenance window so the window itself stays short and predictable:
+
+| Phase | When | What happens | Cluster impact |
+| --- | --- | --- | --- |
+| 1. Sync artifacts | Any time before the window | `upgrade.sh --only-sync-image` uploads images and plugin artifacts to the registry; `violet` pushes Aligned and Agnostic plugins. | None — registry only, no downtime. |
+| 2. Preflight | 1–2 weeks before the window | `upgrade.sh --preflight` validates upgrade readiness. Resolve every blocking item before the window opens. | None — read-only validation. |
+| 3. Upgrade | During the maintenance window | `upgrade.sh --skip-sync-image` deploys or updates the cluster version operator (CVO); the upgrade is then requested and observed. | The cluster is upgraded. |
+
+Phase 1 and Phase 2 do not change cluster state — run them early so the maintenance window only contains Phase 3. A small or lab environment can instead run a single `bash upgrade.sh` that performs synchronization and CVO deployment together, but production windows usually keep them separate.
+
 <Steps>
 
-### Prepare upgrade artifacts
+### Sync upgrade artifacts \{#sync-upgrade-artifacts}
 
-Run `bash upgrade.sh` from the extracted core package directory.
+**When:** any time before the maintenance window. This step uploads artifacts to the registry and does not change cluster state.
 
-`upgrade.sh` prepares the resources required by the CVO-based workflow, including:
+From the extracted core package directory, run `upgrade.sh` in sync-only mode:
+
+```bash
+bash upgrade.sh --only-sync-image
+```
+
+`--only-sync-image` uploads images and plugin artifacts without deploying the cluster version operator. The CVO is deployed later, inside the maintenance window — see [Deploy the cluster version operator](#deploy-the-cluster-version-operator).
+
+`upgrade.sh` synchronizes the artifacts required by the CVO-based workflow, including:
 
 | Type             | Content                    | Purpose                                                                    |
 | ---------------- | -------------------------- | -------------------------------------------------------------------------- |
@@ -73,34 +91,30 @@ Registry behavior depends on how the environment is configured:
 | External registry                             | Automatically set `SKIP_SYNC_IMAGE=true` and skip image synchronization.      |
 | Image upload required but credentials omitted | Read `username` and `password` from the `cpaas-system/registry-admin` Secret. |
 
-Common parameters:
+When the target registry is not the platform default, add registry parameters:
 
-| Parameter                   | Purpose                                       |
-| --------------------------- | --------------------------------------------- |
-| `--registry`                | Specify the target registry address.          |
-| `--username` / `--password` | Specify registry credentials.                 |
-| `--only-sync-image`         | Synchronize images and plugin artifacts only. |
-| `--skip-sync-image`         | Skip image and plugin synchronization.        |
-| `--skip-check-artifacts`    | Skip artifact validation.                     |
+| Parameter                   | Purpose                               |
+| --------------------------- | ------------------------------------- |
+| `--registry`                | Specify the target registry address.  |
+| `--username` / `--password` | Specify registry credentials.         |
 
-```bash
-bash upgrade.sh
-```
+To bypass artifact validation when it is known to be redundant, add `--skip-check-artifacts`.
 
 :::warning
-
-- Do not continue to the next step until image and plugin synchronization is complete.
-- Use `--only-sync-image` only when you want artifact synchronization without further preparation.
-- Use `--skip-sync-image` only when the required images and plugin artifacts have already been uploaded.
-  :::
+Do not open the maintenance window until image and plugin synchronization is complete.
+:::
 
 ### Run preflight checks
 
-Run preflight before requesting the upgrade:
+**When:** 1–2 weeks before the maintenance window, so there is time to resolve any blocking items before the window opens.
+
+Run `upgrade.sh` in preflight mode:
 
 ```bash
 bash upgrade.sh --preflight
 ```
+
+Preflight is read-only — it validates upgrade readiness and does not change cluster state.
 
 Preflight returns two parts:
 
@@ -125,6 +139,8 @@ The default check set includes:
 - `PlatformLicense`
 
 ### Handle preflight blocks when needed \{#handle-preflight-blocks-when-needed}
+
+**When:** before the maintenance window. Resolve every blocking item discovered by preflight so the window is not spent troubleshooting.
 
 If `ResourcePatchUpgradeable` fails with `reason=UnexemptResourcePatches`, inspect the blocking `ResourcePatch` and add the required exemption annotation:
 
@@ -158,9 +174,21 @@ data:
       - VersionUpgradePath
 ```
 
+### Deploy the cluster version operator \{#deploy-the-cluster-version-operator}
+
+**When:** at the start of the maintenance window.
+
+Run `upgrade.sh` in skip-sync mode. Synchronization is skipped because the artifacts were already uploaded in [Sync upgrade artifacts](#sync-upgrade-artifacts):
+
+```bash
+bash upgrade.sh --skip-sync-image
+```
+
+This deploys or updates the cluster version operator (CVO) and completes the remaining preparation. The CVO drives the Core and Aligned plugin upgrade once the upgrade is requested in the next step.
+
 ### Request the upgrade
 
-After the preparation phase completes, request the upgrade through one of the following entry points. The three entry points are equivalent; pick the one that fits your operating model.
+After the cluster version operator is deployed, request the upgrade through one of the following entry points. The three entry points are equivalent; pick the one that fits your operating model.
 
 <Tabs>
   <Tab label="Web Console">
@@ -329,11 +357,11 @@ If any such nodes exist, resolve them before continuing.
 4. Find **<Term name="product" /> etcd Synchronizer** and uninstall it.
 5. Wait for the uninstallation to complete before proceeding.
 
-### Prepare upgrade artifacts on both global clusters
+### Sync upgrade artifacts on both global clusters
 
-Complete **Prepare upgrade artifacts** in the standard workflow on **both** the standby global cluster and the primary global cluster.
+Complete **Sync upgrade artifacts** in the standard workflow on **both** the standby global cluster and the primary global cluster.
 
-Use the same preparation mode on both clusters.
+Use the same synchronization mode on both clusters.
 
 ### Upgrade the standby global cluster
 
@@ -349,19 +377,21 @@ spec:
     - https://<standby-cluster-vip>
 ```
 
-After preparation completes, run the remaining steps from the standard workflow on the **standby global cluster**:
+After synchronization completes, run the remaining steps from the standard workflow on the **standby global cluster**:
 
 1. **Run preflight checks**
-2. **Request the upgrade**
-3. **Observe execution** until the standby global cluster reaches the desired version
+2. **Deploy the cluster version operator**
+3. **Request the upgrade**
+4. **Observe execution** until the standby global cluster reaches the desired version
 
 ### Upgrade the primary global cluster
 
 After the standby global cluster has reached the desired version, run the remaining steps from the standard workflow on the **primary global cluster**:
 
 1. **Run preflight checks**
-2. **Request the upgrade**
-3. **Observe execution** until the primary global cluster reaches the desired version
+2. **Deploy the cluster version operator**
+3. **Request the upgrade**
+4. **Observe execution** until the primary global cluster reaches the desired version
 
 ### Reinstall the etcd synchronization plugin and verify sync status
 

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -46,7 +46,8 @@ If the global window did not push operator packages to this workload cluster —
 violet push <path/to/operator-package> \
   --target-catalog-source "platform" \
   --platform-address "https://<your-platform-domain>" \
-  --platform-token "<platform_token>" \
+  --platform-username "<platform_user>" \
+  --platform-password "<platform_password>" \
   --clusters "<workload-cluster-name>"
 ```
 

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -15,6 +15,13 @@ ACP 4.3 uses the same CVO-based workflow for workload clusters as for the `globa
 - If the platform uses **global DR**, both the standby and primary global clusters must reach the target Distribution Version before any workload cluster is upgraded to that Distribution Version.
 - The target version normally becomes available for a workload cluster only after the global tier has already reached that same Distribution Version.
 
+A workload cluster upgrade is staged like the global cluster upgrade, but shorter. A workload cluster does not have its own cluster version operator — the CVO runs on the global cluster and drives workload upgrades centrally — so a workload cluster has no artifact-synchronization or CVO-deployment step of its own:
+
+| Phase | When | What happens |
+| --- | --- | --- |
+| 1. Preflight | 1–2 weeks before the window | Confirm prerequisites and run `upgrade.sh --cluster=<cluster> --preflight`; resolve every blocking item before the window opens. |
+| 2. Upgrade | During the maintenance window | Request the upgrade and observe execution until the cluster reaches the target version. |
+
 ## Workflow
 
 <Steps>
@@ -47,11 +54,15 @@ You only need to push operator packages for operators actually running on the wo
 
 ### Run preflight checks
 
-Run preflight before requesting the upgrade:
+**When:** 1–2 weeks before the maintenance window, so there is time to resolve any blocking items before the window opens.
+
+Run `upgrade.sh` in preflight mode for the target cluster:
 
 ```bash
 bash upgrade.sh --cluster=<cluster> --preflight
 ```
+
+Preflight is read-only — it validates upgrade readiness and does not change cluster state.
 
 Preflight returns two parts:
 
@@ -66,7 +77,9 @@ For preflight block handling patterns, see [Handle preflight blocks when needed]
 
 ### Request the upgrade
 
-After preflight passes, request the upgrade through one of the following entry points. The two entry points are equivalent; pick the one that fits your operating model.
+**When:** during the maintenance window, after preflight passes.
+
+Request the upgrade through one of the following entry points. The two entry points are equivalent; pick the one that fits your operating model.
 
 <Tabs>
   <Tab label="Web Console">


### PR DESCRIPTION
## Summary

Two upgrade-documentation fixes:

1. **upgrade.sh guidance restructured around the upgrade timeline.** The `upgrade.sh` modes (`--only-sync-image` / `--preflight` / `--skip-sync-image`) are not flat alternatives — they map to three timeline phases separated by days or weeks. The docs now present a timeline overview, an explicit "Deploy the cluster version operator" step, and a `When:` line on every step; the Global DR section is synced; the technical invocation-modes table is dropped.

2. **violet `--platform-token` references removed.** `violet` does not support token-based authentication in ACP 4.3 (token auth lands in 4.4). All `--platform-token` examples / parameter-table entries / "prefer token" guidance are replaced with username/password auth.

## Test plan

- [x] Docs-only change; `yarn lint` passes with 0 errors.
- [x] Reviewer confirms the 3-phase timeline framing matches the actual upgrade.sh behavior.
- [x] Reviewer confirms violet 4.3 has no token-auth support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `violet` CLI authentication examples to use username/password instead of platform tokens.
  * Clarified upgrade workflow timings: artifact synchronization and preflight checks can occur before maintenance windows.
  * Added guidance for non-default container registry authentication.
  * Reorganized upgrade procedures for global and workload clusters with improved step clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/acp-docs/pull/815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->