### PR TITLE
docs: scope node preprocessing to traditional OS (backport to release-4.3)

### DIFF
--- a/docs/en/install/prepare/node_preprocessing.mdx
+++ b/docs/en/install/prepare/node_preprocessing.mdx
@@ -6,6 +6,10 @@ weight: 30
 
 Before installing the `global` cluster, all nodes (control plane nodes and worker nodes) must complete preprocessing.
 
+:::info
+This page applies to nodes running a **traditional operating system** such as RHEL, CentOS, or Ubuntu, which <Term name="productShort" /> provisions over SSH. Several of the checks below — for example the SSH user and the `/etc/ssh/sshd_config` settings — exist to keep the SSH-based node join working. If your environment runs on Immutable Infrastructure (Alauda OS on Huawei DCS, VMware vSphere, or Huawei Cloud Stack), node provisioning is image-based and this preprocessing does not apply; see <ExternalSiteLink name="immutable-infra" href="/global/install.html" children="Installing the global Cluster on Immutable Infrastructure" /> instead.
+:::
+
 ## Supported OS and Kernel Versions \{#supported_os_and_kernels}
 
 The following table lists the supported operating systems, their validated versions, and the corresponding tested kernel versions.

--- a/docs/en/install/prepare/node_preprocessing.mdx
+++ b/docs/en/install/prepare/node_preprocessing.mdx
@@ -103,7 +103,8 @@ The following is the list of checks:
 
 - **Users and Permissions**
   - ✅ The node's SSH user has `root` privileges and can use `sudo` without the password.
-  - ✅ The `UseDNS` and `UsePAM` parameters in `/etc/ssh/sshd_config` must be set to `no`.
+  - ✅ The `UseDNS` parameter in `/etc/ssh/sshd_config` must be set to `no`.
+  - ✅ Set the `UsePAM` parameter in `/etc/ssh/sshd_config` to `no` before adding the node, then restart `sshd`. PAM session policies (such as a forced password change, `pam_access`, `faillock`, or `pam_limits`) can otherwise block the SSH-based node join. After the node reaches the `Ready` state, you can restore `UsePAM yes`. On SELinux-enforcing systems that use password authentication, `UsePAM no` can itself break SSH login; use key-based authentication in that case.
   - ✅ `systemctl show --property=DefaultTasksMax` must return `infinity`; a low limit (such as the `512` default on RHEL 7 / CentOS 7) makes busy containers fail to create threads. If it is not `infinity`, set `DefaultTasksMax=infinity` in `/etc/systemd/system.conf` and run `systemctl daemon-reexec`.
 
 - **Node Network**


### PR DESCRIPTION
## What

Add an info note at the top of `docs/en/install/prepare/node_preprocessing.mdx` stating the page applies to nodes on a **traditional operating system** (RHEL / CentOS / Ubuntu), which the platform provisions **over SSH** — and redirect Immutable Infrastructure (Alauda OS) readers to the immutable-infra install path.

## Why

The install section pages (overview / installing / index) already banner the traditional-OS scope, but `node_preprocessing` itself carried no scope statement, so readers landing directly on the page (search / deep link) had no cue. The note also gives the missing rationale for the SSH-related checks (SSH user, `sshd_config` UseDNS/UsePAM): traditional-OS node join is SSH-based, whereas Immutable Infrastructure provisioning is image-based and skips this preprocessing.

Immutable redirect reuses the existing wording/component from `install/overview.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)