### PR TITLE
docs: advise dedicated disk for etcd local backup storage

### DIFF
--- a/docs/en/configure/backup/etcd.mdx
+++ b/docs/en/configure/backup/etcd.mdx
@@ -22,7 +22,7 @@ After installation, an EtcdBackupConfiguration resource is automatically created
 ## How it works
 
 - etcd backup is provided by **<Term name="product" /> Cluster Enhancer**.
-- Supports both local storage and S3-compatible object storage. By default, backups are stored locally in `/cpaas`. Configuring S3 storage creates an additional copy in the S3 bucket; local backups continue to be generated.
+- Supports both local storage and S3-compatible object storage. Local backups are written to a directory on each control plane node — `/cpaas/backup` by default. Plan this directory on a dedicated disk with room to grow; keeping backups on the root filesystem can cause disk pressure as they accumulate. Configuring S3 storage creates an additional copy in the S3 bucket; local backups continue to be generated.
 - For clusters running on Immutable OS, S3 storage is **required** (local storage is not supported)
 
 ## Configuration Reference
@@ -34,10 +34,16 @@ You can configure the `EtcdBackupConfiguration` resource to customize backup sch
 - **`schedule`**: Defines the backup frequency using standard cron syntax.
   - Example: `0 0 * * *` (Run backup daily at midnight).
 - **`localStorage`**: Configures local backup storage.
-  - **`path`**: The directory on the host where backups are stored. Default is `/cpaas`.
+  - **`path`**: The directory on each control plane node where backups are stored. Default is `/cpaas/backup`. Set this to a directory backed by a dedicated, expandable disk; see the storage note below.
   - **`ttl`**: The retention period for backup files in seconds. Backups older than this duration will be automatically deleted.
     - Example: `7776000` (approximately 90 days).
 - **`paused`**: Set to `true` to temporarily suspend automatic backups without deleting the configuration.
+
+:::warning
+Plan dedicated storage for local backups before enabling etcd backup. Local backups accumulate on the control plane nodes and are kept until their `ttl` expires, so the directory must sit on a disk that is sized for your retention policy and can be expanded later — not on the root filesystem, where growing backups can cause disk pressure and node instability.
+
+The default path `/cpaas/backup` is only suitable when `/cpaas` is mounted on a separate, adequately sized disk on every control plane node. Where `/cpaas` is part of the root filesystem, set `path` to a directory backed by a dedicated disk that you have provisioned, or mount `/cpaas` on a dedicated disk before using the default.
+:::
 
 Example configuration:
 
@@ -50,7 +56,7 @@ spec:
   schedule: "0 0 * * *"       # Run daily at 00:00
   paused: false               # Enable backups
   localStorage:
-    path: /cpaas-backup       # Custom backup path
+    path: /mnt/etcd-backup    # A directory on a dedicated, mounted backup disk
     ttl: "7776000"            # Retain for 90 days
   # ... other fields
 ```


### PR DESCRIPTION
## What changed

Add a storage-planning warning to the etcd backup page (`configure/backup/etcd.mdx`) and correct the default `localStorage.path` from `/cpaas` to `/cpaas/backup`. The page no longer presents `/cpaas` as a recommended default — it tells users to plan a dedicated, expandable disk and explains the disk-pressure risk of keeping backups on the root filesystem.

## Why

Local etcd backups accumulate on control plane nodes until their `ttl` expires. The default path lives under `/cpaas`, which on many deployments is part of the root filesystem; growing backups then cause disk pressure and node instability. The previous wording read as recommending `/cpaas`. The stated default `/cpaas` was also inaccurate — the auto-created `EtcdBackupConfiguration` sets `/cpaas/backup`.

## Where to backport

- **release-4.3 / release-4.2** — same page; advisory backport (separate PRs, opened after this merges).
- **release-4.1** — the page was a stub; a separate PR completes it to parity and adds the same advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local backup directory configuration details
  * Added recommendations for using dedicated backup storage to prevent disk pressure
  * Expanded backup configuration reference documentation
  * Added storage planning guidance and warnings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->