### PR TITLE
docs(workloads): add in-place Pod resize guidance

### DIFF
--- a/docs/en/developer/building_application/application_workloads/pod.mdx
+++ b/docs/en/developer/building_application/application_workloads/pod.mdx
@@ -42,6 +42,10 @@ spec:
 
 While Pods are often managed by higher-level controllers, direct kubectl operations on Pods are useful for troubleshooting, inspection, and ad-hoc tasks.
 
+### Adjusting Pod Resources
+
+To update CPU or memory requests and limits for a running Pod through the Kubernetes `resize` subresource, see [Adjust Pod Resource Levels Without Pod Disruption](./resize_pod_resources_in_place.mdx).
+
 ### Viewing a Pod
 
 - To list all Pods in the current namespace:

--- a/docs/en/developer/building_application/application_workloads/resize_pod_resources_in_place.mdx
+++ b/docs/en/developer/building_application/application_workloads/resize_pod_resources_in_place.mdx
@@ -6,15 +6,15 @@ weight: 95
 
 Use in-place Pod resizing when you need to adjust CPU or memory requests and limits for a running Pod without recreating the Pod. This task uses the Kubernetes Pod `resize` subresource.
 
+## Prerequisites
+
+Ensure that the target Kubernetes cluster supports the Pod `resize` subresource. Use Kubernetes v1.33 or later with the `InPlacePodVerticalScaling` feature gate enabled on the control plane and nodes. In Kubernetes v1.35, this feature is stable and enabled by default.
+
 ## About In-place Pod Resizing
 
 In-place Pod resizing lets you change CPU and memory resource requests and limits for containers in a running Pod. Standard resource changes usually require the Pod to be recreated, which can interrupt applications or lose runtime state. In-place Pod resizing applies supported resource changes through the Kubernetes Pod `resize` subresource.
 
 You can control whether a container restarts during the resize by configuring `resizePolicy` in the Pod specification. For example, you can allow CPU changes without a restart and require a container restart for memory changes.
-
-::: tip
-Ensure that the target Kubernetes cluster supports the Pod `resize` subresource. Use Kubernetes v1.33 or later with the `InPlacePodVerticalScaling` feature gate enabled on the control plane and nodes. In Kubernetes v1.35, this feature is stable and enabled by default.
-:::
 
 ## Configure In-place Pod Resizing
 
@@ -58,7 +58,7 @@ For CPU and memory resources, use one of the following `restartPolicy` values:
 | `NotRequired` | Apply supported resource changes without restarting the container. |
 | `RestartContainer` | Apply supported resource changes and restart the container. |
 
-Memory limits cannot be decreased unless the resize policy for memory is `RestartContainer`.
+When decreasing memory limits with `NotRequired` or no memory `resizePolicy`, the kubelet applies the change on a best-effort basis and does not guarantee that the container avoids an out-of-memory kill. If current memory usage is higher than the requested limit, the resize can be skipped and remain in progress. Use `RestartContainer` for memory changes when you need more predictable behavior.
 
 ## Resize a Running Pod
 

