### PR TITLE
docs: document violet --platform-token authentication (release-4.3)

### DIFF
--- a/docs/en/extend/upload_package.mdx
+++ b/docs/en/extend/upload_package.mdx
@@ -89,8 +89,14 @@ Several `violet` commands accept the following parameters. Refer to individual c
 --platform-address <platform access URL>     # The access URL of the platform, e.g., "https://example.com"
 --platform-username <platform user>          # The username of the platform user
 --platform-password <platform password>      # The password of the platform user
---client-id <OAuth client ID>                # OAuth client ID for username/password login. Override "alauda-auth" only for custom OAuth clients.
+--platform-token <platform token>            # The platform access token; cannot be used together with username/password
 ```
+
+To create or manage platform tokens, sign in to the platform Web Console, open **Profile** > **API Tokens**, and create a token with an appropriate expiration. For details, see [API Authentication](../apis/overview/intro.mdx).
+
+:::warning
+**Identity provider (IdP) users must use a platform token.** Username and password login authenticates only against the platform's local user store. If your account comes from an external identity provider (for example, LDAP or OIDC), username and password login fails — use `--platform-token` instead.
+:::
 
 #### Image Registry Parameters
 
@@ -151,13 +157,20 @@ violet list \
   --platform-password "<platform_password>"
 ```
 
+You can also authenticate with a platform token instead of username and password:
+
+```bash
+violet list \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>"
+```
+
 To export only applications installed in specific clusters, specify multiple cluster names separated by commas:
 
 ```bash
 violet list \
   --platform-address "https://example.com" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --clusters "global,region1" \
   --output-file "./apps.yaml"
 ```
@@ -185,7 +198,7 @@ applications:
 --output-file <output file>                  # The path of the output plugin list file
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`), see [Common Parameters](#common-parameters).
 
 
 ### violet gc \{#violet_gc_usage}
@@ -214,13 +227,20 @@ violet gc \
   --platform-password "<platform_password>"
 ```
 
+You can also authenticate with a platform token instead of username and password:
+
+```bash
+violet gc \
+  --platform-address "https://example.com" \
+  --platform-token "<platform_token>"
+```
+
 To clean up resources related to specific clusters only, specify multiple cluster names separated by commas:
 
 ```bash
 violet gc \
   --platform-address "https://example.com" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --clusters "global,region1"
 ```
 
@@ -248,7 +268,7 @@ No resources were deleted.
 --debug                                      # Use debug log level
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`), see [Common Parameters](#common-parameters).
 
 ### violet verify \{#violet_verify_usage}
 
@@ -300,6 +320,8 @@ No verification file found: 1 file(s)
 The following examples illustrate common usage scenarios.
 
 For platform connection and image registry parameters, see [Common Parameters](#common-parameters).
+
+For non-interactive use, prefer `--platform-token` over `--platform-password`. See [Common Parameters](#common-parameters).
 
 #### Optional Flags
 

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -51,10 +51,11 @@ On any machine with network access to the **<Term name="company" />** platform e
 ```bash
 violet list \
   --platform-address "https://<your-platform-domain>" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --output-file "./apps.yaml"
 ```
+
+Prefer `--platform-token` over `--platform-password` to avoid exposing passwords in shell history and process listings (`ps aux`).
 
 ### Step 3: Align the Customer Portal package list
 
@@ -69,8 +70,7 @@ If you are upgrading **from ACP 4.0 to ACP 4.3** and **<Term name="company" /> B
 violet push <path/to/directory/only_put_topolvm_plugin_here> \
   --target-catalog-source "platform" \
   --platform-address "https://example.com" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --clusters "cluster-a,cluster-b"
 ```
 :::

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -73,15 +73,13 @@ bash upgrade.sh --only-sync-image
 violet push <path/to/aligned-cluster-plugin-package> \
   --target-catalog-source "platform" \
   --platform-address "https://<your-platform-domain>" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>"
+  --platform-token "<platform_token>"
 
 # Push Aligned or Agnostic operators — to global, and to each workload cluster that runs the operator
 violet push <path/to/operator-package> \
   --target-catalog-source "platform" \
   --platform-address "https://<your-platform-domain>" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --clusters "global,<workload-cluster-1>,<workload-cluster-2>"
 ```
 

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -50,8 +50,7 @@ If the global window did not push operator packages to this workload cluster —
 violet push <path/to/operator-package> \
   --target-catalog-source "platform" \
   --platform-address "https://<your-platform-domain>" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
+  --platform-token "<platform_token>" \
   --clusters "<workload-cluster-name>"
 ```
 


### PR DESCRIPTION
## What

Backport of the master change to **release-4.3**. `violet` now supports platform API-token authentication for package publishing. This re-adds the `--platform-token` documentation across the upload and upgrade guides and presents the platform token as the recommended, more secure non-interactive authentication method.

## Changes

- **extend/upload_package.mdx** — add `--platform-token` to the Platform Connection Parameters, the token-creation guidance, the `violet list` / `violet gc` token alternatives, the cross-reference parameter lists, and the "prefer token for non-interactive use" recommendation. Add an identity-provider (IdP) note: IdP (LDAP / OIDC) users **must** authenticate with a platform token, because username/password login only resolves local platform users.
- **upgrade/pre-upgrade.mdx, upgrade_global_cluster.mdx, upgrade_workload_cluster.mdx** — use `--platform-token` in the `violet list` / `violet push` examples and restore the password-exposure recommendation.

`--client-id` is intentionally not documented: it only sets the OAuth client for the username/password token exchange (default `alauda-auth`) and never selects the identity source, so the docs keep to the two real paths — local username/password and platform token.

## Notes

- EN-only; ZH/RU come from the translation pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
