### PR TITLE
docs(upgrade): route immutable-infra readers to cross-version preparation

### DIFF
--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -12,6 +12,10 @@ weight: 20
 
 Before starting, ensure your current platform version is within the supported upgrade range.
 
+:::info
+On Immutable Infrastructure (Huawei DCS, VMware vSphere, Huawei Cloud Stack, and bare-metal immutable OS), the supported upgrade paths above apply to the ACP Distribution Version, which still moves directly to the target version through the Cluster Version Operator. When the target ACP version is more than one Kubernetes minor above the cluster's current version, the Kubernetes upgrade requires additional pre-staging of intermediate-version artifacts. See <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/index.html#cross-version-preparation" children="Preparing for Cross-Version Upgrades" /> before starting the upgrade window.
+:::
+
 ## Important Notes
 
 * Ensure the directory `/cpaas/minio` on the control plane nodes of global cluster has at least **120 GB** of free disk space.


### PR DESCRIPTION
## Summary

Adds an `:::info` callout below "Supported upgrade paths" in `pre-upgrade.mdx` pointing Immutable Infrastructure readers to the new **Preparing for Cross-Version Upgrades** section in immutable-infra-docs.

## Why

The "Supported upgrade paths" list (`4.0/4.1/4.2 → 4.3`) describes the ACP Distribution Version jump, which is CVO-driven and direct in all cases. On **traditional OS**, that direct jump is the complete upgrade path — Core 4.3 ships the full Kubernetes image range and performs in-place Kubernetes upgrades.

On **Immutable Infrastructure** (Huawei DCS, VMware vSphere, Huawei Cloud Stack, and bare-metal immutable OS), the Distribution Version still jumps directly to the target, but the Kubernetes step is separate (delete-recreate via OS images). When the target ACP version is more than one Kubernetes minor above current, the Kubernetes upgrade requires pre-staging intermediate-version Core images and OS images. Without that, the staged Kubernetes rollout cannot pull the intermediate CoreDNS / etcd / Kube-OVN images in an air-gapped registry.

The new shared **Preparing for Cross-Version Upgrades** section in immutable-infra-docs (alauda/immutable-infra-docs#99) documents that preparation. This PR routes acp-docs readers to it.

## What changed

- `docs/en/upgrade/pre-upgrade.mdx` — add `:::info` callout after the "Supported upgrade paths" list, using the existing `<ExternalSiteLink name="immutable-infra">` cross-site link pattern (same as `overview.mdx` and the upgrade `index.mdx`).

## Where to backport

- `release-4.3` — same routing hint applies to the 4.3-line upgrade docs. Will open the backport PR after this lands.

## Verification

- Manual grep — no Chinese characters, no internal bookkeeping tokens.
- Local `yarn lint` was unavailable in the dev environment (`yarn install` hung against the registry mirror). The callout follows the same `:::info` + `<ExternalSiteLink>` patterns used elsewhere in this file's directory; CI lint is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)