### PR TITLE
docs: require DefaultTasksMax=infinity in node checks

### DIFF
--- a/docs/en/configure/nodes/in_place_os_upgrade.mdx
+++ b/docs/en/configure/nodes/in_place_os_upgrade.mdx
@@ -166,7 +166,7 @@ systemctl status ufw 2>/dev/null || echo "ufw not installed"
 # /tmp must not be mounted with noexec.
 mount | grep " /tmp "
 
-# DefaultTasksMax must be infinity or a sufficiently large value.
+# DefaultTasksMax must be infinity.
 systemctl show --property=DefaultTasksMax
 ```
 
@@ -274,7 +274,7 @@ Use this checklist during the maintenance window and keep the completed record a
 | Post-upgrade | Confirm swap is disabled | | |
 | Post-upgrade | Confirm firewall services match the cluster network plan | | |
 | Post-upgrade | Confirm `/tmp` is not mounted with `noexec` | | |
-| Post-upgrade | Confirm `DefaultTasksMax` is `infinity` or a sufficiently large value | | |
+| Post-upgrade | Confirm `DefaultTasksMax` is `infinity` | | |
 | Post-upgrade | Confirm runtime and node component versions were not overwritten | | |
 | Post-upgrade | Confirm `containerd` and `kubelet` are healthy | | |
 | Post-upgrade | Confirm time skew between nodes is no more than 10 seconds | | |

--- a/docs/en/install/prepare/node_preprocessing.mdx
+++ b/docs/en/install/prepare/node_preprocessing.mdx
@@ -106,7 +106,7 @@ The following is the list of checks:
 - **Users and Permissions**
   - ✅ The node's SSH user has `root` privileges and can use `sudo` without the password.
   - ✅ The `UseDNS` and `UsePAM` parameters in `/etc/ssh/sshd_config` must be set to `no`.
-  - ✅ Executing `systemctl show --property=DefaultTasksMax` returns `infinity` or a very large value; otherwise, adjust `/etc/systemd/system.conf`.
+  - ✅ `systemctl show --property=DefaultTasksMax` must return `infinity`; a low limit (such as the `512` default on RHEL 7 / CentOS 7) makes busy containers fail to create threads. If it is not `infinity`, set `DefaultTasksMax=infinity` in `/etc/systemd/system.conf` and run `systemctl daemon-reexec`.
 
 - **Node Network**
   - ✅ `hostname` must comply with the following rules:


### PR DESCRIPTION
## What

Replace the unactionable `DefaultTasksMax` guidance (`infinity` or "a very large value") with a concrete, actionable requirement: **`DefaultTasksMax` must be `infinity`**, plus the apply step.

Touched:
- `docs/en/install/prepare/node_preprocessing.mdx` — preflight checklist item
- `docs/en/configure/nodes/in_place_os_upgrade.mdx` — verify comment + post-upgrade checklist row

## Why

"a very large value" gave readers no threshold to act on. A low per-unit limit (notably the `512` default on systemd 219 / RHEL 7 / CentOS 7, both in our supported matrix) caps each unit's threads and makes busy containers fail with `fork: Resource temporarily unavailable`.

`infinity` is the standard container-host setting (containerd/docker units already use it; openSUSE/MicroOS ships it by default). Removing systemd's per-unit cap is safe on a Kubernetes node because pod-level PID limits (`--pod-max-pids` / CRI pids-limit) and `kernel.pid_max` are the real PID governors.

Backports to release-4.3/4.2/4.1/4.0 cover the same checklist line (those branches do not contain `in_place_os_upgrade.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated node configuration requirements to enforce `DefaultTasksMax=infinity` as a mandatory setting
  * Enhanced pre-installation and post-upgrade checklists with stricter validation and clearer configuration instructions for systemd settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->