### PR TITLE
docs: backport networking guidance to release-4.3

### DIFF
--- a/docs/en/configure/networking/how_to/kube_ovn/configure_egress_gateway.mdx
+++ b/docs/en/configure/networking/how_to/kube_ovn/configure_egress_gateway.mdx
@@ -615,6 +615,25 @@ Session 1
   If all gateway instances are down, egress traffic handled by the VPC Egress Gateway is dropped.
 :::
 
+## Validated Capacity Guidance
+
+The following results were validated on ACP 4.3.2 with Kube-OVN v1.15.13, two replicas for each VPC Egress Gateway, and bfdd CPU request/limit `50m/200m`.
+Use them as sizing guidance, not as a hard product limit.
+
+:::note
+  The validated capacity is for reference only. Actual capacity can vary with hardware performance and cluster load.
+:::
+
+| BFD setting | Validated scale | Recommendation |
+| --- | --- | --- |
+| `100ms / 100ms x2` | 100 gateways / 200 gateway Pods | Use only for smaller deployments that require aggressive detection. |
+| `100ms / 100ms x5` | 150 gateways / 300 gateway Pods | Use when 100 ms probing is required and a larger multiplier is acceptable. |
+| `200ms / 200ms x5` | 300 gateways / 600 gateway Pods | Suitable for medium scale. |
+| `300ms / 300ms x5` | 400 gateways / 800 gateway Pods | Keep capacity headroom when using this setting. |
+| `500ms / 500ms x3` | 500 gateways / 1000 gateway Pods | Recommended for 500-gateway deployments. |
+
+For dedicated Egress Gateway nodes with about 32 vCPUs and 96 GiB memory, the same `500ms / 500ms x3` BFD setting and bfdd `50m/200m` CPU request/limit validated up to about 200 gateway Pods per node.
+
 ## Operations That May Interrupt Traffic
 
 The following operations may briefly interrupt egress traffic because they delete or recreate gateway instances:

--- a/docs/en/networking/observability/operator-deployment.mdx
+++ b/docs/en/networking/observability/operator-deployment.mdx
@@ -78,15 +78,23 @@ metadata:
 spec:
   configuration:
     files:
-      disable-trace-log: |
+      99-disable-system-logs.xml: | # [!code callout]
         <clickhouse>
-          <trace_log remove="remove"/>
-          <query_thread_log remove="remove"/>
-          <query_log remove="remove"/>
-          <text_log remove="remove"/>
-          <metric_log remove="remove"/>
-          <asynchronous_metric_log remove="remove"/>
-          <part_log remove="remove"/>
+          <trace_log remove="1"/>
+          <text_log remove="1"/>
+          <query_log remove="1"/>
+          <query_thread_log remove="1"/>
+          <part_log remove="1"/>
+          <metric_log remove="1"/>
+          <asynchronous_metric_log remove="1"/>
+          <processors_profile_log remove="1"/>
+          <query_metric_log remove="1"/>
+          <error_log remove="1"/>
+          <crash_log remove="1"/>
+          <opentelemetry_span_log remove="1"/>
+          <session_log remove="1"/>
+          <transactions_info_log remove="1"/>
+          <backup_log remove="1"/>
         </clickhouse>
     clusters:
       - layout:
@@ -98,7 +106,7 @@ spec:
         - 127.0.0.1
         - 0.0.0.0/0
         - ::/0
-      clickhouse_root/password_sha256_hex: <SHA256_HEX_PASSWORD>
+      clickhouse_root/password_sha256_hex: <SHA256_HEX_PASSWORD> # [!code callout]
   defaults:
     templates:
       dataVolumeClaimTemplate: default
@@ -152,6 +160,26 @@ spec:
               storage: 15Gi
 ```
 
+<Callouts>
+
+1. Additional ClickHouse configuration file for disabling system logs that are not required by NetObserv. The `99-` prefix makes the file load after the default configuration, and `remove="1"` removes the corresponding log configuration entries.
+2. SHA-256 hash of the password for the ClickHouse user `clickhouse_root`. Generate the hash from the original plaintext password and replace `<SHA256_HEX_PASSWORD>` with the command output.
+
+</Callouts>
+
+For example, to use `NetObserv@123` as the ClickHouse password, run:
+
+```bash
+printf '%s' 'NetObserv@123' | sha256sum | awk '{print $1}'
+```
+
+Use the generated hash in `clickhouse_root/password_sha256_hex`.
+When you create the `ck-auth` secret later, use `clickhouse_root` as the username and the original plaintext password as the password.
+
+If you want to use a different ClickHouse username, replace `clickhouse_root` in both `clickhouse_root/networks/ip` and `clickhouse_root/password_sha256_hex`.
+For example, for a user named `netobserv_user`, use `netobserv_user/networks/ip` and `netobserv_user/password_sha256_hex`.
+Then use the same username in the `ck-auth` secret.
+
 After the ClickHouse instance is ready, get the service endpoint by inspecting field `.status.endpoint` of the ClickHouseInstallation instance.
 You can also run the following command to get the endpoint:
 
@@ -190,9 +218,12 @@ This secret is referenced by `.spec.clickhouse.authSecret.name` in the FlowColle
 1. Create a local file named _ck-auth.env_ with the following content:
 
     ```ini
-    username=<USERNAME>
-    password=<PASSWORD>
+    username=clickhouse_root
+    password=<PLAINTEXT_PASSWORD>
     ```
+
+    If you use the ClickHouseInstallation example in this section, set `password` to the original plaintext password that was used to generate `<SHA256_HEX_PASSWORD>`.
+    If you use a different ClickHouse username, set `username` to that value.
 
 2. Create the Kubernetes secret:
 


### PR DESCRIPTION
## Summary
- backport NetObserv ClickHouse credential guidance
- backport Kube-OVN Egress Gateway capacity guidance

## Verification
- yarn lint