### PR TITLE
docs: bump mysql-mgr to 4.4 (ACP site → mgr-docs release-4.4)

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -66,7 +66,7 @@
     en: Alauda Database Service for MySQL-MGR
     zh: Alauda Database Service for MySQL-MGR
   base: /mysql-mgr
-  version: "4.3"
+  version: "4.4"
   repo: https://github.com/alauda/mgr-docs
 - name: redis
   displayName:


### PR DESCRIPTION
Bumps the mysql-mgr plugin version 4.3 → 4.4 so the ACP docs site surfaces the MGR v4.4.0 content (MySQL 8.4 + in-place 8.0→8.4 upgrade) from mgr-docs release-4.4 (alauda/mgr-docs#50, merged). Only the mysql-mgr entry changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MySQL MGR to version 4.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->