### PR TITLE
docs: document violet --platform-token authentication

### DIFF
--- a/docs/en/extend/upload_package.mdx
+++ b/docs/en/extend/upload_package.mdx
@@ -89,8 +89,15 @@ Several `violet` commands accept the following parameters. Refer to individual c
 --platform-address <platform access URL>     # The access URL of the platform, e.g., "https://example.com"
 --platform-username <platform user>          # The username of the platform user
 --platform-password <platform password>      # The password of the platform user
---client-id <OAuth client ID>                # OAuth client ID for username/password login. Override "alauda-auth" only for custom OAuth clients.
+--platform-token <platform token>            # The platform access token; cannot be used together with username/password
+--client-id <OAuth client ID>                # OAuth client ID for username/password login; ignored when --platform-token is set. Override "alauda-auth" only for custom OAuth clients.
 ```
+
+To create or manage platform tokens, sign in to the platform Web Console, open **Profile** > **API Tokens**, and create a token with an appropriate expiration. For details, see [API Authentication](../apis/overview/intro.mdx).
+
+:::warning
+**Identity provider (IdP) users must use a platform token.** Username and password login authenticates only against the platform's local user store. If your account comes from an external identity provider (for example, LDAP or OIDC), username and password login fails — use `--platform-token` instead. The `--client-id` parameter selects the OAuth client; it does not change the identity source.
+:::
 
 #### Image Registry Parameters
 
@@ -151,13 +158,20 @@ violet list \
   --platform-password "<platform_password>"
 ```
 
+You can also authenticate with a platform token instead of username and password:
+
+```bash
+violet list \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>"
+```
+
 To export only applications installed in specific clusters, specify multiple cluster names separated by commas:
 
 ```bash
 violet list \
   --platform-address "https://example.com" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --clusters "global,region1" \
   --output-file "./apps.yaml"
 ```
@@ -188,7 +202,7 @@ applications:
 --debug                                      # Use debug log level
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
 
 
 ### violet gc \{#violet_gc_usage}
@@ -217,13 +231,20 @@ violet gc \
   --platform-password "<platform_password>"
 ```
 
+You can also authenticate with a platform token instead of username and password:
+
+```bash
+violet gc \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>"
+```
+
 To clean up resources related to specific clusters only, specify multiple cluster names separated by commas:
 
 ```bash
 violet gc \
   --platform-address "https://example.com" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --clusters "global,region1"
 ```
 
@@ -251,7 +272,7 @@ No resources were deleted.
 --debug                                      # Use debug log level
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
 
 
 ### violet verify \{#violet_verify_usage}
@@ -304,6 +325,8 @@ No verification file found: 1 file(s)
 The following examples illustrate common usage scenarios.
 
 For platform connection and image registry parameters, see [Common Parameters](#common-parameters).
+
+For non-interactive use, prefer `--platform-token` over `--platform-password`. See [Common Parameters](#common-parameters).
 
 #### Optional Flags
 

--- a/docs/en/extend/upload_package.mdx
+++ b/docs/en/extend/upload_package.mdx
@@ -90,13 +90,12 @@ Several `violet` commands accept the following parameters. Refer to individual c
 --platform-username <platform user>          # The username of the platform user
 --platform-password <platform password>      # The password of the platform user
 --platform-token <platform token>            # The platform access token; cannot be used together with username/password
---client-id <OAuth client ID>                # OAuth client ID for username/password login; ignored when --platform-token is set. Override "alauda-auth" only for custom OAuth clients.
 ```
 
 To create or manage platform tokens, sign in to the platform Web Console, open **Profile** > **API Tokens**, and create a token with an appropriate expiration. For details, see [API Authentication](../apis/overview/intro.mdx).
 
 :::warning
-**Identity provider (IdP) users must use a platform token.** Username and password login authenticates only against the platform's local user store. If your account comes from an external identity provider (for example, LDAP or OIDC), username and password login fails — use `--platform-token` instead. The `--client-id` parameter selects the OAuth client; it does not change the identity source.
+**Identity provider (IdP) users must use a platform token.** Username and password login authenticates only against the platform's local user store. If your account comes from an external identity provider (for example, LDAP or OIDC), username and password login fails — use `--platform-token` instead.
 :::
 
 #### Image Registry Parameters
