### PR TITLE
docs: generalize LocalDNS config management for OS neutrality

### DIFF
--- a/docs/en/configure/networking/functions/configure_node_local_dns.mdx
+++ b/docs/en/configure/networking/functions/configure_node_local_dns.mdx
@@ -26,7 +26,7 @@ NodeLocal DNSCache is a cluster plugin that improves cluster DNS performance by 
 
 4. **NetworkPolicy Configuration**: If NetworkPolicy is configured in the cluster, you need to additionally allow both from and to directions for the node CIDR and nodeLocalDNSIP in the networkPolicy to ensure proper communication.
 
-5. **Alauda OS Cluster Upgrade**: For Alauda OS clusters, upgrades are performed by rebuilding the cluster, which causes kubelet configuration changes to be lost. To make the NodeLocal DNS configuration persistent across upgrades, you need to add the `--cluster-dns` parameter to `kubeletExtraArgs` in the following three places of the cluster template:
+5. **Cluster Upgrade via Rebuilding**: If the cluster is upgraded by rebuilding nodes (re-provisioning), kubelet configuration changes will be lost. To make the NodeLocal DNS configuration persistent across upgrades, you need to add the `--cluster-dns` parameter to `kubeletExtraArgs` in the following three places of the cluster template:
    - `KubeadmControlPlane` → `initConfiguration` → `nodeRegistration` → `kubeletExtraArgs`
    - `KubeadmControlPlane` → `joinConfiguration` → `nodeRegistration` → `kubeletExtraArgs`
    - `KubeadmConfigTemplate` → `template` → `spec` → `joinConfiguration` → `nodeRegistration` → `kubeletExtraArgs`


### PR DESCRIPTION
Cherry-pick of 03a7b178 (#848) to release-4.3

Remove specific OS product name (MicroOS) from NodeLocal DNSCache documentation. Describe upgrade scenario by behavior (rebuilding nodes) instead of tying it to a particular operating system.

ACP-53148