### PR TITLE
docs: gate etcd sync plugin uninstall on primary/standby consistency (backport #850 to release-4.3)

### DIFF
--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -248,6 +248,10 @@ If the following components are installed, restart their services:
 
 ## Disaster Recovery Process
 
+<Directive type="danger" title="Verify primary/standby consistency before uninstalling the etcd synchronization plugin">
+This procedure uninstalls the etcd synchronization plugin. Before you uninstall it, confirm that the standby cluster data is consistent with the primary cluster. Uninstalling the plugin while the standby is missing data that the primary holds can cause owner references to resolve incorrectly, and workload-cluster node `Machine` objects — including immutable-OS clusters, where this destroys the backing virtual machine — may be deleted. If the consistency check reports missing or surplus keys, do not uninstall the plugin; resolve the inconsistency or contact technical support first.
+</Directive>
+
 1. Restart Elasticsearch on the standby cluster in case it is necessary:
 
     ```bash
@@ -269,7 +273,12 @@ If the following components are installed, restart their services:
     fi
     ```
 
-2. Verify data consistency in the standby cluster (same check as in [Step 3](#etcd_sync));
+2. Verify data consistency in the standby cluster (same check as in [Step 3](#etcd_sync)). If the check reports missing or surplus keys, the standby is not consistent with the primary: do not continue to the next step. Resolve the inconsistency or contact technical support first. On **both** clusters, also confirm that no `Machine` nodes are in a non-running state, and resolve any that are before continuing:
+
+    ```bash
+    kubectl get machines.platform.tkestack.io
+    ```
+
 3. Uninstall the etcd synchronization plugin;
 4. Remove port forwarding for `2379` from both VIPs;
 5. Switch the platform domain DNS to the standby VIP, which now becomes the Primary Cluster;

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -354,7 +354,7 @@ Use this procedure when the environment includes both a primary global cluster a
 
 Follow your regular global DR inspection procedures to ensure that data in the **standby global cluster** is consistent with the **primary global cluster**. For background on the DR topology and synchronization workflow, see [Global Cluster Disaster Recovery](/install/global_dr.mdx).
 
-If inconsistencies are detected, contact technical support before proceeding.
+If inconsistencies are detected, do not uninstall the etcd synchronization plugin in the next step, and contact technical support before proceeding. Uninstalling the plugin while the standby global cluster is missing data that the primary holds can cause owner references to resolve incorrectly, and workload-cluster node `Machine` objects — including immutable-OS clusters, where this destroys the backing virtual machine — may be deleted.
 
 On **both** global clusters, run the following command to ensure no `Machine` nodes are in a non-running state:
 


### PR DESCRIPTION
Backport of #850 to `release-4.3`.

## What
- `install/global_dr.mdx` — *Disaster Recovery Process*: add a DANGER callout and turn switchover step 2 into a hard gate (stop on missing/surplus keys + `kubectl get machines.platform.tkestack.io` non-running check).
- `upgrade/upgrade_global_cluster.mdx` — *Global DR Procedure*: the inconsistency note now says do not uninstall and states the consequence.

## Why
Uninstalling the etcd sync plugin while primary/standby are inconsistent can resolve owner references incorrectly and delete workload-cluster node `Machine` objects (immutable-OS clusters lose the backing VM). The operational gate applies to all versions.

## Notes
Insertions are identical to the merged master change in #850. acp-docs lint runs in CI (cannot run locally in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)