### PR TITLE
docs: align violet --platform-token docs and drop --client-id (release-4.0)

### DIFF
--- a/docs/en/extend/upload_package.mdx
+++ b/docs/en/extend/upload_package.mdx
@@ -90,10 +90,13 @@ Several `violet` commands accept the following parameters. Refer to individual c
 --platform-username <platform user>          # The username of the platform user
 --platform-password <platform password>      # The password of the platform user
 --platform-token <platform token>            # The platform access token; cannot be used together with username/password
---client-id <OAuth client ID>                # OAuth client ID for username/password login; ignored when --platform-token is set. Override "alauda-auth" only for custom OAuth clients.
 ```
 
 To create or manage platform tokens, sign in to the platform Web Console, open **Profile** > **API Tokens**, and create a token with an appropriate expiration. For details, see [API Authentication](../apis/overview/intro.mdx).
+
+:::warning
+**Identity provider (IdP) users must use a platform token.** Username and password login authenticates only against the platform's local user store. If your account comes from an external identity provider (for example, LDAP or OIDC), username and password login fails — use `--platform-token` instead.
+:::
 
 #### Image Registry Parameters
 
@@ -195,7 +198,7 @@ applications:
 --output-file <output file>                  # The path of the output plugin list file
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`), see [Common Parameters](#common-parameters).
 
 
 ### violet gc \{#violet_gc_usage}
@@ -265,7 +268,7 @@ No resources were deleted.
 --debug                                      # Use debug log level
 ```
 
-For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`, `--client-id`), see [Common Parameters](#common-parameters).
+For platform connection parameters (`--platform-address`, `--platform-username`, `--platform-password`, `--platform-token`), see [Common Parameters](#common-parameters).
 
 ### violet verify \{#violet_verify_usage}
 


### PR DESCRIPTION
## What

Align **release-4.0** with the master canonical `violet --platform-token` documentation. release-4.0 already documented `--platform-token`; this PR adds the missing identity-provider guidance and drops `--client-id`.

## Changes

- **extend/upload_package.mdx** — add an identity-provider (IdP) note: IdP (LDAP / OIDC) users **must** authenticate with a platform token, because username/password login only resolves local platform users. Remove `--client-id` from the parameter block and the two cross-reference lists — it only sets the OAuth client for the username/password token exchange and never selects the identity source, so the docs keep to the two real paths (local username/password and platform token).

## Notes

- EN-only; ZH/RU come from the translation pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
