### PR TITLE
docs(upgrade): clarify Kube-OVN is handled by CVO on traditional OS

### DIFF
--- a/docs/en/upgrade/overview.mdx
+++ b/docs/en/upgrade/overview.mdx
@@ -57,6 +57,14 @@ The Cluster Version Operator (CVO) decides which kinds of upgrades it drives end
 
 Customers running real production maintenance windows usually move Core, Aligned, and the in-use Agnostic plugins together. The upgrade pages below document that path: prepare every needed artifact during pre-upgrade, drive Core and Aligned through CVO, and finish the in-use Agnostic plugins from Marketplace.
 
+:::info
+**Kube-OVN on traditional vs. Immutable Infrastructure**
+
+On a **traditional operating system** cluster (this page's scope), Kube-OVN is part of <Term name="productShort" /> Core and is upgraded automatically by CVO together with the rest of Core — operators do not patch any per-cluster Kube-OVN version annotation and do not touch the Kube-OVN `AppRelease` by hand.
+
+On **Immutable Infrastructure** clusters (DCS, vSphere, HCS), Kube-OVN is driven separately by the IaaS provider through the `cpaas.io/kube-ovn-version` annotation on the workload `Cluster` resource — see <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/index.html" children="Upgrading Clusters on Immutable Infrastructure" />. That path does not apply to traditional-OS clusters.
+:::
+
 ## Upgrade Entry Points
 
 - **Global clusters**: Follow the validated `upgrade.sh`-based procedure. After the preparation phase completes, request the upgrade from the Web Console through the two-step RPCH review flow, use ACP CLI, or update `ClusterVersionShadow.spec.desiredUpdate` directly.


### PR DESCRIPTION
## Summary

Adds an info callout to the upgrade overview clarifying how Kube-OVN is upgraded, because the path differs by infrastructure type:

- **Traditional operating system clusters** — Kube-OVN is part of ACP Core and is upgraded automatically by the Cluster Version Operator (CVO) together with the rest of Core. No manual per-cluster action is required.
- **Immutable Infrastructure clusters** (DCS, vSphere, HCS) — Kube-OVN is driven separately by the IaaS provider through the `cpaas.io/kube-ovn-version` annotation on the workload `Cluster` resource. That path is documented in the Immutable Infrastructure upgrade guides.

This prevents readers on traditional-OS clusters from looking for a manual Kube-OVN step that does not apply to them, and points Immutable Infrastructure readers to the correct guide.

## Verification

- `yarn lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)