### PR TITLE
docs(tracing): fix Distributed Tracing install link → installing index [release-4.2]

### DIFF
--- a/docs/en/observability/tracing/installation.mdx
+++ b/docs/en/observability/tracing/installation.mdx
@@ -8,7 +8,7 @@ weight: 15
 
 The Distributed Tracing documentation in this section is deprecated and will be removed in ACP 4.4. ACP 4.3 is the last version that includes this documentation.
 
-Please use <ExternalSiteLink name="distributed-tracing" href="/installing/installing-distributed-tracing.html" children="Installing Alauda Distributed Tracing" /> or <ExternalSiteLink name="distributed-tracing" href="/migrating/migrating-from-acp-tracing.html" children="Migrating from Alauda Container Platform Tracing" /> for all new deployments and migrations.
+Please use <ExternalSiteLink name="distributed-tracing" href="/installing/index.html" children="Installing Alauda Distributed Tracing" /> or <ExternalSiteLink name="distributed-tracing" href="/migrating/migrating-from-acp-tracing.html" children="Migrating from Alauda Container Platform Tracing" /> for all new deployments and migrations.
 
 :::
 


### PR DESCRIPTION
## Why

`docs/en/observability/tracing/installation.mdx` links to the Alauda Distributed Tracing installing page at `/installing/installing-distributed-tracing.html`. That page was split per storage backend (Elasticsearch / OpenSearch) in the distributed-tracing docs, so the old URL no longer resolves.

## What

Point the link to the installing section index `/installing/index.html`, which lists the available backend-specific install guides.

> Note: this tracing section is already marked deprecated (to be removed in ACP 4.4); this only fixes the dangling outbound link.

Sibling PRs target `master`, `release-4.1`, `release-4.2`, `release-4.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
