### PR TITLE
docs(npu-operator): retarget docs at v1.2.4 + add pre-installed-drive…

### DIFF
--- a/docs/en/hardware_accelerator/npu/npu_operator/installation.mdx
+++ b/docs/en/hardware_accelerator/npu/npu_operator/installation.mdx
@@ -23,6 +23,10 @@ If you plan to enable __MindIO TFT__ or __MindIO ACP__, separately stage the mat
 
 ### Step 1: Sync driver images and configure ImageWhiteList \{#sync-driver-images}
 
+:::tip
+__Skip this entire step__ if your NPU nodes already have a Huawei driver installed out-of-band (typically via the `.run` package, at `/usr/local/Ascend/driver` or `/var/lib/Ascend/driver`). In that case, disable __Driver__ in [Step 5.3](#53-create-the-npuoperatorctl-instance) — the operator will configure CDI / device-plugin / runtime against the host's existing driver and never pull a driver image.
+:::
+
 :::warning
 __This is the most common cause of a failed install — do it first.__ The driver image is pulled at runtime by the driver DaemonSet based on each node's kernel label, and lives at the `mlops/ascend-driver` path — not bundled with the operator. If the matching tag isn't in your cluster registry, or isn't listed in an `ImageWhiteList`, the DaemonSet stays in `ImagePullBackOff` and the operator never reaches `Ready`. __If no tag matches your kernel at the source Docker Hub repository, contact <Term name="company"/> Customer Support__ to have one built — see [§1.1](#11-pull-driver-images-from-dockerhub).
 :::
@@ -183,12 +187,12 @@ Ascend Operator, NodeD, ClusterD, Resilience Controller, MindIO TFT, and MindIO 
 
 | Component | Default | Description |
 |------------|---------|-------------|
-| Driver | Enabled | Whether to install driver and firmware. |
+| Driver | Enabled | Whether the operator manages the Ascend driver. Disable on nodes that already have a Huawei `.run` driver installed (at `/usr/local/Ascend/driver` or `/var/lib/Ascend/driver`) — the operator then skips driver staging and upgrades and reuses the host's existing tree for CDI / device-plugin / runtime. |
 | Driver Version | 25.5.0 | Driver and firmware HDK version. Pick a version that you have a matching pre-staged image for (see [Step 1](#sync-driver-images)). Currently supported: `25.5.0` (default), `25.3.RC1`. Hidden when __Driver__ is disabled. |
 | Auto Driver Upgrade Reboot | Disabled | When a driver upgrade needs a node reboot, reboot automatically (cordon + drain first). Off (recommended for production) emits a `RebootRequired` Event and waits for an administrator to approve via the node annotation `npu.openfuyao.com/approve-reboot=true`. See [Driver upgrade and self-healing](./upgrade.mdx). Hidden when __Driver__ is disabled. |
 | Auto Chip-Failure Recovery Reboot | Disabled | When the driver health-watch detects a wedged chip at runtime, reboot the node automatically to recover it (cordon + drain first). Off (default) emits a `RebootRequired` Event and waits for the same admin annotation. Turn this __On__ only for inference clusters whose clients can retry requests; keep it __Off__ for long-running training jobs. Hidden when __Driver__ is disabled. |
 | Ascend Device Plugin | Enabled | Whether to install Ascend Device Plugin. |
-| Ascend Docker Runtime | Enabled | Whether to install the container-runtime CDI generator. In v1.2.3 this component runs `npu-container-toolkit generate-cdi --watch` as a sidecar that emits the CDI spec for the device plugin to reference — workloads no longer need `runtimeClassName: ascend`. |
+| Ascend Docker Runtime | Enabled | Whether to install the container-runtime CDI generator. In v1.2.4 this component runs `npu-container-toolkit generate-cdi --watch` as a sidecar that emits the CDI spec for the device plugin to reference — workloads no longer need `runtimeClassName: ascend`. |
 | NPU Exporter | Enabled | Whether to install NPU Exporter. |
 | Ascend Operator | Disabled | Whether to install Ascend Operator. |
 | NodeD | Disabled | Whether to install NodeD. |
@@ -231,7 +235,7 @@ Ascend Operator, NodeD, ClusterD, Resilience Controller, MindIO TFT, and MindIO 
 
     Each card should report `Health: OK` and a non-zero `Bus-Id`.
 
-5. Validate end-to-end with a sample NPU workload. v1.2.3 no longer requires `runtimeClassName: ascend` — the resource request alone triggers CDI device injection. In air-gapped or image-whitelist-enforced clusters, mirror the sample image to your cluster registry first, or replace it with an equivalent internal test image that includes `npu-smi`.
+5. Validate end-to-end with a sample NPU workload. v1.2.4 no longer requires `runtimeClassName: ascend` — the resource request alone triggers CDI device injection. In air-gapped or image-whitelist-enforced clusters, mirror the sample image to your cluster registry first, or replace it with an equivalent internal test image that includes `npu-smi`.
 
     ```bash
     cat <<EOF | kubectl apply -f -
@@ -303,7 +307,7 @@ After modification:
 
 ### Where is `npu-smi` installed on the host? \{#where-is-npu-smi-installed-on-the-host}
 
-In v1.2.3 the driver pod stages the Huawei tools tree to `/var/lib/Ascend/driver/`, so the binary is at `/var/lib/Ascend/driver/tools/npu-smi`. No host `PATH` symlink is created (KubeOS keeps `/usr` read-only). Call it with the matching `LD_LIBRARY_PATH`:
+In v1.2.4 the driver pod stages the Huawei tools tree to `/var/lib/Ascend/driver/`, so the binary is at `/var/lib/Ascend/driver/tools/npu-smi`. No host `PATH` symlink is created (KubeOS keeps `/usr` read-only). Call it with the matching `LD_LIBRARY_PATH`:
 
 ```bash
 LD_LIBRARY_PATH=/var/lib/Ascend/driver/lib64/driver:/var/lib/Ascend/driver/lib64/common \
@@ -314,7 +318,7 @@ If you prefer a `PATH`-resolvable command, write a small wrapper into a writable
 
 ### Do I still need `runtimeClassName: ascend` on workload pods?
 
-No. v1.2.3 uses CDI for device injection: requesting `huawei.com/Ascend910` (or `Ascend310P`) is enough. Existing manifests that still set `runtimeClassName: ascend` continue to work — the RuntimeClass is kept for backwards compatibility — but no new manifests need it.
+No. v1.2.4 uses CDI for device injection: requesting `huawei.com/Ascend910` (or `Ascend310P`) is enough. Existing manifests that still set `runtimeClassName: ascend` continue to work — the RuntimeClass is kept for backwards compatibility — but no new manifests need it.
 
 ### What should I pay attention to when uninstalling Alauda Build of NPU Operator?
 

--- a/docs/en/hardware_accelerator/npu/npu_operator/intro.mdx
+++ b/docs/en/hardware_accelerator/npu/npu_operator/intro.mdx
@@ -8,12 +8,13 @@ Kubernetes exposes specialized hardware such as Ascend NPUs through the Device P
 
 The __Alauda Build of NPU Operator__ folds all of that into a single operator that reconciles the full software stack — Ascend driver and firmware, container runtime configuration, MindCluster device plugin, and the optional NPU exporter — from a single `NPUOperatorCtl` custom resource. With it installed, AI training and inference workloads can request `huawei.com/Ascend910` (or `Ascend310P`) the same way they would any other Kubernetes resource.
 
-## What's new in v1.2.3
+## What's new in v1.2.4
 
-v1.2.3 is the first release built for the __KubeOS__ immutable OS, and is delivered as an OLM operator bundle rather than a cluster plugin. The key user-visible changes are:
+v1.2.4 is the first release built for the __KubeOS__ immutable OS, and is delivered as an OLM operator bundle rather than a cluster plugin. The key user-visible changes are:
 
 - __KubeOS / immutable-OS support__. NPU worker nodes are no longer restricted to traditional Linux distros. The operator handles KubeOS's read-only `/usr` and absent package-manager constraints transparently — there is no need to pre-install kernel headers, DKMS, or any host package.
 - __Pre-compiled driver image__. The driver, firmware, and runtime tooling are shipped as a container image keyed on `<HDK>-<chip>-<kernel>-<os>` and loaded into the host kernel from the running pod. The legacy `.run` package + DKMS pipeline is gone. See [Installation](./installation.mdx) for the image prerequisite.
+- __Pre-installed-driver passthrough__. For hosts that already have a Huawei `.run` driver installed out-of-band (e.g. bare-metal clusters under independent driver lifecycle management), set `spec.driver.enabled=false`: the operator skips driver staging and upgrades entirely and configures CDI / device-plugin / runtime against the host's existing `/var/lib/Ascend/driver` or `/usr/local/Ascend/driver` tree.
 - __CDI device injection__. Workload pods no longer need `runtimeClassName: ascend`. Requesting `huawei.com/Ascend910` (or `Ascend310P`) is enough — the operator sets up the Container Device Interface so that containerd binds `/dev/davinciN` and the driver userspace libraries into the container automatically.
 - __Driver upgrade lifecycle__. Bumping `NPUOperatorCtl.spec.driver.version` now drives a per-node rolling upgrade: cordon → drain → node reboot → reload new driver → validate → uncordon. The reboot phase is required because Ascend chips cannot tolerate `rmmod` of a running driver. Auto-roll and manual-approval modes are both supported. See [Driver upgrade and self-healing](./upgrade.mdx).
 - __Chip self-healing__. A health-watch loop inside the driver pod probes each NPU every minute; if a chip enters a wedged state at runtime it writes a recovery marker so the node can be rebooted to recover. Opt-in via `spec.driver.recoveryPolicy.autoRecover`.

--- a/docs/en/hardware_accelerator/npu/npu_operator/release_notes.mdx
+++ b/docs/en/hardware_accelerator/npu/npu_operator/release_notes.mdx
@@ -4,34 +4,36 @@ weight: 30
 
 # Release Notes
 
-## v1.2.3
+## v1.2.4
 
-Based on the openFuyao [npu-operator 1.2.0](https://gitcode.com/openFuyao/npu-operator/tree/1.2.0) community release. v1.2.3 is the first release built for the __KubeOS__ immutable operating system and reworks how the driver is delivered, how devices reach workloads, and how the operator manages the driver lifecycle.
+Based on the openFuyao [npu-operator 1.2.0](https://gitcode.com/openFuyao/npu-operator/tree/1.2.0) community release. v1.2.4 is the first release built for the __KubeOS__ immutable operating system and reworks how the driver is delivered, how devices reach workloads, and how the operator manages the driver lifecycle.
 
 ### Breaking changes
 
-- __Delivery model changed from cluster plugin to operator.__ Earlier versions of __Alauda Build of NPU Operator__ shipped as a cluster plugin, installed from __Marketplace__ > __Cluster Plugins__. Starting with v1.2.3 the project is packaged as an OLM operator bundle and installed from __Marketplace__ > __OperatorHub__.
+- __Delivery model changed from cluster plugin to operator.__ Earlier versions of __Alauda Build of NPU Operator__ shipped as a cluster plugin, installed from __Marketplace__ > __Cluster Plugins__. Starting with v1.2.4 the project is packaged as an OLM operator bundle and installed from __Marketplace__ > __OperatorHub__.
 
     :::warning
-    In-place upgrade from v1.1.3 (or any earlier cluster-plugin release) is __not__ supported. To move to v1.2.3, uninstall the old cluster plugin first and then install the new operator from scratch:
+    In-place upgrade from v1.1.3 (or any earlier cluster-plugin release) is __not__ supported. To move to v1.2.4, uninstall the old cluster plugin first and then install the new operator from scratch:
 
     1. Uninstall the existing __Alauda Build of NPU Operator__ cluster plugin from __Marketplace__ > __Cluster Plugins__.
     2. If the driver is no longer needed on the host, run on each NPU node:
         ```bash
         /usr/local/Ascend/driver/script/uninstall.sh
         ```
-    3. Install v1.2.3 from __Marketplace__ > __OperatorHub__ following the [Installation](./installation.mdx) page.
+    3. Install v1.2.4 from __Marketplace__ > __OperatorHub__ following the [Installation](./installation.mdx) page.
     :::
 
-- __Driver is now delivered as a container image, not a `.run` package.__ The driver, firmware, and runtime tooling ship in `mlops/ascend-driver:<HDK>-<chip>-<kernel>-<os-stem>` and are loaded into the host kernel from the running pod. The legacy DKMS / kernel-headers / `make` host prerequisites listed in v1.1.x are no longer needed (and no longer used even if present). For air-gapped clusters, the matching driver image must be pre-staged to the cluster registry before installation — see [Step 1: Sync driver images](./installation.mdx#sync-driver-images).
+- __Driver is now delivered as a container image, not a `.run` package.__ By default the driver, firmware, and runtime tooling ship in `mlops/ascend-driver:<HDK>-<chip>-<kernel>-<os-stem>` and are loaded into the host kernel from the running pod. The legacy DKMS / kernel-headers / `make` host prerequisites listed in v1.1.x are no longer needed (and no longer used even if present). For air-gapped clusters, the matching driver image must be pre-staged to the cluster registry before installation — see [Step 1: Sync driver images](./installation.mdx#sync-driver-images). Clusters whose nodes already carry a host-installed `.run` driver can opt out by setting `spec.driver.enabled=false` (see _New features_ below).
 
-- __OS support model changed: kernel-keyed, not distro-keyed.__ v1.2.3 does __not__ restrict to specific distros. Any arm64 Linux running containerd is supported, as long as a driver image matching the node's kernel exists at [`docker.io/alaudadockerhub/ascend-driver`](https://hub.docker.com/r/alaudadockerhub/ascend-driver) — the driver image is shipped independently from the operator bundle and is built on demand. If your kernel isn't on the tag list yet, contact <Term name="company"/> Customer Support to have a new tag built and published. Smoke-tested in this release: 310P + 910B on KubeOS 6.6, 910B on openEuler 22.03 LTS SP3 bare-metal. The v1.1.x DKMS host-side flow is gone — the container-image model replaces it.
+- __OS support model changed: kernel-keyed, not distro-keyed.__ v1.2.4 does __not__ restrict to specific distros. Any arm64 Linux running containerd is supported, as long as a driver image matching the node's kernel exists at [`docker.io/alaudadockerhub/ascend-driver`](https://hub.docker.com/r/alaudadockerhub/ascend-driver) — the driver image is shipped independently from the operator bundle and is built on demand. If your kernel isn't on the tag list yet, contact <Term name="company"/> Customer Support to have a new tag built and published. Smoke-tested in this release: 310P + 910B on KubeOS 6.6, 910B on openEuler 22.03 LTS SP3 bare-metal. The v1.1.x DKMS host-side flow is gone — the container-image model replaces it.
 
-- __Workloads no longer need `runtimeClassName: ascend`.__ Device injection in v1.2.3 is driven by the Container Device Interface (CDI). Requesting `huawei.com/Ascend910` (or `Ascend310P`) is enough — containerd binds `/dev/davinciN` and the driver userspace libraries into the container automatically. Existing pods that still set `runtimeClassName: ascend` continue to work; the legacy RuntimeClass is retained for backwards compatibility.
+- __Workloads no longer need `runtimeClassName: ascend`.__ Device injection in v1.2.4 is driven by the Container Device Interface (CDI). Requesting `huawei.com/Ascend910` (or `Ascend310P`) is enough — containerd binds `/dev/davinciN` and the driver userspace libraries into the container automatically. Existing pods that still set `runtimeClassName: ascend` continue to work; the legacy RuntimeClass is retained for backwards compatibility.
 
 ### New features
 
 - __KubeOS / immutable-OS support.__ NPU nodes running KubeOS are now fully supported. The operator stages the driver tree under `/var/lib/Ascend` / `/var/lib/ascend` / `/home/bios/driver` (all on writable partitions on KubeOS), inserts kernel modules directly from the driver pod, and never writes to `/usr` or relies on a package manager.
+
+- __Pre-installed-driver passthrough (`spec.driver.enabled=false`).__ Clusters whose NPU hosts already carry a Huawei `.run` driver — typically bare-metal sites running an independent driver lifecycle — can now opt the operator out of driver management entirely. With __Driver__ disabled at install time (or set to `false` on the `NPUOperatorCtl` later), the operator skips the driver image sync ([installation Step 1](./installation.mdx#sync-driver-images)), does not deploy the driver / rebooter DaemonSets, and points CDI / device-plugin / runtime at the host's existing driver tree at `/var/lib/Ascend/driver` or `/usr/local/Ascend/driver` (auto-detected by the toolkit). Driver upgrades and chip-recovery reboots are then the host operator's responsibility.
 
 - __Driver upgrade lifecycle.__ Editing `NPUOperatorCtl.spec.driver.version` now triggers a per-node rolling upgrade. The operator walks each node through `upgrade-required → cordon-required → wait-for-jobs-required → pod-deletion-required → drain-required → node-reboot-required → pod-restart-required → validation-required → uncordon-required → upgrade-done`, with the rollout pace gated by:
 

--- a/docs/en/hardware_accelerator/npu/npu_operator/upgrade.mdx
+++ b/docs/en/hardware_accelerator/npu/npu_operator/upgrade.mdx
@@ -4,7 +4,11 @@ weight: 25
 
 # Driver upgrade and self-healing
 
-Starting with v1.2.3 the NPU Operator manages the driver lifecycle on each NPU node end-to-end. This page covers the two state-driven flows it exposes:
+:::info
+This page applies only when __Driver__ is enabled on the `NPUOperatorCtl` instance. If you set `spec.driver.enabled=false` (pre-installed driver mode), the operator does not touch the host driver and neither flow below runs — manage the driver version and any chip-recovery reboots through whatever process installed the `.run` package.
+:::
+
+Starting with v1.2.4 the NPU Operator manages the driver lifecycle on each NPU node end-to-end. This page covers the two state-driven flows it exposes:
 
 - __Driver upgrade__ — rolling out a new driver version cluster-wide.
 - __Chip self-healing__ — automatically recovering a node whose chip has wedged at runtime.
@@ -126,12 +130,12 @@ You can now restore the NPU workloads you stopped in Step 1.2.
 ## Chip self-healing
 
 :::caution
-__Experimental feature.__ Chip self-healing is shipped as a tech preview in v1.2.3 and disabled by default. Validate it in a staging environment before turning it on in production, and keep `autoRecover` set to `false` until you have signed off on the behaviour for your hardware profile.
+__Experimental feature.__ Chip self-healing is shipped as a tech preview in v1.2.4 and disabled by default. Validate it in a staging environment before turning it on in production, and keep `autoRecover` set to `false` until you have signed off on the behaviour for your hardware profile.
 :::
 
 Some Ascend deployment scenarios — most notably 910B in VM with PCI passthrough — can occasionally leave the chip in a state where the kernel modules are loaded but the driver itself reports `dev_num=0` and refuses DCMI calls. From userspace this looks like a "healthy" host (all `/dev/davinciN` exist, modules loaded) but every `npu-smi info` returns an error. The only recovery is a node reboot.
 
-v1.2.3 detects this case automatically:
+v1.2.4 detects this case automatically:
 
 - The driver pod runs a __health-watch loop__ that probes each NPU with `npu-smi info` every 60 seconds.
 - After three consecutive failures (≈3 minutes), the loop declares a runtime wedge: it drops the driver-ready marker (so the validator pod sees `NotReady` and the device plugin reports the chip as `Unhealthy` immediately) and writes a `recovery` marker for the rebooter.


### PR DESCRIPTION
…r passthrough

v1.2.3 is being skipped — v1.2.4 ships as the first GA on KubeOS / OLM. The release line adds a `spec.driver.enabled=false` mode for hosts that already have a Huawei `.run` driver installed out-of-band: the operator skips the driver image sync / upgrade flows entirely and points CDI, device-plugin and runtime at the host's existing `/var/lib/Ascend/driver` or `/usr/local/Ascend/driver` tree (auto-detected by the toolkit).

- installation.mdx: tip on Step 1 telling pre-installed-driver hosts to skip the whole image-sync step, plus a clarification on the Driver toggle in the deployment form.
- upgrade.mdx: leading info banner that the page does not apply when Driver is disabled.
- intro.mdx + release_notes.mdx: new bullet for the passthrough, v1.2.3 -> v1.2.4 throughout.