### PR TITLE
docs: bump mysql-mgr to 4.4 on release-4.3 (ACP 4.3 → mgr-docs release-4.4)

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -66,7 +66,7 @@
     en: Alauda Database Service for MySQL-MGR
     zh: Alauda Database Service for MySQL-MGR
   base: /mysql-mgr
-  version: "4.3"
+  version: "4.4"
   repo: https://github.com/alauda/mgr-docs
 - name: redis
   displayName:


### PR DESCRIPTION
MGR v4.4.0 is published for ACP v4.3 (AC上架 acp_version v4.1/v4.2/v4.3). Bumps the mysql-mgr plugin version 4.3→4.4 on the ACP 4.3 docs site so it surfaces the MGR v4.4 content from mgr-docs release-4.4 (merged). Only the mysql-mgr entry changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)