### PR TITLE
docs(npu-operator): bring release-4.2 npu_operator docs up to v1.2.3

### DIFF
--- a/docs/en/hardware_accelerator/npu/npu_operator/installation.mdx
+++ b/docs/en/hardware_accelerator/npu/npu_operator/installation.mdx
@@ -32,7 +32,7 @@ __You do NOT need to edit `/etc/containerd/config.toml` manually__ to enable CDI
 :::
 
 :::caution
-__After upgrading the host's containerd package__, the package install may replace `/etc/containerd/config.toml` with its default template, reverting the operator's `enable_cdi = true` patch. CDI device injection will silently fail for any NPU pod scheduled afterwards. Restart the containerd-config sidecar so it re-applies the patch:
+__After upgrading the host's containerd package__, the package install may replace `/etc/containerd/config.toml` with its default template, reverting the operator's `enable_cdi = true` patch. CDI device injection will silently fail for any NPU pod scheduled afterward. Restart the containerd-config sidecar so it re-applies the patch:
 
 ```bash
 kubectl -n npu-operator rollout restart ds/ascend-runtime-containerd
@@ -143,8 +143,8 @@ The __Volcano__ cluster plugin can be left uninstalled for now. Install it from 
 Apply the label `masterselector=dls-master-node` to all master nodes and the label `workerselector=dls-worker-node` to the worker nodes that should host NPU components:
 
 ```bash
