### PR TITLE
docs: rebrand MicroOS to Alauda OS (backport to release-4.0, AIT-70977)

### DIFF
--- a/docs/en/configure/clusters/overview.mdx
+++ b/docs/en/configure/clusters/overview.mdx
@@ -15,10 +15,9 @@ In this model, the platform provisions both the machines and the node operating 
 All nodes use an **Immutable OS**, which ensures a consistent, declarative, and easily recoverable infrastructure state.
 This model provides full automation across the entire cluster lifecycle — from provisioning to scaling and upgrades.
 
-**Examples of Immutable OS:**
+**Immutable OS on the platform:**
 
-Common Immutable OS examples include **Fedora CoreOS**, **Flatcar Linux**, and **openSUSE MicroOS**.
-Currently, the platform supports **MicroOS** for immutable node management.
+The platform uses **Alauda OS** for immutable node management.
 
 **Responsibilities:**
 


### PR DESCRIPTION
## What

Backport of the MicroOS → Alauda OS brand purge (AIT-70977) onto **release-4.0**.

## Scope (1 file)

- `configure/clusters/overview.mdx` — the only doc on 4.0 that referenced the upstream brand. The "Examples of Immutable OS" block (Fedora CoreOS / Flatcar / openSUSE MicroOS) is rewritten to "The platform uses **Alauda OS**".

Verified: zero `MicroOS` / `openSUSE` remain under `docs/`. EN only.

Ref: AIT-70977
