### PR TITLE
docs: scope node preprocessing to traditional OS (backport to release-4.2)

### DIFF
--- a/docs/en/install/prepare/node_preprocessing.mdx
+++ b/docs/en/install/prepare/node_preprocessing.mdx
@@ -6,6 +6,10 @@ weight: 30
 
 Before installing the `global` cluster, all nodes (control plane nodes and worker nodes) must complete preprocessing.
 
+:::info
+This page applies to nodes running a **traditional operating system** such as RHEL, CentOS, or Ubuntu, which <Term name="productShort" /> provisions over SSH. Several of the checks below — for example the SSH user and the `/etc/ssh/sshd_config` settings — exist to keep the SSH-based node join working.
+:::
+
 ## Supported OS and Kernel Versions \{#supported_os_and_kernels}
 
 The following table lists the supported operating systems, their validated versions, and the corresponding tested kernel versions.

--- a/docs/en/install/prepare/node_preprocessing.mdx
+++ b/docs/en/install/prepare/node_preprocessing.mdx
@@ -103,7 +103,8 @@ The following is the list of checks:
 
 - **Users and Permissions**
   - ✅ The node's SSH user has `root` privileges and can use `sudo` without the password.
-  - ✅ The `UseDNS` and `UsePAM` parameters in `/etc/ssh/sshd_config` must be set to `no`.
+  - ✅ The `UseDNS` parameter in `/etc/ssh/sshd_config` must be set to `no`.
+  - ✅ Set the `UsePAM` parameter in `/etc/ssh/sshd_config` to `no` before adding the node, then restart `sshd`. PAM session policies (such as a forced password change, `pam_access`, `faillock`, or `pam_limits`) can otherwise block the SSH-based node join. After the node reaches the `Ready` state, you can restore `UsePAM yes`. On SELinux-enforcing systems that use password authentication, `UsePAM no` can itself break SSH login; use key-based authentication in that case.
   - ✅ `systemctl show --property=DefaultTasksMax` must return `infinity`; a low limit (such as the `512` default on RHEL 7 / CentOS 7) makes busy containers fail to create threads. If it is not `infinity`, set `DefaultTasksMax=infinity` in `/etc/systemd/system.conf` and run `systemctl daemon-reexec`.
 
 - **Node Network**


### PR DESCRIPTION
## What

Add an info note at the top of `docs/en/install/prepare/node_preprocessing.mdx` stating the page applies to nodes on a **traditional operating system** (RHEL / CentOS / Ubuntu), which the platform provisions **over SSH**.

## Why

`node_preprocessing` carried no scope statement, so readers landing directly on the page had no cue, and the SSH-related checks (SSH user, `sshd_config` UseDNS/UsePAM) had no stated rationale — traditional-OS node join is SSH-based.

Note: this release line (release-4.2) has **no Immutable Infrastructure path** (0 immutable references across `docs/en/install`), so unlike master / release-4.3 this variant **omits** the immutable redirect to avoid introducing a concept that does not exist in this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)