### PR TITLE
docs(upgrade): route immutable-infra readers to cross-version preparation (release-4.3)

### DIFF
--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -16,6 +16,10 @@ Before starting, ensure your current platform version is within the supported up
 If you have **MySQL-PXC** instances, they will become **unmanaged** after upgrading to ACP v4.3.0 or later (when the MySQL operator is also upgraded). See <ExternalSiteLink name="mysql-mgr" href="/upgrade" children="MySQL Operator Upgrade Guide" /> for migration instructions.
 :::
 
+:::info
+On Immutable Infrastructure (Huawei DCS, VMware vSphere, Huawei Cloud Stack, and bare-metal immutable OS), the supported upgrade paths above apply to the ACP Distribution Version, which still moves directly to the target version through the Cluster Version Operator. When the target ACP version is more than one Kubernetes minor above the cluster's current version, the Kubernetes upgrade requires additional pre-staging of intermediate-version artifacts. See <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/index.html#cross-version-preparation" children="Preparing for Cross-Version Upgrades" /> before starting the upgrade window.
+:::
+
 ## Important Notes
 
 * Ensure the directory `/cpaas/minio` on the control plane nodes of global cluster has at least **120 GB** of free disk space.


### PR DESCRIPTION
## Summary

Backport of #833 to `release-4.3`.

Adds an `:::info` callout below "Supported upgrade paths" in `pre-upgrade.mdx` pointing Immutable Infrastructure readers to the **Preparing for Cross-Version Upgrades** section in immutable-infra-docs (alauda/immutable-infra-docs#99, backported there in #100).

## Back-port Notes

Not a clean cherry-pick — resolved one conflict in `pre-upgrade.mdx`:

- `release-4.3` still carries the **MySQL-PXC removal warning** (`:::warning` block) that was removed from `master` after this branch was cut. The cherry-pick conflicted because the new `:::info` callout lands in the same location.
- **Resolution**: keep both — the existing MySQL-PXC warning is preserved, and the new cross-version `:::info` callout is added immediately after it. No release-4.3 content was dropped.

No dev dependency bump.

## Verification

- Manual grep — no Chinese characters, no internal bookkeeping tokens; no conflict markers remain.
- Local `yarn lint` was unavailable in the dev environment (`yarn install` hung against the registry mirror). CI lint is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)