### PR TITLE
docs(sites): add CloudNativePG (cnpg) -> cnpg-docs release-1.29

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -103,6 +103,13 @@
   base: /postgresql
   version: "4.3"
   repo: https://github.com/alauda/pg-docs
+- name: cnpg
+  displayName:
+    en: Alauda support for CloudNativePG
+    zh: Alauda support for CloudNativePG
+  base: /cnpg
+  version: "1.29"
+  repo: https://github.com/alauda/cnpg-docs
 - name: costmanagement
   displayName:
     en: Alauda Cost Management


### PR DESCRIPTION
Adds a `cnpg` entry to `sites.yaml` pointing at **cnpg-docs `release-1.29`** (`version: "1.29"`), so the CloudNativePG **v1.29.1-acp.1 GA** docs render under `/cnpg` on the ACP 4.3 docs site. Modeled on the sibling `postgresql` entry; `release-1.29` was just cut from cnpg-docs main (release notes + nav polish merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)