-kubectl label nodes {master-node-id} masterselector=dls-master-node
-kubectl label nodes {worker-node-id} workerselector=dls-worker-node
+kubectl label nodes <master-node-id> masterselector=dls-master-node
+kubectl label nodes <worker-node-id> workerselector=dls-worker-node
 ```
 
 #### 5.2 Install the operator

--- a/docs/en/hardware_accelerator/npu/npu_operator/installation.mdx
+++ b/docs/en/hardware_accelerator/npu/npu_operator/installation.mdx
@@ -41,7 +41,7 @@ kubectl -n npu-operator rollout restart ds/ascend-runtime-containerd
 (Replace `npu-operator` with your install namespace if you chose a different one.)
 :::
 
-#### 1.1 Pull driver images from Docker Hub
+#### 1.1 Pull driver images from Docker Hub \{#11-pull-driver-images-from-dockerhub}
 
 The driver image is __shipped independently__ on Docker Hub at [`docker.io/alaudadockerhub/ascend-driver`](https://hub.docker.com/r/alaudadockerhub/ascend-driver) — not as part of the operator bundle — because the driver `.ko` binaries are kernel-specific and the kernel list grows over time. Each tag follows the pattern `<HDK>-<chip>-<kernel>-<os-stem>`, for example `25.5.0-910b-6.6.0-145.0.4.135-oe2403sp3`. Pick the tag matching your nodes' `uname -r` and chip.
 
@@ -113,7 +113,7 @@ From the Marketplace on the __<Term name="company"/> Customer Portal__ website, 
 - (Optional) The __Volcano__ cluster plugin package — only needed if you plan to enable the __ClusterD__ component during deployment.
 :::
 
-### Step 3: Upload packages
+### Step 3: Upload packages \{#step-3-upload-packages}
 
 The platform provides the `violet` command-line tool for uploading both operator packages and cluster plugin packages downloaded from the Customer Portal Marketplace.
 
@@ -161,7 +161,7 @@ kubectl label nodes {worker-node-id} workerselector=dls-worker-node
 At this point __no driver pod, device plugin, or other NPU pod is running yet__. The controller pods are idle and waiting for an `NPUOperatorCtl` instance. If you stop here the NPU nodes will not be configured.
 :::
 
-#### 5.3 Create the NPUOperatorCtl instance
+#### 5.3 Create the NPUOperatorCtl instance \{#53-create-the-npuoperatorctl-instance}
 
 The deployment form opens when you create the instance, not when you install the operator above.
 

--- a/docs/en/hardware_accelerator/npu/npu_operator/installation.mdx
+++ b/docs/en/hardware_accelerator/npu/npu_operator/installation.mdx
@@ -6,243 +6,324 @@ weight: 20
 
 ## Prerequisites
 
-### Online Installation
+### Common requirements
 
-1. **ACP version: v4.0 or later**
-2. **Cluster administrator access to your ACP cluster**
-3. **Ensure that the bash tool exists in the NPU node. Otherwise, the driver and firmware installation script may fail to be parsed.**
-4. **Worker Node Operating System Requirements**
-    - Worker nodes (or node groups) running **NPU workloads** must use one of the following operating systems (Arm architecture):
-      - `openEuler 22.03 LTS`
-      - `Ubuntu 22.04`
+1. __ACP version__: v4.0 or later.
+2. __Cluster administrator access__ to the target ACP cluster.
+3. __Supported NPU hardware__. NPU worker nodes must carry one of:
+    - `Ascend 910B`
+    - `Ascend 310P`
+4. __`Alauda Build of Node Feature Discovery` cluster plugin__ must be installed. The operator reads NPU presence and kernel/OS labels from NFD to decide which driver image to pull on each node.
 
-    - Worker nodes running **CPU workloads only** can use any operating system, as the NPU operator performs no configuration on nodes without NPU workloads.
-5. **Supported NPU Hardware**
-    - Nodes must use supported NPUs:
-      - `Ascend 910B`
-      - `Ascend 310P`
+### MindIO SDK (optional)
 
-    - For detailed OS and hardware compatibility, see [MindCluster Documentation](https://www.hiascend.com/document/detail/zh/mindx-dl/600/clusterscheduling/clusterschedulingig/clusterschedulingig/dlug_installation_002.html)
-
-6. **The `Alauda Build of Node Feature Discovery` cluster plugin must be installed.**
-
-### Offline Installation
-
-1. **Offline installation requires all online installation prerequisites plus additional preparation steps.**
-
-2. **Prepare the driver and firmware package and the MindIO SDK package.**
-    Download the following packages (if you do not need to install MindIO, then you do not need to download the MindIO package):
-    - For the driver and firmware package, find the `config.json` file in the GitCode repository of the [npu-driver-installer](https://gitcode.com/openFuyao/npu-driver-installer/tree/1.1.1/downloader/NPU), and download the package based on the version you want to choose, the NPU model and OS architecture of the corresponding node through the corresponding link provided.
-    - For the MindIO SDK package, find the `config.json` file in the GitCode repository of the [npu-node-provision](https://gitcode.com/openFuyao/npu-node-provision/blob/1.1.1/downloader/software/7.2.RC1/config.json), and download the SDK package based on the NPU model and OS architecture of the corresponding node through the corresponding link provided.
-3. **Save the ZIP file of the driver and firmware package to the `/tmp/driver_pkg/` path of the node where the offline installation is to be performed.**
-4. **Save the ZIP file of the MindIO package to the `/opt/openFuyao/mindio/` path of the node where the offline installation is to be performed. (If you do not need to install MindIO, skip this step.)**
-5. **Check whether the target node contains the following tools.**
-    - For systems using Yum as the package manager, the following package needs to be installed: "jq wget unzip which net-tools pciutils gcc make kernel-devel-$(uname-r) kernel-headers-(uname-r) dkms".
-    - For systems using apt-get as the package manager, the following package needs to be installed: "jq wget unzip debianutils net-tools pciutils gcc make dkms linux-headers-$(uname -r)".
-    - For systems using DNF as the package manager, the following package needs to be installed: "jq wget unzip which net-tools pciutils gcc make kernel-devel-$(uname -r) kernel-headers-(uname-r) dkms".
+If you plan to enable __MindIO TFT__ or __MindIO ACP__, separately stage the matching MindIO SDK package on each NPU node under `/opt/openFuyao/mindio/`. Skip this step otherwise.
 
 ## Procedure
 
-### Downloading Cluster plugin
+### Step 1: Sync driver images and configure ImageWhiteList \{#sync-driver-images}
 
-:::info
-You can download the app named `Alauda Build of NPU Operator` and `Alauda Build of Node Feature Discovery` from the Marketplace on the Customer Portal website.
+:::warning
+__This is the most common cause of a failed install — do it first.__ The driver image is pulled at runtime by the driver DaemonSet based on each node's kernel label, and lives at the `mlops/ascend-driver` path — not bundled with the operator. If the matching tag isn't in your cluster registry, or isn't listed in an `ImageWhiteList`, the DaemonSet stays in `ImagePullBackOff` and the operator never reaches `Ready`. __If no tag matches your kernel at the source Docker Hub repository, contact <Term name="company"/> Customer Support__ to have one built — see [§1.1](#11-pull-driver-images-from-dockerhub).
 :::
 
-Note: The Volcano cluster plugin can be left uninstalled for now.
+:::info
+__You do NOT need to edit `/etc/containerd/config.toml` manually__ to enable CDI. The operator ships an `ascend-runtime-containerd` DaemonSet that runs on every NPU node and idempotently flips `enable_cdi = true` and adds the default `cdi_spec_dirs` (`/var/run/cdi`, `/etc/cdi`) in containerd's config, then `SIGHUP`s containerd. This works on both containerd 1.7.x (where CDI is off by default) and 2.x (where it is on by default).
+:::
 
-### Uploading the Cluster plugin
+:::caution
+__After upgrading the host's containerd package__, the package install may replace `/etc/containerd/config.toml` with its default template, reverting the operator's `enable_cdi = true` patch. CDI device injection will silently fail for any NPU pod scheduled afterwards. Restart the containerd-config sidecar so it re-applies the patch:
 
-The platform provides the **`violet`** command-line tool for uploading packages downloaded from the Custom Portal Marketplace.
+```bash
+kubectl -n npu-operator rollout restart ds/ascend-runtime-containerd
+```
+
+(Replace `npu-operator` with your install namespace if you chose a different one.)
+:::
+
+#### 1.1 Pull driver images from Docker Hub
+
+The driver image is __shipped independently__ on Docker Hub at [`docker.io/alaudadockerhub/ascend-driver`](https://hub.docker.com/r/alaudadockerhub/ascend-driver) — not as part of the operator bundle — because the driver `.ko` binaries are kernel-specific and the kernel list grows over time. Each tag follows the pattern `<HDK>-<chip>-<kernel>-<os-stem>`, for example `25.5.0-910b-6.6.0-145.0.4.135-oe2403sp3`. Pick the tag matching your nodes' `uname -r` and chip.
+
+:::warning
+__No matching tag for your kernel?__ Do not try to compile a driver image yourself or fall back to a `.run` install on the host — contact <Term name="company"/> __Customer Support__ with the output of `uname -r` and your chip model (e.g. `Ascend 910B4`, `Ascend 310P3`). A new tag for your kernel will be built and published to the same Docker Hub repository, no operator code changes required. Proceeding without a matching image will leave the driver DaemonSet in `ImagePullBackOff` indefinitely.
+:::
+
+List available tags:
+
+```bash
+curl -s 'https://hub.docker.com/v2/repositories/alaudadockerhub/ascend-driver/tags/?page_size=100' \
+  | jq -r '.results[].name'
+```
+
+On a machine with internet access, mirror each selected tag into your cluster registry:
+
+```bash
+TAG=25.5.0-<chip>-<kernel>-<os-stem>
+
+skopeo copy --all \
+  docker://docker.io/alaudadockerhub/ascend-driver:$TAG \
+  docker://<your-cluster-registry>/mlops/ascend-driver:$TAG
+```
+
+The operator configuration defaults `spec.driver.image.repository` to `mlops/ascend-driver`; override it in the deployment form if your registry uses a different namespace.
+
+#### 1.2 Allow the driver image in ImageWhiteList
+
+ACP gates which images pods are allowed to pull. Every driver-image tag the DaemonSet may pull must be listed explicitly in an `ImageWhiteList`.
+
+Create one (or extend the existing `ascend-driver` `ImageWhiteList` in `cpaas-system`):
+
+```yaml
+apiVersion: app.alauda.io/v1alpha1
+kind: ImageWhiteList
+metadata:
+  name: ascend-driver
+  namespace: cpaas-system
+spec:
+  repoList:
+  # one entry per tag you mirrored in step 1.1 — full image reference, not bare repo path
+  - <your-cluster-registry>/mlops/ascend-driver:25.5.0-910b-<kernel>-<os-stem>
+  - <your-cluster-registry>/mlops/ascend-driver:25.5.0-310p-<kernel>-<os-stem>
+```
+
+Add one `repoList` entry per `<chip, kernel>` tag you mirrored. Each entry is a __full image reference including the tag__ (the API does not accept bare repository paths). If you override `spec.driver.image.repository` later, list the new path instead.
+
+:::tip
+If your platform doesn't enforce ImageWhiteList (`Allow` policy by default), this sub-step is a no-op — kubelet still authenticates to the registry, so credentials gate the actual pull.
+:::
+
+#### 1.3 Verify
+
+On each NPU node, the kubelet should be able to pull a driver image (use the tag matching the node's kernel):
+
+```bash
+crictl pull <your-cluster-registry>/mlops/ascend-driver:$TAG
+```
+
+If this succeeds, Step 1 is complete. A later `ImagePullBackOff` on the driver DaemonSet usually means a missing tag in the registry, a registry credential issue, or a missing `repoList` entry in the `ImageWhiteList`.
+
+### Step 2: Download packages
+
+:::info
+From the Marketplace on the __<Term name="company"/> Customer Portal__ website, download:
+
+- The __Alauda Build of NPU Operator__ operator package (delivered as an OLM OperatorBundle).
+- The __Alauda Build of Node Feature Discovery__ cluster plugin package.
+- (Optional) The __Volcano__ cluster plugin package — only needed if you plan to enable the __ClusterD__ component during deployment.
+:::
+
+### Step 3: Upload packages
+
+The platform provides the `violet` command-line tool for uploading both operator packages and cluster plugin packages downloaded from the Customer Portal Marketplace.
 
 For details, see [Upload Packages](/extend/upload_package).
 
+### Step 4: Install the Node Feature Discovery cluster plugin
 
-### Installing Alauda Build of NPU Operator
+`Alauda Build of Node Feature Discovery` is a __cluster plugin__, not an operator. Install it first because the NPU Operator depends on its node labelling.
 
+1. Navigate to __Administrator__ > __Marketplace__ > __Cluster Plugins__.
+2. Switch to the target cluster.
+3. Locate __Alauda Build of Node Feature Discovery__ and click __Install__.
 
-1. Apply the label `masterselector=dls-master-node` to all master nodes and the label `workerselector=dls-worker-node` to all worker nodes.
-    ```bash
-    kubectl label nodes {master-node-id} masterselector=dls-master-node
-    kubectl label nodes {worker-node-id} workerselector=dls-worker-node
-    ```
+:::tip
+The __Volcano__ cluster plugin can be left uninstalled for now. Install it from the same __Cluster Plugins__ page only if you later enable the __ClusterD__ component of the NPU Operator.
+:::
 
-2. Go to the `Administrator` -> `Marketplace` -> `Cluster Plugin` page, switch to the target cluster, and then deploy the `Alauda Build of NPU Operator` Cluster plugin.
+### Step 5: Install the Alauda Build of NPU Operator
 
-    Deployment form parameter description:
-    :::warning
-    If the components listed in the table below are already installed, be sure to disable the corresponding buttons during deployment.
-    :::
+`Alauda Build of NPU Operator` is delivered as an __operator__ (OLM bundle). Installation has two distinct sub-steps on the platform UI:
 
-    :::tip
-    Ascend Operator, NodeD, ClusterD, Resilience Controller, MindIO TFT, and MindIO ACP are not deployed by default. Please deploy them only when there is a clear need for them.
-    :::
+1. __Install the operator__ — the OperatorHub flow only brings up the operator's __controller pods__ (`npu-operator-controller-manager` + `npu-operator`). It does __not__ deploy any driver, device plugin, or other NPU components.
+2. __Create an `NPUOperatorCtl` instance__ — only at this step do you fill in the deployment form, and only after the instance is created do the controller pods start reconciling and rolling out the NPU components onto the nodes.
 
-    | Component | Default | Description |
-    |------------|---------|-------------|
-    | Driver | Enabled | Whether to install driver and firmware.|
-    | Version | 24.1.RC3 | Driver and firmware version. You must select the version number from the repository directory [npu-driver-installer](https://gitcode.com/openFuyao/npu-driver-installer/tree/1.1.1/downloader/NPU).|
-    | Ascend Device Plugin | Enabled | Whether to install Ascend Device Plugin. |
-    | Ascend Docker Runtime | Enabled | Whether to install Ascend Docker Runtime. |
-    | NPU exporter | Enabled | Whether to install NPU exporter. |
-    | Ascend Operator | Disabled | Whether to install Ascend Operator. |
-    | NodeD | Disabled | Whether to install NodeD. |
-    | ClusterD | Disabled | Whether to install ClusterD. Need to install the Volcano cluster plugin first. |
-    | Resilience Controller | Disabled | Whether to install Resilience Controller. |
-    | MindIO TFT | Disabled | Whether to install MindIO TFT. |
-    | MindIO ACP | Disabled | Whether to install MindIO ACP. |
+#### 5.1 Label nodes
 
+Apply the label `masterselector=dls-master-node` to all master nodes and the label `workerselector=dls-worker-node` to the worker nodes that should host NPU components:
+
+```bash
+kubectl label nodes {master-node-id} masterselector=dls-master-node
+kubectl label nodes {worker-node-id} workerselector=dls-worker-node
+```
+
+#### 5.2 Install the operator
+
+1. Navigate to __Administrator__ > __Marketplace__ > __OperatorHub__, switch to the target cluster, and locate the __Alauda Build of NPU Operator__ entry. If the status is _Absent_, confirm the operator package was uploaded with `violet` in [Step 3](#step-3-upload-packages).
+
+2. Click the operator to open its details page, then click __Install__.
+
+3. On the install page, leave __Channel__ unchanged, confirm __Version__, leave __Installation Location__ as `npu-operator` (the default; all NPU components created in the next sub-step land here), and select __Manual__ for __Upgrade Strategy__. Click __Install__.
+
+4. Wait for the subscription to reach _Succeeded_. The __Alauda Build of NPU Operator__ tile should transition from _Installing_ to _Installed_, and `kubectl -n npu-operator get pod` will show the two controller pods (`npu-operator` and `npu-operator-controller-manager`) `Running`.
+
+:::warning
+At this point __no driver pod, device plugin, or other NPU pod is running yet__. The controller pods are idle and waiting for an `NPUOperatorCtl` instance. If you stop here the NPU nodes will not be configured.
+:::
+
+#### 5.3 Create the NPUOperatorCtl instance
+
+The deployment form opens when you create the instance, not when you install the operator above.
+
+1. On the __Installed Operators__ page, click the __Alauda Build of NPU Operator__ tile, then click __Create Instance__ (or open the __NPUOperatorCtl__ tab and click __Create NPUOperatorCtl__).
+
+2. Fill in the form (see the table below) and click __Create__.
+
+3. The operator immediately reconciles: driver / device plugin / runtime sidecar / exporter / rebooter DaemonSets land on every NPU node, and the controller updates the `NPUOperatorCtl` `status.conditions` to `Deployed=True / UpgradeSuccessful` once everything is up.
+
+Deployment form parameter description:
+
+:::warning
+If a component listed in the table below is already installed on the cluster by some other path (for example a hand-rolled Ascend Operator), disable the corresponding switch here so the NPU Operator does not fight it.
+:::
+
+:::tip
+Ascend Operator, NodeD, ClusterD, Resilience Controller, MindIO TFT, and MindIO ACP are not deployed by default. Please deploy them only when there is a clear need for them.
+:::
+
+| Component | Default | Description |
+|------------|---------|-------------|
+| Driver | Enabled | Whether to install driver and firmware. |
+| Driver Version | 25.5.0 | Driver and firmware HDK version. Pick a version that you have a matching pre-staged image for (see [Step 1](#sync-driver-images)). Currently supported: `25.5.0` (default), `25.3.RC1`. Hidden when __Driver__ is disabled. |
+| Auto Driver Upgrade Reboot | Disabled | When a driver upgrade needs a node reboot, reboot automatically (cordon + drain first). Off (recommended for production) emits a `RebootRequired` Event and waits for an administrator to approve via the node annotation `npu.openfuyao.com/approve-reboot=true`. See [Driver upgrade and self-healing](./upgrade.mdx). Hidden when __Driver__ is disabled. |
+| Auto Chip-Failure Recovery Reboot | Disabled | When the driver health-watch detects a wedged chip at runtime, reboot the node automatically to recover it (cordon + drain first). Off (default) emits a `RebootRequired` Event and waits for the same admin annotation. Turn this __On__ only for inference clusters whose clients can retry requests; keep it __Off__ for long-running training jobs. Hidden when __Driver__ is disabled. |
+| Ascend Device Plugin | Enabled | Whether to install Ascend Device Plugin. |
+| Ascend Docker Runtime | Enabled | Whether to install the container-runtime CDI generator. In v1.2.3 this component runs `npu-container-toolkit generate-cdi --watch` as a sidecar that emits the CDI spec for the device plugin to reference — workloads no longer need `runtimeClassName: ascend`. |
+| NPU Exporter | Enabled | Whether to install NPU Exporter. |
+| Ascend Operator | Disabled | Whether to install Ascend Operator. |
+| NodeD | Disabled | Whether to install NodeD. |
+| ClusterD | Disabled | Whether to install ClusterD. Requires the Volcano cluster plugin to be installed first. |
+| Resilience Controller | Disabled | Whether to install Resilience Controller. |
+| MindIO TFT | Disabled | Whether to install MindIO TFT. |
+| MindIO ACP | Disabled | Whether to install MindIO ACP. |
 
 #### Verification
 
-1. First, you can see the status of "Installed" in the `Alauda Build of NPU Operator` Cluster plugin page.
-2. Wait for the npu-driver pod to become running. Offline installation takes about 10 minutes, while online installation is much faster.
-    ```bash
-    kubectl -n kube-system get pod -w | grep npu-driver
-    ```
-3. Reboot all the NPU nodes.
+1. Confirm the `NPUOperatorCtl` instance is reconciling cleanly:
 
-4. Run the following command on the npu node.
     ```bash