@@ -202,7 +201,7 @@ applications:
 --debug                                      # Use debug log level
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`), see [Common Parameters](#common-parameters).
 
 
 ### violet gc \{#violet_gc_usage}
@@ -272,7 +271,7 @@ No resources were deleted.
 --debug                                      # Use debug log level
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`), see [Common Parameters](#common-parameters).
 
 
 ### violet verify \{#violet_verify_usage}

--- a/docs/en/observability/alerting/notification.mdx
+++ b/docs/en/observability/alerting/notification.mdx
@@ -25,9 +25,10 @@ Use violet to push the <Term name="product" /> Cluster Notification plugin to th
 ```shell
 violet push aiops-notification-business.ALL.vx.x.x.tgz \
   --platform-address https://<platform-address>/ \
-  --platform-username <username> \
-  --platform-password '<password>'
+  --platform-token "<platform_token>"
 ```
+
+For non-interactive use, prefer `--platform-token` over a username and password. Identity provider (IdP) users must use a platform token. For all authentication options, see [Upload Packages](/extend/upload_package.html#common-parameters).
 
 ### Install via web console
 

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -47,10 +47,11 @@ On any machine with network access to the **<Term name="company" />** platform e
 ```bash
 violet list \
   --platform-address "https://<your-platform-domain>" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --output-file "./apps.yaml"
 ```
+
+Prefer `--platform-token` over `--platform-password` to avoid exposing passwords in shell history and process listings (`ps aux`).
 
 ### Step 3: Align the Customer Portal package list
 
@@ -65,8 +66,7 @@ If you are upgrading **from ACP 4.0 to ACP 4.3** and **<Term name="company" /> B
 violet push <path/to/directory/only_put_topolvm_plugin_here> \
   --target-catalog-source "platform" \
   --platform-address "https://example.com" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --clusters "cluster-a,cluster-b"
 ```
 :::

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -69,15 +69,13 @@ bash upgrade.sh --only-sync-image
 violet push <path/to/aligned-cluster-plugin-package> \
   --target-catalog-source "platform" \
   --platform-address "https://<your-platform-domain>" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>"
+  --platform-token "<platform_token>"
 
 # Push Aligned or Agnostic operators — to global, and to each workload cluster that runs the operator
 violet push <path/to/operator-package> \
   --target-catalog-source "platform" \
   --platform-address "https://<your-platform-domain>" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --clusters "global,<workload-cluster-1>,<workload-cluster-2>"
 ```
 

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -46,8 +46,7 @@ If the global window did not push operator packages to this workload cluster —
 violet push <path/to/operator-package> \
   --target-catalog-source "platform" \
   --platform-address "https://<your-platform-domain>" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --clusters "<workload-cluster-name>"
 ```
 


### PR DESCRIPTION
## What

`violet` now supports platform API-token authentication for package publishing. This re-adds the `--platform-token` documentation (previously removed while token auth was unavailable) and applies it consistently across the upload and upgrade guides, presenting the platform token as the recommended, more secure non-interactive authentication method.

## Changes

- **extend/upload_package.mdx** — restore `--platform-token` in the Platform Connection Parameters block, the token-creation guidance, the `violet list` / `violet gc` token alternatives, the three cross-reference parameter lists, and the "prefer token for non-interactive use" recommendation. Add an identity-provider (IdP) note: IdP (LDAP / OIDC) users **must** authenticate with a platform token, because username/password login only resolves local platform users and `--client-id` selects the OAuth client, not the identity source.
- **upgrade/pre-upgrade.mdx, upgrade_global_cluster.mdx, upgrade_workload_cluster.mdx** — use `--platform-token` in the `violet list` / `violet push` examples and restore the password-exposure recommendation.
- **observability/alerting/notification.mdx** — use `--platform-token` in the `violet push` example and point to the authentication reference.

## Notes

- EN-only; ZH/RU are produced by the translation pipeline.
- This is the `master` change. Re-add on `release-4.3` and consistency alignment on `release-4.2` / `release-4.1` / `release-4.0` follow after this is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized platform authentication guidance to prefer token-based authentication (`--platform-token`) for violet commands across installation, upgrade, observability, and package upload topics.
  * Updated command examples and notes to use `--platform-token` for non-interactive workflows and IdP users; adjusted cross-references and removed legacy username/password/client-id examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->