--- a/docs/en/developer/building_application/application_workloads/resize_pod_resources_in_place.mdx
+++ b/docs/en/developer/building_application/application_workloads/resize_pod_resources_in_place.mdx
@@ -1,0 +1,154 @@
+---
+weight: 95
+---
+
+# Adjust Pod Resource Levels Without Pod Disruption
+
+Use in-place Pod resizing when you need to adjust CPU or memory requests and limits for a running Pod without recreating the Pod. This task uses the Kubernetes Pod `resize` subresource.
+
+## About In-place Pod Resizing
+
+In-place Pod resizing lets you change CPU and memory resource requests and limits for containers in a running Pod. Standard resource changes usually require the Pod to be recreated, which can interrupt applications or lose runtime state. In-place Pod resizing applies supported resource changes through the Kubernetes Pod `resize` subresource.
+
+You can control whether a container restarts during the resize by configuring `resizePolicy` in the Pod specification. For example, you can allow CPU changes without a restart and require a container restart for memory changes.
+
+## Configure In-place Pod Resizing
+
+Configure `resizePolicy` before you resize a running Pod. You cannot add or modify `resizePolicy` on an existing Pod. If the Pod is managed by an owner object, such as a Deployment or StatefulSet, add or update `resizePolicy` in the owner object's Pod template.
+
+```yaml title="deployment-resize-policy.yaml"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: resize-demo
+spec:
+  selector:
+    matchLabels:
+      app: resize-demo
+  template:
+    metadata:
+      labels:
+        app: resize-demo
+    spec:
+      containers:
+        - name: app
+          image: nginx:latest
+          resizePolicy:
+            - resourceName: cpu
+              restartPolicy: NotRequired
+            - resourceName: memory
+              restartPolicy: RestartContainer
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+```
+
+For CPU and memory resources, use one of the following `restartPolicy` values:
+
+| Value | Description |
+| --- | --- |
+| `NotRequired` | Apply supported resource changes without restarting the container. |
+| `RestartContainer` | Apply supported resource changes and restart the container. |
+
+Memory limits cannot be decreased unless the resize policy for memory is `RestartContainer`.
+
+## Resize a Running Pod
+
+Use the `resize` subresource when editing Pod resources. Run the commands from a workstation that can access the target cluster.
+
+Use `kubectl` v1.32.0 or later, or another API client that supports the Pod `resize` subresource. Older `kubectl` clients might reject `--subresource=resize` with errors such as `invalid subresource value: "resize"` or might not provide the `--subresource` flag for some commands, even when the Kubernetes API server supports `pods/resize`.
+
+Edit the Pod resources interactively:
+
+```bash
+kubectl edit pod <pod_name> -n <namespace> --subresource=resize
+```
+
+Apply an updated Pod manifest through the `resize` subresource by using server-side apply:
+
+```bash
+kubectl apply --server-side -f <file_name>.yaml --subresource=resize
+```
+
+Patch the target container resources directly:
+
+```bash
+kubectl patch pod <pod_name> \
+  -n <namespace> \
+  --subresource=resize \
+  --patch '{"spec":{"containers":[{"name":"<container_name>","resources":{"requests":{"cpu":"800m"},"limits":{"cpu":"800m"}}}]}}'
+```
+
+Replace `<pod_name>`, `<namespace>`, and `<container_name>` with the target Pod, namespace, and container names.
+
+Because this operation requires the Pod `resize` subresource, use `kubectl` or an API client version that supports the subresource.
+
+## Verify Restart Behavior
+
+Check whether the Pod restarted after the resize:
+
+```bash
+kubectl get pods -n <namespace>
+```
+
+If `restartPolicy` is `NotRequired` for the changed resource, the Pod should remain running without a container restart.
+
+```text
+NAME         READY   STATUS    RESTARTS   AGE
+resize-pod   1/1     Running   0          5s
+```
+
+If `restartPolicy` is `RestartContainer` for the changed resource, the container restarts while the Pod remains running.
+
+```text
+NAME         READY   STATUS    RESTARTS      AGE
+resize-pod   1/1     Running   1 (5s ago)    5s
+```
+
+## Check Resize Status
+
+Check the resources currently applied to the running container:
+
+```bash
+kubectl get pod <pod_name> \
+  -n <namespace> \
+  -o jsonpath='{.status.containerStatuses[?(@.name=="<container_name>")].resources}'
+```
+
+Check resize conditions and events:
+
+```bash
+kubectl describe pod <pod_name> -n <namespace>
+```
+
+Resize conditions include:
+
+- `PodResizeInProgress`: kubelet can allocate the requested resources and is applying the change.
+- `PodResizePending`: kubelet cannot apply the change immediately.
+  - `Infeasible`: The requested resize cannot be executed on the current node.
+  - `Deferred`: The requested resize is not currently possible, but might become possible later.
+  - `Error`: kubelet reports an error during resource allocation.
+
+## Limitations
+
+- Only CPU and memory requests and limits can be resized.
+- In-place Pod resizing is not supported for non-restartable init containers or ephemeral containers.
+- The resize must not violate other Pod mutability constraints, such as changing the Pod QoS class.
+- Pods managed by static `cpuManagerPolicy` or `memoryManagerPolicy` cannot be resized in place.
+- Pods that use swap memory must use `RestartContainer` for memory requests.
+- ResourceQuota, LimitRange, and admission policies can still reject the resize request.
+
+::: note
+Because this operation requires the Pod `resize` subresource, it might not be available through web console resource editing. Use `kubectl` or an API client version that supports the `resize` subresource.
+:::
+
+## Additional Resources
+
+- [Pods](./pod.mdx)
+- [Resource Units](../concepts/unit.mdx)
+- [Configuring VerticalPodAutoscaler (VPA)](../operation_maintaining/add_vpa.mdx)
+- [Pod API Reference](../../../apis/kubernetes_apis/workload/pod.mdx)