-    npu-smi info
-    ```
-    Make sure the display is working correctly.
-
-5. Run the following command on the master node.
-    ```bash
-    kubectl get npuclusterpolicy cluster
-    ```
-    Make sure the status of the `npuclusterpolicy` is Ready.
-
-6. Check whether there are allocatable NPU resources on the NPU node in the control node of the business cluster. Run the following command:
-    ```bash
-    kubectl get node  ${nodeName} -o=jsonpath='{.status.allocatable}'
-    # Example, the output contains: "huawei.com/Ascend310P":"1" (the specific value depends on the number of NPU cards)
+    kubectl -n npu-operator get npuoperatorctl
     ```
 
-7. Run validation workload.
-    Create spec file:
+    The `Deployed` condition should be `True` with reason `UpgradeSuccessful`. (Replace `npu-operator` below and in subsequent commands with the namespace you chose at install time if it differs.)
+
+2. Wait for the `npu-driver` pod to become `Running`. First-time install takes a few minutes for the driver image to pull and the modules to be inserted into the host kernel:
+
     ```bash
-    key="huawei.com/Ascend310P" # For 310P
-    cat <<EOF > deploy-npu.yaml
-    apiVersion: apps/v1
-    kind: Deployment
+    kubectl -n npu-operator get pod -w | grep npu-driver
+    ```
+
+3. Check that the NPU node is now reporting allocatable Ascend devices:
+
+    ```bash
+    kubectl get node ${nodeName} -o jsonpath='{.status.allocatable}'
+    # Example output includes:
+    #   "huawei.com/Ascend910":"8"   (910B nodes; specific value depends on card count)
+    #   "huawei.com/Ascend310P":"1"  (310P nodes)
+    ```
+
+4. (Optional) Run `npu-smi info` on the host. The operator does not symlink `npu-smi` into the host `PATH` (`/usr` is read-only on KubeOS), so call the binary directly with its libraries loaded:
+
+    ```bash
+    LD_LIBRARY_PATH=/var/lib/Ascend/driver/lib64/driver:/var/lib/Ascend/driver/lib64/common \
+      /var/lib/Ascend/driver/tools/npu-smi info
+    ```
+
+    Each card should report `Health: OK` and a non-zero `Bus-Id`.
+
+5. Validate end-to-end with a sample NPU workload. v1.2.3 no longer requires `runtimeClassName: ascend` — the resource request alone triggers CDI device injection. In air-gapped or image-whitelist-enforced clusters, mirror the sample image to your cluster registry first, or replace it with an equivalent internal test image that includes `npu-smi`.
+
+    ```bash
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    kind: Pod
     metadata:
