### PR TITLE
docs: require DefaultTasksMax=infinity in node checks (backport to release-4.0)

### DIFF
--- a/docs/en/install/prepare/node_preprocessing.mdx
+++ b/docs/en/install/prepare/node_preprocessing.mdx
@@ -98,7 +98,7 @@ The following is the list of checks:
 - **Users and Permissions**
   - ✅ The node's SSH user has `root` privileges and can use `sudo` without the password.
   - ✅ The `UseDNS` and `UsePAM` parameters in `/etc/ssh/sshd_config` must be set to `no`.
-  - ✅ Executing `systemctl show --property=DefaultTasksMax` returns `infinity` or a very large value; otherwise, adjust `/etc/systemd/system.conf`.
+  - ✅ `systemctl show --property=DefaultTasksMax` must return `infinity`; a low limit (such as the `512` default on RHEL 7 / CentOS 7) makes busy containers fail to create threads. If it is not `infinity`, set `DefaultTasksMax=infinity` in `/etc/systemd/system.conf` and run `systemctl daemon-reexec`.
 
 - **Node Network**
   - ✅ `hostname` must comply with the following rules:


### PR DESCRIPTION
Backport of #841 to `release-4.0`.

Replaces the unactionable `DefaultTasksMax` guidance ("infinity or a very large value") in `docs/en/install/prepare/node_preprocessing.mdx` with a concrete requirement: **`DefaultTasksMax` must be `infinity`**, plus the apply step (`systemctl daemon-reexec`).

A low per-unit limit (notably the `512` default on RHEL 7 / CentOS 7, both in the supported matrix) caps each unit's threads and makes busy containers fail with `fork: Resource temporarily unavailable`. `infinity` is the standard container-host setting; pod-level PID limits and `kernel.pid_max` remain the real PID governors.

This release branch does not contain `in_place_os_upgrade.mdx`, so only the preflight checklist line changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)