### PR TITLE
docs: align violet --platform-token docs and drop --client-id (release-4.2)

### DIFF
--- a/docs/en/extend/upload_package.mdx
+++ b/docs/en/extend/upload_package.mdx
@@ -90,10 +90,13 @@ Several `violet` commands accept the following parameters. Refer to individual c
 --platform-username <platform user>          # The username of the platform user
 --platform-password <platform password>      # The password of the platform user
 --platform-token <platform token>            # The platform access token; cannot be used together with username/password
---client-id <OAuth client ID>                # OAuth client ID for username/password login; ignored when --platform-token is set. Override "alauda-auth" only for custom OAuth clients.
 ```
 
 To create or manage platform tokens, sign in to the platform Web Console, open **Profile** > **API Tokens**, and create a token with an appropriate expiration. For details, see [API Authentication](../apis/overview/intro.mdx).
+
+:::warning
+**Identity provider (IdP) users must use a platform token.** Username and password login authenticates only against the platform's local user store. If your account comes from an external identity provider (for example, LDAP or OIDC), username and password login fails — use `--platform-token` instead.
+:::
 
 #### Image Registry Parameters
 
@@ -194,7 +197,7 @@ applications:
 --output-file <output file>                  # The path of the output plugin list file
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`), see [Common Parameters](#common-parameters).
 
 
 ### violet gc \{#violet_gc_usage}
@@ -264,7 +267,7 @@ No resources were deleted.
 --debug                                      # Use debug log level
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`), see [Common Parameters](#common-parameters).
 
 ### violet verify \{#violet_verify_usage}
 

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -60,9 +60,6 @@ If any cluster installed the **<Term name="company" /> Build of TopoLVM**, uploa
 violet push <path/to/directory/only_put_topolvm_plugin_here> \
   --target-catalog-source "platform" \
   --platform-address "https://example.com" \
-  --platform-username "<platform_user>" \
-  --platform-password "<platform_password>" \
-  --clusters "<cluster_name>"
   --platform-token "<platform_token>" \
   --clusters "cluster-a,cluster-b"
 ```


### PR DESCRIPTION
## What

Align **release-4.2** with the master canonical `violet --platform-token` documentation. release-4.2 already documented `--platform-token`; this PR adds the missing identity-provider guidance, drops `--client-id`, and fixes a malformed example.

## Changes

- **extend/upload_package.mdx** — add an identity-provider (IdP) note: IdP (LDAP / OIDC) users **must** authenticate with a platform token, because username/password login only resolves local platform users. Remove `--client-id` from the parameter block and the two cross-reference lists — it only sets the OAuth client for the username/password token exchange and never selects the identity source, so the docs keep to the two real paths (local username/password and platform token).
- **upgrade/pre-upgrade.mdx** — fix a malformed TopoLVM `violet push` example that mixed username/password and token flags with duplicate `--clusters` lines; it now uses a single clean `--platform-token` form.

## Notes

- EN-only; ZH/RU come from the translation pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