-      name: ascend-pytorch
+      name: npu-smoke
     spec:
-      replicas: 1
-      selector:
-        matchLabels:
-          service.cpaas.io/name: deployment-ascend-pytorch
-      strategy:
-        rollingUpdate:
-          maxSurge: 1
-          maxUnavailable: 1
-        type: RollingUpdate
-      template:
-        metadata:
-          labels:
-            service.cpaas.io/name: deployment-ascend-pytorch
-        spec:
-          affinity: {}
-          containers:
-            - args:
-                - |
-                  sleep infinity
-              command:
-                - /bin/bash
-                - -c
-              image: ascendai/pytorch:ubuntu-python3.8-cann8.0.rc1.beta1-pytorch2.1.0
-              imagePullPolicy: Always
-              name: ascend-pytorch
-              resources:
-                limits:
-                  cpu: 500m
-                  $key: "1"
-                  memory: 2Gi
-                requests:
-                  cpu: 500m
-                  memory: 2Gi
-          runtimeClassName: ascend
+      restartPolicy: Never
+      containers:
+      - name: probe
+        image: ascendai/pytorch:ubuntu-python3.8-cann8.0.rc1.beta1-pytorch2.1.0
+        command: ["bash", "-c"]
+        args:
+          - |
+            ls /dev/davinci*
+            npu-smi info
+            sleep 3600
+        resources:
+          limits:
+            huawei.com/Ascend910: 1   # Change to huawei.com/Ascend310P on a 310P node
     EOF
