### PR TITLE
docs(storage): add Ceph Multus multi-NIC how-to (ACP-51208)

### DIFF
--- a/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
@@ -173,7 +173,7 @@ addressRanges:
 Submit the wizard while still in YAML mode (click **Create Cluster**). Do not switch back to form mode before submitting, as it may not preserve the network fields.
 
 :::warning
-On the new console, configure the network here in the `StorageCluster`, not by editing the `CephCluster` afterwards. When a cluster is managed by a `StorageCluster`, `spec.network` is a managed field and manual edits to the `CephCluster` are reverted by the operator.
+On the new console, configure the network here in the `StorageCluster`, not by editing the `CephCluster` afterward. When a cluster is managed by a `StorageCluster`, `spec.network` is a managed field and manual edits to the `CephCluster` are reverted by the operator.
 :::
 
 </Steps>
@@ -184,10 +184,10 @@ After the storage cluster is created, verify the network configuration from both
 
 ### (New console) Check the StorageCluster network settings
 
-If your cluster is managed by a `StorageCluster`, confirm the desired configuration:
+If your cluster is managed by a `StorageCluster`, confirm the desired configuration (replace `<storage-cluster-name>` with your StorageCluster's name):
 
 ```bash
-kubectl get storagecluster ceph-storage -n rook-ceph -o yaml
+kubectl get storagecluster <storage-cluster-name> -n rook-ceph -o yaml
 ```
 
 The output should contain the expected provider and selectors:

--- a/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
@@ -1,0 +1,244 @@
+---
+weight: 74
+---
+
+# Configure Multus multi-NIC networking
+
+This topic describes how to attach ACP distributed storage (Ceph) to dedicated container networks using Multus, so that the Ceph **public** and **cluster** traffic can be separated onto different network interfaces (NICs).
+
+## Overview
+
+By default, an ACP Ceph storage cluster uses the host network (`provider: host`). When you create a storage cluster from the web console, you can also choose **Container Network**, which places Ceph traffic on a single container network (a single `NetworkAttachmentDefinition` assigned to the `rook-ceph` namespace). See [Create a Standard Storage Service](../installation/create_service_stand.mdx) for the basic single-network option.
+
+Multus multi-NIC networking extends the container-network model so that you can map the two Ceph network roles onto **separate** networks:
+
+- **public network** — client traffic between Ceph clients (CSI, applications) and the cluster.
+- **cluster network** — internal traffic between OSDs, such as replication and recovery.
+
+Separating these roles onto different NICs improves isolation and can prevent heavy replication/recovery traffic from competing with client I/O.
+
+### Two management surfaces \{#two-management-surfaces}
+
+ACP provides a legacy and a new web console, which manage Ceph storage through **different** resources. Configure the network on the resource that manages your cluster:
+
+| Web console | Managing resource | Where to set the network |
+| :--- | :--- | :--- |
+| New web console | `StorageCluster` (managed by the storage operator) | `StorageCluster.spec.ceph.network` — the operator maps it to the underlying `CephCluster.spec.network` |
+| Legacy web console | `CephCluster` (Rook, managed directly) | `CephCluster.spec.network` |
+
+To determine which resource manages a given cluster, check whether a `StorageCluster` exists:
+
+```bash
+kubectl get storagecluster -A
+```
+
+- If a `StorageCluster` exists for your cluster, it is managed by the new console — configure the network on the **StorageCluster** (the operator reverts manual edits to the underlying `CephCluster`).
+- If no `StorageCluster` exists, the cluster is managed directly as a **CephCluster** by the legacy console — configure the network on the `CephCluster`.
+
+Both resources expose the same network fields (`provider`, `selectors`, `addressRanges`). The sections below give the manifest for each surface.
+
+The network role to network mapping is declared with `selectors`:
+
+| Selector key | Ceph role | Backing network |
+| :--- | :--- | :--- |
+| `public` | Ceph public network | A `NetworkAttachmentDefinition` (NAD) referenced as `<namespace>/<nad-name>` |
+| `cluster` | Ceph cluster (replication) network | A `NetworkAttachmentDefinition` (NAD) referenced as `<namespace>/<nad-name>` |
+
+You can specify only `public`, or both `public` and `cluster`. At least one selector is required when `provider` is `multus`.
+
+## Limitations and prerequisites
+
+Before you configure Multus multi-NIC networking, note the following restrictions:
+
+- **Creation-time only**
+  - Multus multi-NIC networking must be configured **when the storage cluster is created**. Changing the network provider on a running cluster is **not supported**: Ceph must fail over all monitors to apply a new network model, and the API rejects switching directly from one non-empty provider to another (the provider must first be reverted to an empty value). Treat the network model as a fixed property of the cluster.
+
+- **Multus CNI plugin installed**
+  - The cluster must use Kube-OVN as its network plugin, and the Multus CNI plugin must be installed. This is a one-time, cluster-wide setup. To install it, navigate to **Administrator** > **Marketplace** > **Cluster Plugins**, search for `multus`, and install **Alauda Container Platform Networking for Multus**. For details, see [Configuring Kube-OVN Network to Support Pod Multi-Network Interfaces](/networking/how_to/kube_ovn/multiple_networks.mdx).
+
+- **Single IP family**
+  - A Multus network must use a single IP family. IPv4 and IPv6 are both supported, but dual-stack (IPv4 and IPv6 together) is not supported with Multus. To use IPv6, set `ipFamily: IPv6` in the network block.
+  - This differs from the basic **Container Network** option in [Create a Standard Storage Service](../installation/create_service_stand.mdx), which does not support IPv6. That restriction applies only to that single-network form option; the Multus multi-NIC procedure described here does support IPv6.
+
+:::warning
+When Ceph uses a Multus network, only clients that are attached to the same Multus network can reach the storage; reachability is bound to the underlay network and its routing. A restart or failure of the Ceph CSI Pod may also cause a temporary service interruption. Plan the network roles, NADs, and operational ownership before deployment.
+:::
+
+## Configure multi-NIC networking at cluster creation
+
+The multi-NIC settings cannot be expressed in the wizard's form fields, but the **Create Cluster** wizard provides a **YAML mode**. The recommended flow is to complete the wizard as usual so it auto-populates the manifest, then switch to YAML mode, edit only the network section, and submit from YAML mode. This avoids hand-writing the full manifest.
+
+The manifest shown in YAML mode depends on your console (see [Two management surfaces](#two-management-surfaces)): the new console shows a `StorageCluster`, the legacy console shows a `CephCluster`. Edit the network block at the path that matches.
+
+<Steps>
+
+### Create the Multus networks
+
+To put storage traffic on dedicated physical NICs at near-host speed, use a **Kube-OVN Underlay** network rather than an overlay one. Underlay bridges a dedicated physical NIC directly to the storage network, with no encapsulation overhead.
+
+Underlay requires the physical network to be prepared first: each storage node needs a dedicated NIC (not carrying other traffic such as SSH), and the upstream switch port/VLAN and gateway must be configured. Then create a **bridge network** (`ProviderNetwork`) and a **VLAN** (`Vlan`) that the storage subnet will attach to. For the physical prerequisites and how to create the bridge network and VLAN, see [Preparing the Kube-OVN Underlay Physical Network](/networking/how_to/kube_ovn/kubeovn_underlay_py.mdx) and [Configure Subnet](/networking/functions/configure_subnet.mdx#kube_ovn_underlay_network).
+
+For each Ceph network role you want to isolate, create a `NetworkAttachmentDefinition` in the `rook-ceph` namespace and a backing underlay subnet. The following creates the **public** network; repeat with different names and a different CIDR/VLAN for the **cluster** network if you also want to separate replication traffic.
+
+Create the `NetworkAttachmentDefinition`. The `provider` field must use the `<name>.<namespace>.ovn` format:
+
+```yaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ceph-public-net
+  namespace: rook-ceph
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.0",
+      "type": "kube-ovn",
+      "server_socket": "/run/openvswitch/kube-ovn-daemon.sock",
+      "provider": "ceph-public-net.rook-ceph.ovn"
+    }
+```
+
+Create the underlay Kube-OVN subnet that provides addresses for that network. Set `vlan` to the `Vlan` you prepared, use a `cidrBlock`/`gateway` that match the physical network, and make `provider` match the one in the `NetworkAttachmentDefinition`:
+
+```yaml
+apiVersion: kubeovn.io/v1
+kind: Subnet
+metadata:
+  name: ceph-public-net
+spec:
+  protocol: IPv4
+  cidrBlock: 192.168.10.0/24
+  gateway: 192.168.10.1
+  vlan: ceph-public-vlan
+  provider: ceph-public-net.rook-ceph.ovn
+```
+
+Apply both resources, then confirm the `NetworkAttachmentDefinition` exists:
+
+```bash
+kubectl get net-attach-def -n rook-ceph
+```
+
+The `selectors` you set in a later step reference these NADs in `<namespace>/<name>` form, for example `rook-ceph/ceph-public-net`.
+
+### Open the Create Cluster wizard
+
+Start creating a distributed storage cluster as described in [Create a Standard Storage Service](../installation/create_service_stand.mdx). On the **Create Cluster** step, configure device classes, storage devices, and component placement as usual so the wizard fills in the rest of the manifest.
+
+### Switch to YAML mode
+
+Toggle the wizard from form mode to **YAML** mode. The manifest is already populated from your selections.
+
+### Edit the network section
+
+Add or replace the network block in the manifest. Set `provider: multus` and the `selectors` that map the Ceph public/cluster roles to your NADs.
+
+- **New web console** — the manifest is a `StorageCluster`; edit `spec.ceph.network`:
+
+  ```yaml
+  spec:
+    ceph:
+      network:
+        provider: multus
+        selectors:
+          public: rook-ceph/ceph-public-net
+          cluster: rook-ceph/ceph-cluster-net
+  ```
+
+- **Legacy web console** — the manifest is a `CephCluster`; edit `spec.network` (same fields, without the `spec.ceph` wrapper):
+
+  ```yaml
+  spec:
+    network:
+      provider: multus
+      selectors:
+        public: rook-ceph/ceph-public-net
+        cluster: rook-ceph/ceph-cluster-net
+  ```
+
+If you only need to move client traffic onto a dedicated network, keep just the `public` selector and omit `cluster`.
+
+To pin CIDR ranges (when Rook's auto-detection is unreliable), add an `addressRanges` block at the same level as `selectors`:
+
+```yaml
+addressRanges:
+  public:
+    - 192.168.10.0/24
+  cluster:
+    - 192.168.20.0/24
+```
+
+### Submit from YAML mode
+
+Submit the wizard while still in YAML mode (click **Create Cluster**). Do not switch back to form mode before submitting, as it may not preserve the network fields.
+
+:::warning
+On the new console, configure the network here in the `StorageCluster`, not by editing the `CephCluster` afterwards. When a cluster is managed by a `StorageCluster`, `spec.network` is a managed field and manual edits to the `CephCluster` are reverted by the operator.
+:::
+
+</Steps>
+
+## Verification
+
+After the storage cluster is created, verify the network configuration from both the ACP and Ceph sides.
+
+### (New console) Check the StorageCluster network settings
+
+If your cluster is managed by a `StorageCluster`, confirm the desired configuration:
+
+```bash
+kubectl get storagecluster ceph-storage -n rook-ceph -o yaml
+```
+
+The output should contain the expected provider and selectors:
+
+```yaml
+spec:
+  ceph:
+    network:
+      provider: multus
+      selectors:
+        public: rook-ceph/ceph-public-net
+        cluster: rook-ceph/ceph-cluster-net
+```
+
+### Check the effective CephCluster network settings
+
+This check applies to both consoles, because the `CephCluster` is the resource Rook acts on:
+
+```bash
+kubectl get cephcluster ceph-cluster -n rook-ceph -o jsonpath='{.spec.network}' | jq
+```
+
+The `provider` and `selectors` should match what you configured. On the new console, they should also match the managing `StorageCluster`.
+
+### Check that Ceph Pods are attached to the networks
+
+Confirm that the Ceph daemon Pods (for example, MON and OSD) carry the Multus network attachment annotation and report the expected interfaces:
+
+```bash
+kubectl get pod -n rook-ceph -l app=rook-ceph-osd \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/networks}{"\n"}{end}'
+```
+
+Each OSD Pod should reference the public (and, if configured, cluster) network.
+
+### Check workload mounts
+
+Create or restart a test workload that mounts a CephFS PVC and an RBD PVC, then verify:
+
+- the Pod starts successfully
+- the filesystem can be read and written
+- no mount-related errors appear in CSI or workload logs
+
+## Troubleshooting suggestions
+
+If the storage cluster fails to become healthy after enabling Multus, check the following items first:
+
+1. **NAD does not exist** — the `NetworkAttachmentDefinition` referenced by a selector is missing from the `rook-ceph` namespace, or the `<namespace>/<nad-name>` reference is misspelled.
+2. **Missing selector** — `provider: multus` is set but no `public` or `cluster` selector is defined. At least one selector is required.
+3. **CIDR detection failures** — Rook cannot auto-detect the network range. Specify `addressRanges` explicitly.
+4. **IP exhaustion** — the IPAM pool backing the NAD (for example, the configured CIDR or address range) has no free addresses for new Ceph Pods.
+5. **Client reachability** — a client is not attached to, or cannot route to, the underlay network. With Multus networking, the storage endpoints live on the underlay network, so clients must be on that network or have routes to it.
+
+If the cluster cannot be recovered, recreate it with a corrected network configuration. Because the network model cannot be switched on a running cluster, network mistakes are resolved by recreating the storage cluster rather than by patching it in place.

--- a/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
@@ -65,7 +65,7 @@ Before you configure Multus multi-NIC networking, note the following restriction
   - This differs from the basic **Container Network** option in [Create a Standard Storage Service](../installation/create_service_stand.mdx), which does not support IPv6. That restriction applies only to that single-network form option; the Multus multi-NIC procedure described here does support IPv6.
 
 :::warning
-When Ceph uses a Multus network, only clients that are attached to the same Multus network can reach the storage; reachability is bound to the underlay network and its routing. A restart or failure of the Ceph CSI Pod may also cause a temporary service interruption. Plan the network roles, NADs, and operational ownership before deployment.
+Multus moves the storage **data path** (OSD traffic) onto the dedicated NIC, but it does not change how workloads consume storage: **application Pods do not need to join the Multus network.** Clients reach the monitors over the default network (through the mon Service), and the Ceph CSI driver — which runs with host networking on each node — handles the data path to the OSDs. The real requirement is therefore that the **storage nodes can route to the underlay network**, not that workload Pods are attached to it. Plan the network roles, NADs, and node routing before deployment.
 :::
 
 ## Configure multi-NIC networking at cluster creation
@@ -249,6 +249,6 @@ If the storage cluster fails to become healthy after enabling Multus, check the 
 2. **Missing selector** — `provider: multus` is set but no `public` or `cluster` selector is defined. At least one selector is required.
 3. **CIDR detection failures** — Rook cannot auto-detect the network range. Specify `addressRanges` explicitly.
 4. **IP exhaustion** — the IPAM pool backing the NAD (for example, the configured CIDR or address range) has no free addresses for new Ceph Pods.
-5. **Client reachability** — a client is not attached to, or cannot route to, the underlay network. With Multus networking, the storage endpoints live on the underlay network, so clients must be on that network or have routes to it.
+5. **Node cannot reach the underlay** — the Ceph CSI driver runs with host networking, so each **node** (not the workload Pod) must be able to route to the OSD addresses on the underlay network. If mounts hang, verify the node's Kube-OVN underlay routing and that OSD addresses are reachable from the node.
 
 If the cluster cannot be recovered, recreate it with a corrected network configuration. Because the network model cannot be switched on a running cluster, network mistakes are resolved by recreating the storage cluster rather than by patching it in place.

--- a/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
@@ -17,6 +17,10 @@ Multus multi-NIC networking extends the container-network model so that you can 
 
 Separating these roles onto different NICs improves isolation and can prevent heavy replication/recovery traffic from competing with client I/O.
 
+:::note
+OSD daemons bind directly to the Multus network, so OSD (replication and client data) traffic uses the dedicated NIC. Daemons that are reached through a Kubernetes Service — monitors, managers, and RGW — keep listening on the default cluster network even though the Multus interface is attached to their Pods. This is a Rook behavior, not a configuration error.
+:::
+
 ### Two management surfaces \{#two-management-surfaces}
 
 ACP provides a legacy and a new web console, which manage Ceph storage through **different** resources. Configure the network on the resource that manages your cluster:

--- a/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
@@ -18,7 +18,7 @@ Multus multi-NIC networking extends the container-network model so that you can 
 Separating these roles onto different NICs improves isolation and can prevent heavy replication/recovery traffic from competing with client I/O.
 
 :::note
-OSD daemons bind directly to the Multus network, so OSD (replication and client data) traffic uses the dedicated NIC. Daemons that are reached through a Kubernetes Service — monitors, managers, and RGW — keep listening on the default cluster network even though the Multus interface is attached to their Pods. This is a Rook behavior, not a configuration error.
+Daemons that clients connect to directly — **OSDs and MDS (CephFS metadata servers)** — bind the Multus network, so block (RBD) and file (CephFS) data traffic, plus OSD replication, use the dedicated NIC. Daemons that are reached through a Kubernetes Service — **monitors, managers, and RADOS Gateway (RGW)** — keep listening on the default network even though the Multus interface is attached to their Pods. This is a Rook behavior, not a configuration error: clients still reach the monitors over the default network to obtain the cluster map. Multus therefore isolates the storage data path, not the full control path.
 :::
 
 ### Two management surfaces \{#two-management-surfaces}

--- a/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
@@ -158,15 +158,21 @@ Add or replace the network block in the manifest. Set `provider: multus` and the
 
 If you only need to move client traffic onto a dedicated network, keep just the `public` selector and omit `cluster`.
 
-To pin CIDR ranges (when Rook's auto-detection is unreliable), add an `addressRanges` block at the same level as `selectors`:
+Set the CIDR ranges explicitly with an `addressRanges` block at the same level as `selectors`. Rook attempts to auto-detect the CIDRs of the attached networks, but this detection is unreliable on Kube-OVN underlay networks and can fail, leaving the cluster stuck at "Configuring Ceph Mons". Specifying `addressRanges` avoids this:
 
 ```yaml
 addressRanges:
   public:
-    - 192.168.10.0/24
+    - 10.176.0.0/16
   cluster:
-    - 192.168.20.0/24
+    - 10.176.0.0/16
 ```
+
+Use the CIDR of the underlay subnet you created (only `public` is needed if you did not separate the cluster network).
+
+:::tip
+If a `StorageCluster` stays in `Progressing` with the underlying `CephCluster` reporting `failed to discover network CIDRs for multus`, add or correct `addressRanges`.
+:::
 
 ### Submit from YAML mode
 
@@ -184,10 +190,10 @@ After the storage cluster is created, verify the network configuration from both
 
 ### (New console) Check the StorageCluster network settings
 
-If your cluster is managed by a `StorageCluster`, confirm the desired configuration (replace `<storage-cluster-name>` with your StorageCluster's name):
+If your cluster is managed by a `StorageCluster`, confirm the desired configuration. A Ceph `StorageCluster` is always named `ceph-cluster` in the `rook-ceph` namespace (both are enforced by admission):
 
 ```bash
-kubectl get storagecluster <storage-cluster-name> -n rook-ceph -o yaml
+kubectl get storagecluster ceph-cluster -n rook-ceph -o yaml
 ```
 
 The output should contain the expected provider and selectors:

--- a/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx
@@ -18,7 +18,7 @@ Multus multi-NIC networking extends the container-network model so that you can 
 Separating these roles onto different NICs improves isolation and can prevent heavy replication/recovery traffic from competing with client I/O.
 
 :::note
-Daemons that clients connect to directly — **OSDs and MDS (CephFS metadata servers)** — bind the Multus network, so block (RBD) and file (CephFS) data traffic, plus OSD replication, use the dedicated NIC. Daemons that are reached through a Kubernetes Service — **monitors, managers, and RADOS Gateway (RGW)** — keep listening on the default network even though the Multus interface is attached to their Pods. This is a Rook behavior, not a configuration error: clients still reach the monitors over the default network to obtain the cluster map. Multus therefore isolates the storage data path, not the full control path.
+All traffic **to and from OSDs uses the Multus network** — this is the bulk storage data path: RBD client I/O, CephFS data and metadata (MDS), object data (RGW reading/writing objects on OSDs), and OSD replication. Endpoints that are reached through a **Kubernetes Service** — the **monitors** (clients use the mon Service to fetch the cluster map), the **manager**, and the **RGW S3 endpoint** — are served over the default network; those daemons keep their Service-facing listeners on the default network even though the Multus interface is attached to their Pods. This is Rook behavior, not a configuration error. Multus therefore isolates the storage **data path**, not the Service-fronted control and ingress endpoints.
 :::
 
 ### Two management surfaces \{#two-management-surfaces}


### PR DESCRIPTION
## 关联
- Jira: [ACP-51208](https://jira.alauda.cn/browse/ACP-51208)（Epic [ACP-51059](https://jira.alauda.cn/browse/ACP-51059) Ceph 容器网络支持多网卡）
- Spec: 无（调研驱动文档，无独立 spec）
- 关联 MR: 无（docs-only）

## 背景 动机
ACP-51208 后端调研结论：ASO 已支持 Ceph Multus（`StorageCluster.spec.ceph.network` 直通 Rook `NetworkSpec`，CRD 暴露 `multus`/`selectors`+CEL，已有单测）。需要面向用户的操作文档，让用户照文档即可把 Ceph 多网卡（public/cluster 流量分离到专用物理网卡）配起来。

## 改动
- 新增 how-to：`docs/en/storage/storagesystem_ceph/how_to/configure-multus-multi-nic.mdx`
- 覆盖 4.4 两套管理面双路径：新 console = `StorageCluster`、旧 console = `CephCluster`，并给出 `kubectl get storagecluster -A` 判断归属
- 流程基于「创建集群向导的 YAML 模式」：向导自动填充 → 切 YAML → 只改网络块 → YAML 模式提交
- 端到端网络准备：采用 **Kube-OVN Underlay**（NAD + underlay Subnet，带 `vlan`/`gateway`/`provider`），对齐 ODF 的 macvlan/underlay 设计
- 含验证（StorageCluster→CephCluster→Pod 注解→挂载）与排错

## 影响范围
- 纯文档新增，无代码/接口/行为变化
- 不涉及升级 / 已有集群 / 破坏性变更
- 仅新增页面（how_to 目录下，侧边导航按 `weight` 自动生成）

## 验证
- 人工核对：NAD / Subnet / StorageCluster 字段对照 ASO CRD 与仓库内 kube-ovn underlay 文档（`configure_subnet.mdx`）
- 已修 `doom-lint-no-unmatched-anchor`：给「Two management surfaces」加显式 `\{#...}` anchor，核对唯一 intra-page 锚点匹配
- ⚠️ 本机无 node_modules 未实跑 `yarn lint`，请 CI 跑 doom lint/build 复验

## 范围说明 后续
- 本特性仅「创建时」配置；运行中切换 network provider 不支持（Rook 限制）
- Non-Goals：NAD 校验护栏、provider 切换护栏（后端缺口）
- UX/UI 引导归 [ACP-51206](https://jira.alauda.cn/browse/ACP-51206)；测试归 [ACP-51209](https://jira.alauda.cn/browse/ACP-51209)
- IPv6 单栈支持、双栈不支持（已在文档「Single IP family」限制段写明）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an MDX guide for configuring ACP Ceph to use Multus multi-NIC networking, separating Ceph **public (client)** traffic from **cluster (replication/recovery)** traffic.
  * Covers prerequisites and constraints (including Multus setup at cluster creation time and single IP family per Multus network), step-by-step creation of underlay/NADs with selector mapping, and YAML-based configuration.
  * Includes verification steps (effective network settings, Multus attachments, mount tests) and troubleshooting guidance for common network and IP/CIDR issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->