### PR TITLE
docs: rebrand MicroOS to Alauda OS (backport to release-4.2, AIT-70977)

### DIFF
--- a/docs/en/configure/clusters/overview.mdx
+++ b/docs/en/configure/clusters/overview.mdx
@@ -15,10 +15,9 @@ In this model, the platform provisions both the machines and the node operating 
 All nodes use an **Immutable OS**, which ensures a consistent, declarative, and easily recoverable infrastructure state.
 This model provides full automation across the entire cluster lifecycle — from provisioning to scaling and upgrades.
 
-**Examples of Immutable OS:**
+**Immutable OS on the platform:**
 
-Common Immutable OS examples include **Fedora CoreOS**, **Flatcar Linux**, and **openSUSE MicroOS**.
-Currently, the platform supports **MicroOS** for immutable node management.
+The platform uses **Alauda OS** for immutable node management.
 
 **Responsibilities:**
 

--- a/docs/en/configure/networking/functions/configure_node_local_dns.mdx
+++ b/docs/en/configure/networking/functions/configure_node_local_dns.mdx
@@ -26,7 +26,7 @@ NodeLocal DNSCache is a cluster plugin that improves cluster DNS performance by 
 
 4. **NetworkPolicy Configuration**: If NetworkPolicy is configured in the cluster, you need to additionally allow both from and to directions for the node CIDR and nodeLocalDNSIP in the networkPolicy to ensure proper communication.
 
-5. **MicroOS Cluster Upgrade**: For MicroOS clusters, upgrades are performed by rebuilding the cluster, which causes kubelet configuration changes to be lost. To make the NodeLocal DNS configuration persistent across upgrades, you need to add the `--cluster-dns` parameter to `kubeletExtraArgs` in the following three places of the cluster template:
+5. **Alauda OS Cluster Upgrade**: For Alauda OS clusters, upgrades are performed by rebuilding the cluster, which causes kubelet configuration changes to be lost. To make the NodeLocal DNS configuration persistent across upgrades, you need to add the `--cluster-dns` parameter to `kubeletExtraArgs` in the following three places of the cluster template:
    - `KubeadmControlPlane` → `initConfiguration` → `nodeRegistration` → `kubeletExtraArgs`
    - `KubeadmControlPlane` → `joinConfiguration` → `nodeRegistration` → `kubeletExtraArgs`
    - `KubeadmConfigTemplate` → `template` → `spec` → `joinConfiguration` → `nodeRegistration` → `kubeletExtraArgs`

--- a/docs/en/security/security_and_compliance/compliance_service.mdx
+++ b/docs/en/security/security_and_compliance/compliance_service.mdx
@@ -5,6 +5,6 @@ weight: 30
 
 # About Alauda Container Platform Compliance Service
 
-Compliance Service is a platform module designed to support STIG compliance scanning and MicroOS operating system scanning. It provides out-of-the-box compliance scanning capabilities with support for scheduled scanning and comprehensive reporting.
+Compliance Service is a platform module designed to support STIG compliance scanning and Alauda OS operating system scanning. It provides out-of-the-box compliance scanning capabilities with support for scheduled scanning and comprehensive reporting.
 
 <ExternalSite name="compliance-service" />

--- a/docs/en/virtualization/virtualization/virtual_machine/how_to/create-template.mdx
+++ b/docs/en/virtualization/virtualization/virtual_machine/how_to/create-template.mdx
@@ -58,7 +58,7 @@ apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataSource
 metadata:
   annotations:
-    cpaas.io/display-name: MicroOS-Clone
+    cpaas.io/display-name: AlaudaOS-Clone
   labels:
     virtualization.cpaas.io/image-os-arch: amd64
     virtualization.cpaas.io/image-os-type: linux
@@ -66,7 +66,7 @@ metadata:
     virtualization.cpaas.io/access-mode: ReadWriteMany
     virtualization.cpaas.io/size: 30Gi
     virtualization.cpaas.io/volume-mode: Block
-  name: microos-clone
+  name: alaudaos-clone
   namespace: kube-public
 spec:
   source:


### PR DESCRIPTION
## What

Backport of the MicroOS → Alauda OS brand purge (AIT-70977) onto **release-4.2**.

Customer-facing docs on 4.2 no longer expose `MicroOS` / `openSUSE MicroOS`.

## Scope (4 files)

- `configure/clusters/overview.mdx` — rewrote the "Examples of Immutable OS" block (Fedora CoreOS / Flatcar / openSUSE MicroOS) to "The platform uses **Alauda OS**".
- `configure/networking/functions/configure_node_local_dns.mdx` — "MicroOS Cluster Upgrade" / "MicroOS clusters" → "Alauda OS".
- `security/.../compliance_service.mdx` — "MicroOS operating system scanning" → "Alauda OS".
- `virtualization/.../create-template.mdx` — DataSource `cpaas.io/display-name: MicroOS-Clone` → `AlaudaOS-Clone`, `name: microos-clone` → `alaudaos-clone`.

Verified: zero `MicroOS` / `openSUSE` remain under `docs/`. EN only.

Ref: AIT-70977