-    ```
-    Apply spec:
 
-    ```bash
-    kubectl apply -f deploy-npu.yaml
+    kubectl logs npu-smoke
     ```
 
-    ```bash
-    kubectl exec -it  deploy/ascend-pytorch -- bash
-    ```
+    The pod should reach `Running`. `ls /dev/davinci*` should show `/dev/davinci_manager` plus one per-card device node (e.g. `/dev/davinci0`), and `npu-smi info` should print the card's status. Both confirm that CDI injected the device into the container.
 
-    Then run the following command in the container:
-    ```bash
-    npu-smi info
-    ```
-    Make sure the display is working correctly.
+### Step 6: Verify monitoring
 
-### Installing Monitor
+If the NPU Exporter component was deployed when installing the Alauda Build of NPU Operator, the operator automatically deploys a `ServiceMonitor` named `npu-exporter-servicemonitor` in the operator namespace, wired up to the `npu-exporter` Service. No manual `ServiceMonitor` creation is required. You can verify it with:
 
-If the NPU exporter component was deployed when installing the Alauda Build of NPU Operator, perform the following steps to create a monitoring panel.
+```bash
+kubectl -n npu-operator get servicemonitor npu-exporter-servicemonitor
+```
 
-1. Execute commands on the **control node** of the cluster.
+To get a Grafana dashboard, import the JSON file by following [Import Dashboard](../../../observability/monitor/functions/manage_dashboard.html#import-dashboard).
 
-    ```bash
-    cat << EOF | kubectl apply -f -
-    apiVersion: monitoring.coreos.com/v1
-    kind: ServiceMonitor
-    metadata:
-      labels:
-        prometheus: kube-prometheus
-        serviceMonitorSelector: prometheus
-      name: npu-exporter-ai
-      namespace: monitoring
-    spec:
-      endpoints:
-      - interval: 10s
-        path: /metrics
-        port: http
-        targetPort: 8082
-      namespaceSelector:
-        matchNames:
-        - npu-exporter
-      selector:
-        matchLabels:
-          app: npu-exporter-svc
-    EOF
-    ```
-2. You can import a Grafana dashboard JSON file by following [Import Dashboard](../../../observability/monitor/functions/manage_dashboard.html#import-dashboard), which converts it into a monitoring dashboard for display.
-    The JSON file is available in [ascend-npu-dashboard](https://github.com/Cz200OK/ascend-npu-dashboard/blob/main/Dashboards/ascend-npu-exporter-Dashboard_20240301.json).
+The JSON file is available in [ascend-npu-dashboard](https://github.com/Cz200OK/ascend-npu-dashboard/blob/main/Dashboards/ascend-npu-exporter-Dashboard_20240301.json).
 
-    :::note
-    Tags in the Grafana dashboard JSON file cannot contain Chinese characters and need to be manually deleted.
-    For examples:
-    ```json
-    {
-      "tags": [
-        "ascend",
-        "昇腾"
-      ]
-    }
-    ```
+:::note
+Tags in the Grafana dashboard JSON file cannot contain non-ASCII characters and need to be edited out. For example:
 
-    After modification:
-    ```json
-    {
-      "tags": [
-        "ascend"
-      ]
-    }
-    ```
-    :::
+```json
+{
+  "tags": [
+    "ascend",
+    "昇腾"
+  ]
+}
+```
+
+After modification:
+
+```json
+{
+  "tags": [
+    "ascend"
+  ]
+}
+```
+:::
+
+## What's next
+
+- [Driver upgrade and self-healing](./upgrade.mdx) — how to roll the driver version forward and how the chip self-healing path works.
 
 ## FAQ
 
+### Where is `npu-smi` installed on the host? \{#where-is-npu-smi-installed-on-the-host}
+
+In v1.2.3 the driver pod stages the Huawei tools tree to `/var/lib/Ascend/driver/`, so the binary is at `/var/lib/Ascend/driver/tools/npu-smi`. No host `PATH` symlink is created (KubeOS keeps `/usr` read-only). Call it with the matching `LD_LIBRARY_PATH`:
+
+```bash
+LD_LIBRARY_PATH=/var/lib/Ascend/driver/lib64/driver:/var/lib/Ascend/driver/lib64/common \
+  /var/lib/Ascend/driver/tools/npu-smi info
+```
+
+If you prefer a `PATH`-resolvable command, write a small wrapper into a writable location (e.g. `/opt/bin/npu-smi`) that exports `LD_LIBRARY_PATH` and execs the real binary.
+
+### Do I still need `runtimeClassName: ascend` on workload pods?
+
+No. v1.2.3 uses CDI for device injection: requesting `huawei.com/Ascend910` (or `Ascend310P`) is enough. Existing manifests that still set `runtimeClassName: ascend` continue to work — the RuntimeClass is kept for backwards compatibility — but no new manifests need it.
+
 ### What should I pay attention to when uninstalling Alauda Build of NPU Operator?
 
-Even after Alauda Build of NPU Operator is uninstalled, the driver may still exist on the host machine.
-On the NPU node, execute the following command to uninstall the driver:
+Uninstalling the operator removes the driver DaemonSet, but the driver modules already loaded into the host kernel stay loaded — `rmmod` would risk leaving the chip in an unrecoverable state. To fully remove the driver from a host, reboot the node after the operator is uninstalled; the modules will not auto-reload because the DaemonSet is gone.
+
+Files staged to the host can be cleaned up manually if needed:
+
 ```bash
