### PR TITLE
docs: gate etcd sync plugin uninstall on primary/standby consistency

### DIFF
--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -233,6 +233,10 @@ If the following components are installed, restart their services:
 
 ## Disaster Recovery Process
 
+<Directive type="danger" title="Verify primary/standby consistency before uninstalling the etcd synchronization plugin">
+This procedure uninstalls the etcd synchronization plugin. Before you uninstall it, confirm that the standby cluster data is consistent with the primary cluster. Uninstalling the plugin while the standby is missing data that the primary holds can cause owner references to resolve incorrectly, and workload-cluster node `Machine` objects — including immutable-OS clusters, where this destroys the backing virtual machine — may be deleted. If the consistency check reports missing or surplus keys, do not uninstall the plugin; resolve the inconsistency or contact technical support first.
+</Directive>
+
 1. Restart Elasticsearch on the standby cluster in case it is necessary:
 
     ```bash
@@ -254,7 +258,12 @@ If the following components are installed, restart their services:
     fi
     ```
 
-2. Verify data consistency in the standby cluster (same check as in [Step 3](#etcd_sync));
+2. Verify data consistency in the standby cluster (same check as in [Step 3](#etcd_sync)). If the check reports missing or surplus keys, the standby is not consistent with the primary: do not continue to the next step. Resolve the inconsistency or contact technical support first. On **both** clusters, also confirm that no `Machine` nodes are in a non-running state, and resolve any that are before continuing:
+
+    ```bash
+    kubectl get machines.platform.tkestack.io
+    ```
+
 3. Uninstall the etcd synchronization plugin;
 4. Remove port forwarding for `2379` from both VIPs;
 5. Switch the platform domain DNS to the standby VIP, which now becomes the Primary Cluster;

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -341,7 +341,7 @@ Use this procedure when the environment includes both a primary global cluster a
 
 Follow your regular global DR inspection procedures to ensure that data in the **standby global cluster** is consistent with the **primary global cluster**. For background on the DR topology and synchronization workflow, see [Global Cluster Disaster Recovery](/install/global_dr.mdx).
 
-If inconsistencies are detected, contact technical support before proceeding.
+If inconsistencies are detected, do not uninstall the etcd synchronization plugin in the next step, and contact technical support before proceeding. Uninstalling the plugin while the standby global cluster is missing data that the primary holds can cause owner references to resolve incorrectly, and workload-cluster node `Machine` objects — including immutable-OS clusters, where this destroys the backing virtual machine — may be deleted.
 
 On **both** global clusters, run the following command to ensure no `Machine` nodes are in a non-running state:
 


### PR DESCRIPTION
## What
Harden the guidance around uninstalling the **etcd Synchronizer** plugin in a `global` DR environment so it is not uninstalled while the standby `global` cluster is inconsistent with the primary.

- `install/global_dr.mdx` — *Disaster Recovery Process*: add a DANGER callout and turn switchover step 2 into a hard gate (stop on missing/surplus keys, plus the `kubectl get machines.platform.tkestack.io` non-running check), matching the upgrade path.
- `upgrade/upgrade_global_cluster.mdx` — *Global DR Procedure*: the inconsistency note now says **do not uninstall** and states the consequence.

## Why
If the etcd sync plugin is uninstalled while primary/standby are inconsistent, owner references can resolve incorrectly and workload-cluster node `Machine` objects may be deleted — on immutable-OS clusters this destroys the backing VM. This operational gate applies to **all versions**, not only 4.1.

## Scope
`master` only. Backports to `release-4.3` / `release-4.2` / `release-4.1` will follow as separate, per-branch-adapted PRs (the upgrade page differs pre-CVO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added critical safety warnings for disaster recovery procedures to prevent data loss
* Enhanced verification steps to confirm cluster consistency before recovery operations
* Updated guidance to contact technical support when inconsistencies are detected
* Improved instructions for validating cluster health during disaster recovery processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->