### PR TITLE
[codex] Add MinIO deprecation warning

### DIFF
--- a/docs/en/storage/storagesystem_minio/intro.mdx
+++ b/docs/en/storage/storagesystem_minio/intro.mdx
@@ -5,6 +5,10 @@ sourceSHA: 1eac407d04dd88f95a6c24024dc03bd0a0869a1f7e57682897e4d4ec519c8f82
 
 # Introduction
 
+:::warning Deprecation Notice
+MinIO Object Storage is deprecated. The upstream community no longer maintains the MinIO Operator used by this deployment path, so ACP will also deprecate MinIO. Do not use MinIO for new deployments. Migrate existing data to Ceph RGW as soon as possible. See [MinIO to Rook Ceph RGW Data Migration Guide](./how_to/minio-to-ceph-rgw-with-volsync.md) for migration instructions.
+:::
+
 Alauda Container Platform (ACP) Object Storage with MinIO is an object storage service licensed under the Apache License v2.0. It is compatible with the Amazon S3 cloud storage service interface, making it particularly suitable for storing large volumes of unstructured data, such as images, videos, log files, backup data, and container/virtual machine images. An object file can range in size from a few KB to a maximum of 5T.
 
 **The main advantages are as follows:**


### PR DESCRIPTION
## Summary

- Add a deprecation warning to the MinIO Object Storage introduction page.
- Explain that the upstream MinIO Operator used by this deployment path is no longer maintained.
- Direct users to migrate existing MinIO data to Ceph RGW and link to the existing VolSync migration guide.

## Validation

- Commit hook lint passed when creating the documentation commit.
- After updating to the latest release-4.3, yarn install could not complete because registry.npmmirror.com returned repeated 502/504 responses for multiple packages, so lint could not be rerun after dependency sync.

## Impact

Users reading the MinIO introduction now see the deprecation status before following deployment guidance and can navigate directly to the MinIO-to-Ceph RGW migration document.