-/usr/local/Ascend/driver/script/uninstall.sh
+rm -rf /var/lib/Ascend /var/lib/ascend /home/bios/driver /etc/ascend_install.info /run/ascend
 ```
+
+Run these only after the operator and its driver pod have been removed, and after the node has been rebooted (or before, if you intend to reboot anyway).

--- a/docs/en/hardware_accelerator/npu/npu_operator/intro.mdx
+++ b/docs/en/hardware_accelerator/npu/npu_operator/intro.mdx
@@ -4,6 +4,22 @@ weight: 10
 
 # Introduction
 
-Kubernetes provides access to special hardware resources (such as Ascend NPUs) through Device Plugins. However, multiple software components (such as drivers, container runtimes, or other libraries) are required to configure and manage a node having these hardware resources. Installation of these components is complex, difficult, and error-prone. The NPU operator uses the Operator Framework in Kubernetes to automatically manage all software components required for configuring Ascend devices. These components include the Ascend driver and firmware (which support the entire running process of clusters), as well as the MindCluster device plug-in (which supports cluster operations such as job scheduling, O&M monitoring, and fault recovery). By installing corresponding components, you can manage NPU resources, optimize workload scheduling, and containerize training and inference tasks, so that AI jobs can be deployed and run on NPU devices as containers.
+Kubernetes exposes specialized hardware such as Ascend NPUs through the Device Plugin interface, but configuring an NPU node end-to-end is genuinely complex: the driver and firmware have to match the kernel, the container runtime has to know how to inject devices into workload containers, and a device plugin has to report the chips to the scheduler.
 
-For more details, refer to [NPU Operator](https://gitcode.com/openFuyao/docs/blob/master/docs/zh/user_guide/npu_operator.md).
+The __Alauda Build of NPU Operator__ folds all of that into a single operator that reconciles the full software stack — Ascend driver and firmware, container runtime configuration, MindCluster device plugin, and the optional NPU exporter — from a single `NPUOperatorCtl` custom resource. With it installed, AI training and inference workloads can request `huawei.com/Ascend910` (or `Ascend310P`) the same way they would any other Kubernetes resource.
+
+## What's new in v1.2.3
+
+v1.2.3 is the first release built for the __KubeOS__ immutable OS, and is delivered as an OLM operator bundle rather than a cluster plugin. The key user-visible changes are:
+
+- __KubeOS / immutable-OS support__. NPU worker nodes are no longer restricted to traditional Linux distros. The operator handles KubeOS's read-only `/usr` and absent package-manager constraints transparently — there is no need to pre-install kernel headers, DKMS, or any host package.
+- __Pre-compiled driver image__. The driver, firmware, and runtime tooling are shipped as a container image keyed on `<HDK>-<chip>-<kernel>-<os>` and loaded into the host kernel from the running pod. The legacy `.run` package + DKMS pipeline is gone. See [Installation](./installation.mdx) for the image prerequisite.
+- __CDI device injection__. Workload pods no longer need `runtimeClassName: ascend`. Requesting `huawei.com/Ascend910` (or `Ascend310P`) is enough — the operator sets up the Container Device Interface so that containerd binds `/dev/davinciN` and the driver userspace libraries into the container automatically.
+- __Driver upgrade lifecycle__. Bumping `NPUOperatorCtl.spec.driver.version` now drives a per-node rolling upgrade: cordon → drain → node reboot → reload new driver → validate → uncordon. The reboot phase is required because Ascend chips cannot tolerate `rmmod` of a running driver. Auto-roll and manual-approval modes are both supported. See [Driver upgrade and self-healing](./upgrade.mdx).
+- __Chip self-healing__. A health-watch loop inside the driver pod probes each NPU every minute; if a chip enters a wedged state at runtime it writes a recovery marker so the node can be rebooted to recover. Opt-in via `spec.driver.recoveryPolicy.autoRecover`.
+- __MindCluster v7.3.0 stack__. Picks up the v7.3.0 train of `ascend-k8sdeviceplugin`, `ascend-operator`, `ascend-docker-runtime`, `noded`, `clusterd`, and `npu-exporter`. Default driver version bumps to `25.5.0`.
+- __Bug fix: NPU exporter ServiceMonitor__. The exporter is now scraped automatically by the platform's Prometheus — no manual `ServiceMonitor` needed.
+
+See [Release notes](./release_notes.mdx) for the full change list, and [Installation](./installation.mdx) to get started.
+
+For more details on the upstream project, refer to [openFuyao NPU Operator](https://gitcode.com/openFuyao/docs/blob/master/docs/zh/user_guide/npu_operator.md).

--- a/docs/en/hardware_accelerator/npu/npu_operator/release_notes.mdx
+++ b/docs/en/hardware_accelerator/npu/npu_operator/release_notes.mdx
@@ -1,0 +1,69 @@
+---
+weight: 30
+---
+
+# Release Notes
+
+## v1.2.3
+
+Based on the openFuyao [npu-operator 1.2.0](https://gitcode.com/openFuyao/npu-operator/tree/1.2.0) community release. v1.2.3 is the first release built for the __KubeOS__ immutable operating system and reworks how the driver is delivered, how devices reach workloads, and how the operator manages the driver lifecycle.
+
+### Breaking changes
+
+- __Delivery model changed from cluster plugin to operator.__ Earlier versions of __Alauda Build of NPU Operator__ shipped as a cluster plugin, installed from __Marketplace__ > __Cluster Plugins__. Starting with v1.2.3 the project is packaged as an OLM operator bundle and installed from __Marketplace__ > __OperatorHub__.
+
+    :::warning
+    In-place upgrade from v1.1.3 (or any earlier cluster-plugin release) is __not__ supported. To move to v1.2.3, uninstall the old cluster plugin first and then install the new operator from scratch:
+
+    1. Uninstall the existing __Alauda Build of NPU Operator__ cluster plugin from __Marketplace__ > __Cluster Plugins__.
+    2. If the driver is no longer needed on the host, run on each NPU node:
+        ```bash
+        /usr/local/Ascend/driver/script/uninstall.sh
+        ```
+    3. Install v1.2.3 from __Marketplace__ > __OperatorHub__ following the [Installation](./installation.mdx) page.
+    :::
+
+- __Driver is now delivered as a container image, not a `.run` package.__ The driver, firmware, and runtime tooling ship in `mlops/ascend-driver:<HDK>-<chip>-<kernel>-<os-stem>` and are loaded into the host kernel from the running pod. The legacy DKMS / kernel-headers / `make` host prerequisites listed in v1.1.x are no longer needed (and no longer used even if present). For air-gapped clusters, the matching driver image must be pre-staged to the cluster registry before installation — see [Step 1: Sync driver images](./installation.mdx#sync-driver-images).
+
+- __OS support model changed: kernel-keyed, not distro-keyed.__ v1.2.3 does __not__ restrict to specific distros. Any arm64 Linux running containerd is supported, as long as a driver image matching the node's kernel exists at [`docker.io/alaudadockerhub/ascend-driver`](https://hub.docker.com/r/alaudadockerhub/ascend-driver) — the driver image is shipped independently from the operator bundle and is built on demand. If your kernel isn't on the tag list yet, contact <Term name="company"/> Customer Support to have a new tag built and published. Smoke-tested in this release: 310P + 910B on KubeOS 6.6, 910B on openEuler 22.03 LTS SP3 bare-metal. The v1.1.x DKMS host-side flow is gone — the container-image model replaces it.
+
+- __Workloads no longer need `runtimeClassName: ascend`.__ Device injection in v1.2.3 is driven by the Container Device Interface (CDI). Requesting `huawei.com/Ascend910` (or `Ascend310P`) is enough — containerd binds `/dev/davinciN` and the driver userspace libraries into the container automatically. Existing pods that still set `runtimeClassName: ascend` continue to work; the legacy RuntimeClass is retained for backwards compatibility.
+
+### New features
+
+- __KubeOS / immutable-OS support.__ NPU nodes running KubeOS are now fully supported. The operator stages the driver tree under `/var/lib/Ascend` / `/var/lib/ascend` / `/home/bios/driver` (all on writable partitions on KubeOS), inserts kernel modules directly from the driver pod, and never writes to `/usr` or relies on a package manager.
+
+- __Driver upgrade lifecycle.__ Editing `NPUOperatorCtl.spec.driver.version` now triggers a per-node rolling upgrade. The operator walks each node through `upgrade-required → cordon-required → wait-for-jobs-required → pod-deletion-required → drain-required → node-reboot-required → pod-restart-required → validation-required → uncordon-required → upgrade-done`, with the rollout pace gated by:
+
+    - `spec.driver.upgradePolicy.autoUpgrade` — `true` for fully automatic rolling upgrades, `false` (default) to wait for a per-node `npu.openfuyao.com/approve-reboot=true` annotation before each reboot.
+    - `spec.driver.upgradePolicy.maxParallelUpgrades` and `maxUnavailable` — concurrency caps.
+    - `spec.driver.upgradePolicy.drainSpec`, `podDeletion`, `waitForCompletion` — drain and eviction policy fields, modelled on the upstream `k8s-operator-libs` schema.
+
+    The node reboot is always required because `rmmod` of a running Ascend driver leaves the chip in an unrecoverable state. The new __rebooter__ component performs the reboot using `sysrq b` (panic-reboot) to avoid VFIO/AER deadlocks on PCI-passthrough VMs. See [Driver upgrade and self-healing](./upgrade.mdx) for the full walk-through.
+
+- __Chip self-healing.__ A `health-watch` loop inside the driver pod runs `npu-smi info` every 60 seconds. After three consecutive failures (≈3 minutes) the loop detects a runtime chip-wedge condition, drops the driver-ready marker (causing the device plugin to report the chip as `Unhealthy`), and writes a recovery marker for the rebooter. With `spec.driver.recoveryPolicy.autoRecover: true` the rebooter automatically reboots the node to recover the chip; with `false` (default) it waits for the same approve-reboot annotation used for upgrades.
+
+- __CDI device injection.__ Replaces the v1.1.x `ascend-docker-hook` mechanism. The `Ascend Docker Runtime` form toggle now provisions `npu-container-toolkit generate-cdi --watch` as a sidecar that emits the CDI spec at `/var/run/cdi/ascend.com-npu.yaml`. The CDI kind is `huawei.com/ascend`; the pod annotation key the device plugin attaches is `cdi.k8s.io/ascend-device-plugin`.
+
+- __Validator DaemonSet.__ A new `npu-validator` DaemonSet runs alongside the driver. The upgrade state machine waits for both the driver pod and the validator pod to report `PodReady` before transitioning past `validation-required`, so a driver pod that self-reports ready but whose ready file isn't actually visible to other host consumers no longer fools the upgrade.
+
+- __Device-plugin drain-aware.__ The MindCluster device plugin now watches for the `npu.openfuyao.com/driver-upgrade-state` and `reboot-required` node labels, and reports every NPU on the node as `Unhealthy` while either is set. The scheduler therefore stops placing new NPU workloads on a node about to be torn down.
+
+- __Per-node `npu-smi` access on the host.__ The driver pod stages `npu-smi` to `/var/lib/Ascend/driver/tools/npu-smi`. The operator does not add it to the host `PATH` (KubeOS keeps `/usr` read-only); call it with the matching `LD_LIBRARY_PATH` or wrap it in a script under `/opt/bin/`. See the [Installation FAQ](./installation.mdx#where-is-npu-smi-installed-on-the-host).
+
+- __MindCluster / Ascend component stack upgraded to v7.3.0.__ Picks up the v7.3.0 train of `ascend-docker-runtime`, `ascend-operator`, `ascend-k8sdeviceplugin`, `noded`, `vc-controller-manager`, `vc-scheduler`, `clusterd`, and `npu-exporter`. The driver and firmware default HDK version is bumped to `25.5.0`. `25.3.RC1` is shipped as a co-supported alternative.
+
+### Bug fixes
+
+- Fixed `npu-exporter` `ServiceMonitor` not taking effect: it was created in the wrong namespace and missed Prometheus selector labels, so the platform's Prometheus never scraped the exporter. The operator now ships a `ServiceMonitor` in its own namespace with the correct `prometheus: kube-prometheus` label and `honorLabels: true`. No manual `ServiceMonitor` creation is required.
+
+- Fixed the operator never advancing the upgrade state machine past `validation-required` when only the driver-pod readinessProbe was used as the signal: a separate validator pod now confirms the driver-ready marker is visible to other host consumers.
+
+- Fixed `runtime-init.sh` fast-skipping in a half-installed state on nodes whose chip had wedged while the driver pod was running: the fast-skip predicate now includes a chip-health probe (`davinci_dev_num > 0` via PCI sysfs) so a wedged-but-loaded chip falls through to the recovery path.
+
+- (Community) Fixed installation / detection logic on nodes that do not carry NPU cards.
+- (Community) Fixed environment-variable indicators not being deduplicated.
+
+## v1.1.3
+
+Based on the openFuyao [npu-operator 1.1.1](https://gitcode.com/openFuyao/npu-operator/tree/1.1.1) community release. Backed by the MindCluster / Ascend v7.2.RC1 component stack and delivered as a cluster plugin.

--- a/docs/en/hardware_accelerator/npu/npu_operator/upgrade.mdx
+++ b/docs/en/hardware_accelerator/npu/npu_operator/upgrade.mdx
@@ -1,0 +1,183 @@
+---
+weight: 25
+---
+
+# Driver upgrade and self-healing
+
+Starting with v1.2.3 the NPU Operator manages the driver lifecycle on each NPU node end-to-end. This page covers the two state-driven flows it exposes:
+
+- __Driver upgrade__ — rolling out a new driver version cluster-wide.
+- __Chip self-healing__ — automatically recovering a node whose chip has wedged at runtime.
+
+Both flows go through the same node-reboot path. Ascend chips cannot tolerate `rmmod` of a running driver — attempting an in-place driver swap leaves the chip in an unrecoverable `dev_num=0` state. The operator therefore always loads new modules from a fresh boot rather than reloading them inside a running kernel.
+
+## Driver upgrade
+
+:::warning
+__Stop all NPU workloads before starting a driver upgrade.__ The upgrade reboots every NPU node in sequence and is __not__ designed to be transparent to running training jobs or inference services. Scale every NPU-requesting Deployment / StatefulSet / training job to zero, drain in-flight requests, and persist any model checkpoints __before__ patching `spec.driver.version`. Restore the workloads after the rollout finishes — see [Step 4](#step-4-verify) for how to detect that.
+:::
+
+The upgrade walks through four ordered steps: prepare the cluster, trigger the version bump, approve each node's reboot, and verify the new driver. Do not start triggering until Step 1 is done — that is the single most common cause of a stuck rollout.
+
+### Step 1: Prepare before triggering \{#step-1-prepare-before-triggering}
+
+Two things must be in place before you touch `spec.driver.version`. Both are __mandatory__; skipping either is how upgrades get stuck.
+
+#### 1.1 Pre-upgrade checklist
+
+1. **New driver image present in the cluster registry for every NPU node profile.** Reuse the `skopeo copy` step from [Step 1.1 of installation](./installation.mdx#sync-driver-images) for each `(chip, kernel, OS)` combination:
+
+    ```bash
+    # On a machine with internet access:
+    NEW_VERSION=25.5.0
+
+    for COMBO in 910b-6.6.0-145.0.4.135-oe2403sp3 310p-6.6.0-145.0.4.135-oe2403sp3; do
+      skopeo copy --all \
+        docker://docker.io/alaudadockerhub/ascend-driver:${NEW_VERSION}-$COMBO \
+        docker://<your-cluster-registry>/mlops/ascend-driver:${NEW_VERSION}-$COMBO
+    done
+    ```
+
+    If no tag in the source Docker Hub repo matches your node's kernel, contact <Term name="company"/> Customer Support — see the [installation note on missing tags](./installation.mdx#11-pull-driver-images-from-dockerhub).
+
+2. **`ImageWhiteList` updated** to include the new tag(s):
+
+    ```bash
+    kubectl edit imagewhitelist ascend-driver -n cpaas-system
+    # add each new tag under spec.repoList
+    ```
+
+#### 1.2 Stop NPU workloads \{#stop-npu-workloads}
+
+Scale every NPU-requesting Deployment / StatefulSet / training job to zero before continuing. Restore them once the rollout finishes — see [Step 4](#step-4-verify).
+
+```bash
+# Examples — scale every NPU-using workload to zero
+kubectl scale -n serving inferenceservice/my-model --replicas=0
+kubectl scale -n training statefulset/llama-trainer --replicas=0
+```
+
+### Step 2: Trigger the upgrade \{#step-2-trigger-the-upgrade}
+
+Edit your `NPUOperatorCtl` instance (created at the end of [Step 5.3 of installation](./installation.mdx#53-create-the-npuoperatorctl-instance)) and update __two fields in a single save__:
+
+- `spec.driver.version` — the new driver version (e.g. `25.5.0`).
+- `spec.driver.upgradePolicy.autoUpgrade` — keep the default `false` to approve each node reboot manually; set `true` to let the operator roll the whole cluster automatically. Automatic mode is recommended only for routine version bumps on bare-metal clusters.
+
+__Via the platform UI__ (recommended):
+
+1. __Administrator__ > __Marketplace__ > __OperatorHub__ > __Installed Operators__ > __Alauda Build of NPU Operator__.
+2. Open the __NPUOperatorCtl__ tab and click the instance (default name `npuoperatorctl-sample`).
+3. __Edit YAML__, change both fields, then __Save__.
+
+__Via `kubectl`__:
+
+```bash
+NEW_VERSION=25.5.0
+
+kubectl -n npu-operator patch npuoperatorctl npuoperatorctl-sample --type=merge \
+  -p "{\"spec\":{\"driver\":{\"version\":\"${NEW_VERSION}\",\"upgradePolicy\":{\"autoUpgrade\":false}}}}"
+```
+
+(Replace `npu-operator` with your install namespace and `npuoperatorctl-sample` with your instance name if either differs.)
+
+### Step 3: Approve each node's reboot \{#step-3-approve-reboots}
+
+Skip this step if you set `autoUpgrade: true` in Step 2 — the operator reboots each node automatically.
+
+In manual mode, the operator waits for an admin to annotate each NPU node with `npu.openfuyao.com/approve-reboot=true` before it will reboot that node. The annotation can be set __at any time__ — including before Step 2 — and is consumed by the operator once per reboot. The simplest pattern is to approve every NPU node up front in a single command:
+
+```bash
+kubectl get nodes -l openfuyao.com/npu.present -o name \
+  | xargs -I{} kubectl annotate {} npu.openfuyao.com/approve-reboot=true --overwrite
+```
+
+Or approve one node at a time, in any order:
+
+```bash
+kubectl annotate node ${nodeName} npu.openfuyao.com/approve-reboot=true
+```
+
+### Step 4: Verify the new driver is in place \{#step-4-verify}
+
+The rollout is finished when every node's `DRIVER-UPGRADE-STATE` value is empty. Check the node labels first:
+
+```bash
+kubectl get nodes -l openfuyao.com/npu.present \
+  -o custom-columns=NAME:.metadata.name,DRIVER-UPGRADE-STATE:.metadata.labels.npu\.openfuyao\.com/driver-upgrade-state
+```
+
+Then confirm each driver pod is running the new image:
+
+```bash
+kubectl get pod -n npu-operator -l app=npu-driver-daemonset \
+  -o jsonpath='{range .items[*]}{.spec.nodeName}{"\t"}{.spec.containers[0].image}{"\n"}{end}'
+```
+
+Finally, run `npu-smi` on each NPU node host (or enter the node through your platform's node-debug / SSH workflow) and confirm the host reports the new version:
+
+```bash
+LD_LIBRARY_PATH=/var/lib/Ascend/driver/lib64/driver:/var/lib/Ascend/driver/lib64/common \
+  /var/lib/Ascend/driver/tools/npu-smi info | head -2
+```
+
+You can now restore the NPU workloads you stopped in Step 1.2.
+
+## Chip self-healing
+
+:::caution
+__Experimental feature.__ Chip self-healing is shipped as a tech preview in v1.2.3 and disabled by default. Validate it in a staging environment before turning it on in production, and keep `autoRecover` set to `false` until you have signed off on the behaviour for your hardware profile.
+:::
+
+Some Ascend deployment scenarios — most notably 910B in VM with PCI passthrough — can occasionally leave the chip in a state where the kernel modules are loaded but the driver itself reports `dev_num=0` and refuses DCMI calls. From userspace this looks like a "healthy" host (all `/dev/davinciN` exist, modules loaded) but every `npu-smi info` returns an error. The only recovery is a node reboot.
+
+v1.2.3 detects this case automatically:
+
+- The driver pod runs a __health-watch loop__ that probes each NPU with `npu-smi info` every 60 seconds.
+- After three consecutive failures (≈3 minutes), the loop declares a runtime wedge: it drops the driver-ready marker (so the validator pod sees `NotReady` and the device plugin reports the chip as `Unhealthy` immediately) and writes a `recovery` marker for the rebooter.
+- A rebooter pod observes the marker on its next 30-second poll cycle.
+
+### Auto vs. manual recovery
+
+The behaviour at this point is controlled by `spec.driver.recoveryPolicy.autoRecover` (independent of `autoUpgrade`):
+
+| `autoRecover` | Behaviour after wedge detection |
+|---|---|
+| `false` (default) | The rebooter emits a `RebootRequired` Event (with `reason=recovery`) and waits for an administrator to annotate the node. |
+| `true` | The rebooter reboots the node after the uptime guard and cluster-wide lock are satisfied. |
+
+When auto-recovery is on the chip self-heals without operator intervention — typically 3 minutes of detection plus a few minutes of reboot. When it is off, the same approve-reboot annotation used for upgrades authorizes the recovery reboot.
+
+A typical recovery configuration:
+
+```yaml
+spec:
+  driver:
+    recoveryPolicy:
+      autoRecover: true   # rebooter reboots automatically on detected wedge
+```
+
+### Manual recovery walk-through
+
+If `autoRecover: false` and the health-watch loop has detected a wedge:
+
+1. Find the affected nodes and read the marker reason:
+
+    ```bash
+    kubectl get nodes -l npu.openfuyao.com/reboot-required=true
+    kubectl get events -A --field-selector reason=RebootRequired --sort-by=.lastTimestamp | tail
+    ```
+
+    For self-healing, the Event message contains `reason=recovery`. (Driver upgrades use `reason=upgrade`.)
+
+2. Approve the reboot when convenient:
+
+    ```bash
+    kubectl annotate node ${nodeName} npu.openfuyao.com/approve-reboot=true
+    ```
+
+3. The rebooter reboots the node; on fresh boot the driver pod loads the modules cleanly and the validator pod re-confirms readiness.
+
+### False-positive suppression
+
+If the chip recovers on its own before the rebooter acts, the health-watch loop clears its own marker so the node is not rebooted unnecessarily.


### PR DESCRIPTION
release-4.2 still shipped the v1.1.3 npu-operator docs (cluster-plugin delivery, .run package driver, runtimeClassName: ascend, no NPUOperatorCtl, no upgrade lifecycle). Replace the npu_operator/ folder contents with the v1.2.3-aligned versions from
feat/aml-dev-npu-operator-manual-upgrade-pod-pause @ 703c425c so the release-4.2 marketplace and the master PR ship matching customer docs.

Net changes:
  - installation.mdx — full rewrite for OLM bundle + CDI + NPUOperatorCtl instance flow; adds containerd-upgrade caution.
  - intro.mdx — v1.2.3 feature list + NPUOperatorCtl CR.
  - release_notes.mdx — new (release-4.2 base did not have one).
  - upgrade.mdx — new (driver upgrade + chip self-healing flows).
  - index.mdx — unchanged from master / release-4.2 (identical blob).