--- a/docs/en/developer/building_application/application_workloads/resize_pod_resources_in_place.mdx
+++ b/docs/en/developer/building_application/application_workloads/resize_pod_resources_in_place.mdx
@@ -12,6 +12,10 @@ In-place Pod resizing lets you change CPU and memory resource requests and limit
 
 You can control whether a container restarts during the resize by configuring `resizePolicy` in the Pod specification. For example, you can allow CPU changes without a restart and require a container restart for memory changes.
 
+::: tip
+Ensure that the target Kubernetes cluster supports the Pod `resize` subresource. Use Kubernetes v1.33 or later with the `InPlacePodVerticalScaling` feature gate enabled on the control plane and nodes. In Kubernetes v1.35, this feature is stable and enabled by default.
+:::
+
 ## Configure In-place Pod Resizing
 
 Configure `resizePolicy` before you resize a running Pod. You cannot add or modify `resizePolicy` on an existing Pod. If the Pod is managed by an owner object, such as a Deployment or StatefulSet, add or update `resizePolicy` in the owner object's Pod template.
@@ -60,7 +64,9 @@ Memory limits cannot be decreased unless the resize policy for memory is `Restar
 
 Use the `resize` subresource when editing Pod resources. Run the commands from a workstation that can access the target cluster.
 
+::: tip
 Use `kubectl` v1.32.0 or later, or another API client that supports the Pod `resize` subresource. Older `kubectl` clients might reject `--subresource=resize` with errors such as `invalid subresource value: "resize"` or might not provide the `--subresource` flag for some commands, even when the Kubernetes API server supports `pods/resize`.
+:::
 
 Edit the Pod resources interactively:
 

--- a/docs/en/developer/building_application/operation_maintaining/add_vpa.mdx
+++ b/docs/en/developer/building_application/operation_maintaining/add_vpa.mdx
@@ -36,7 +36,7 @@ The VPA provides resource recommendations based on historical usage patterns, al
 > **Important**: When manually applying VPA recommendations, pod recreation will occur, which can cause temporary disruption to your application. Consider applying recommendations during maintenance windows for production workloads.
 
 ::: info
-VPA recommendations and in-place Pod resizing solve different parts of resource management. VPA recommends or applies resource values based on observed usage. In-place Pod resizing is a Kubernetes mechanism for updating CPU or memory resources of a running Pod through the Pod `resize` subresource. Some VPA versions support `InPlaceOrRecreate`, where VPA can try to apply recommendations through in-place Pod resizing and fall back to Pod recreation when an in-place update is not possible. Check the VPA CRD in your cluster before using this mode, because available `updateMode` values are defined by the installed CRD. For manual runtime adjustments and `resizePolicy` behavior, see [Adjust Pod Resource Levels Without Pod Disruption](../application_workloads/resize_pod_resources_in_place.mdx).
+VPA recommendations and in-place Pod resizing solve different parts of resource management. VPA recommends or applies resource values based on observed usage. In-place Pod resizing is a Kubernetes mechanism for updating CPU or memory resources of a running Pod through the Pod `resize` subresource. Some VPA versions support `InPlaceOrRecreate`, where VPA can try to apply recommendations through in-place Pod resizing and fall back to Pod recreation when an in-place update is not possible. This mode requires Kubernetes in-place Pod resizing support, VPA components that enable the `InPlaceOrRecreate` feature, and a VPA CRD that accepts this `updateMode` value. For manual runtime adjustments and `resizePolicy` behavior, see [Adjust Pod Resource Levels Without Pod Disruption](../application_workloads/resize_pod_resources_in_place.mdx).
 :::
 
 ## Prerequisites
@@ -101,7 +101,7 @@ You can create a VerticalPodAutoscaler using the command line interface by defin
       - Initial: Only sets resource requests when creating pods, no modifications afterward.
       - Recreate: Automatically sets resource requests when creating pods and evicts current pods to update to recommended resource requests. Will not use in-place updates.
       - Auto: Automatically sets resource requests when creating pods and updates current pods to recommended resource requests. Currently equivalent to "Recreate" and may cause application downtime.
-      - InPlaceOrRecreate: Available only when the VPA CRD in your cluster includes this value. VPA first attempts to apply recommendations by using in-place Pod resizing, then falls back to Pod recreation when the in-place update cannot be applied. Container `resizePolicy` settings can determine whether a container restarts during the resize.
+      - InPlaceOrRecreate: Available only when the cluster supports in-place Pod resizing, the VPA components enable the `InPlaceOrRecreate` feature, and the VPA CRD accepts this value. VPA first attempts to apply recommendations by using in-place Pod resizing, then falls back to Pod recreation when the in-place update cannot be applied. Container `resizePolicy` settings can determine whether a container restarts during the resize.
    8. Resource policy that can set specific strategies for different containers. For example, setting a container's mode to "Auto" means it will calculate recommendations for that container, while "Off" means it won't calculate recommendations.
    9. Apply policy to all containers in the pod.
    10. Set the mode to Auto or Off. Auto means recommendations will be generated for this container, Off means no recommendations will be generated.
@@ -171,7 +171,7 @@ You can create a VerticalPodAutoscaler using the command line interface by defin
 - `updateMode: "Initial"` - Only sets resource requests when creating pods, no modifications afterward.
 - `updateMode: "Recreate"` - Automatically sets resource requests when creating pods and evicts current pods to update to recommended values.
 - `updateMode: "Auto"` - Automatically sets resource requests when creating pods and updates current pods to recommended values. Currently equivalent to "Recreate".
-- `updateMode: "InPlaceOrRecreate"` - Available only when the VPA CRD in your cluster includes this value. VPA first attempts to apply recommendations by using in-place Pod resizing, then falls back to Pod recreation when the in-place update cannot be applied. Container `resizePolicy` settings can determine whether a container restarts during the resize.
+- `updateMode: "InPlaceOrRecreate"` - Available only when the cluster supports in-place Pod resizing, the VPA components enable the `InPlaceOrRecreate` feature, and the VPA CRD accepts this value. VPA first attempts to apply recommendations by using in-place Pod resizing, then falls back to Pod recreation when the in-place update cannot be applied. Container `resizePolicy` settings can determine whether a container restarts during the resize.
 - `minReplicas: <number>` - Minimum number of replicas. Ensures this minimum number of pods remain available when the Updater evicts pods. Must be greater than 0.
 
 #### Container Policy Options

--- a/docs/en/developer/building_application/operation_maintaining/add_vpa.mdx
+++ b/docs/en/developer/building_application/operation_maintaining/add_vpa.mdx
@@ -35,6 +35,10 @@ The VPA provides resource recommendations based on historical usage patterns, al
 
 > **Important**: When manually applying VPA recommendations, pod recreation will occur, which can cause temporary disruption to your application. Consider applying recommendations during maintenance windows for production workloads.
 
+::: info
+VPA recommendations and in-place Pod resizing solve different parts of resource management. VPA recommends or applies resource values based on observed usage. In-place Pod resizing is a Kubernetes mechanism for updating CPU or memory resources of a running Pod through the Pod `resize` subresource. Some VPA versions support `InPlaceOrRecreate`, where VPA can try to apply recommendations through in-place Pod resizing and fall back to Pod recreation when an in-place update is not possible. Check the VPA CRD in your cluster before using this mode, because available `updateMode` values are defined by the installed CRD. For manual runtime adjustments and `resizePolicy` behavior, see [Adjust Pod Resource Levels Without Pod Disruption](../application_workloads/resize_pod_resources_in_place.mdx).
+:::
+
 ## Prerequisites
 Before using VPA, ensure the following:
 - The **Alauda Container Platform Vertical Pod Autoscaler** cluster plugin is installed in your cluster.
@@ -93,10 +97,11 @@ You can create a VerticalPodAutoscaler using the command line interface by defin
    5. Specify the type of object.
    6. The target resource to which the VPA applies
    7. Update policy that defines how VPA applies recommendations. The updateMode can be:
-      - Auto: Automatically sets resource requests when creating pods and updates current pods to recommended resource requests. Currently equivalent to "Recreate". This mode may cause application downtime. Once in-place pod resource updates are supported, "Auto" mode will adopt this update mechanism.
-      - Recreate: Automatically sets resource requests when creating pods and evicts current pods to update to recommended resource requests. Will not use in-place updates.
-      - Initial: Only sets resource requests when creating pods, no modifications afterward.
       - Off: Does not automatically modify pod resource requests, only provides recommendations in the VPA object.
+      - Initial: Only sets resource requests when creating pods, no modifications afterward.
+      - Recreate: Automatically sets resource requests when creating pods and evicts current pods to update to recommended resource requests. Will not use in-place updates.
+      - Auto: Automatically sets resource requests when creating pods and updates current pods to recommended resource requests. Currently equivalent to "Recreate" and may cause application downtime.
+      - InPlaceOrRecreate: Available only when the VPA CRD in your cluster includes this value. VPA first attempts to apply recommendations by using in-place Pod resizing, then falls back to Pod recreation when the in-place update cannot be applied. Container `resizePolicy` settings can determine whether a container restarts during the resize.
    8. Resource policy that can set specific strategies for different containers. For example, setting a container's mode to "Auto" means it will calculate recommendations for that container, while "Off" means it won't calculate recommendations.
    9. Apply policy to all containers in the pod.
    10. Set the mode to Auto or Off. Auto means recommendations will be generated for this container, Off means no recommendations will be generated.
@@ -163,9 +168,10 @@ You can create a VerticalPodAutoscaler using the command line interface by defin
 #### Update Policy Options
 
 - `updateMode: "Off"` - VPA only provides recommendations without automatically applying them. You can manually apply these recommendations as needed.
-- `updateMode: "Auto"` - Automatically sets resource requests when creating pods and updates current pods to recommended values. Currently equivalent to "Recreate".
-- `updateMode: "Recreate"` - Automatically sets resource requests when creating pods and evicts current pods to update to recommended values.
 - `updateMode: "Initial"` - Only sets resource requests when creating pods, no modifications afterward.
+- `updateMode: "Recreate"` - Automatically sets resource requests when creating pods and evicts current pods to update to recommended values.
+- `updateMode: "Auto"` - Automatically sets resource requests when creating pods and updates current pods to recommended values. Currently equivalent to "Recreate".
+- `updateMode: "InPlaceOrRecreate"` - Available only when the VPA CRD in your cluster includes this value. VPA first attempts to apply recommendations by using in-place Pod resizing, then falls back to Pod recreation when the in-place update cannot be applied. Container `resizePolicy` settings can determine whether a container restarts during the resize.
 - `minReplicas: <number>` - Minimum number of replicas. Ensures this minimum number of pods remain available when the Updater evicts pods. Must be greater than 0.
 
 #### Container Policy Options
@@ -177,7 +183,7 @@ You can create a VerticalPodAutoscaler using the command line interface by defin
 **Notes**:
 
 - VPA recommendations are based on historical usage data, so it may take several days of pod operation before recommendations become accurate.
-- Pod recreation will occur when VPA recommendations are applied in Auto mode, which can cause temporary disruption to your application.
+- Pod recreation will occur when VPA recommendations are applied in Auto or Recreate mode, which can cause temporary disruption to your application. If your VPA plugin supports InPlaceOrRecreate mode, in-place updates can still fall back to Pod recreation when the requested resize cannot be applied in place.
 
 ## Follow-Up Actions
 


### PR DESCRIPTION
Document Pod resize workflows and related VPA links. Verified with lint, build, and live-cluster e2e checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on adjusting Pod CPU/memory live, including when in-place resizing applies, how to perform it, verification steps, and limitations.
  * Clarified VPA behavior vs. in-place resizing and introduced the InPlaceOrRecreate option with fallback-to-recreate details.
  * Improved navigation and links to related Pod resource adjustment workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/acp-docs/pull/824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->