### PR TITLE
docs: clarify customInterfaces must use VLAN sub-interface in MetalLB underlay config

### DIFF
--- a/docs/en/configure/networking/how_to/kube_ovn/config_metallb_underlay.mdx
+++ b/docs/en/configure/networking/how_to/kube_ovn/config_metallb_underlay.mdx
@@ -66,6 +66,12 @@ metadata:
 spec:
   defaultInterface: underlay0.341
   autoCreateVlanSubinterfaces: true  # Automatically creates VLAN sub-interfaces (e.g., underlay0.341) if only parent interface (underlay0) exists
+  # If customInterfaces are used, each interface MUST also be the VLAN sub-interface
+  # (parent interface name + VLAN suffix, e.g., underlay0.341), not the parent interface
+  # customInterfaces:
+  #   - interface: underlay0.341
+  #     nodes:
+  #       - node1
 
 ---
 apiVersion: kubeovn.io/v1
@@ -79,6 +85,8 @@ status:
   subnets:
   - ovn-default
 ```
+
+> ⚠️ **Important**: If the `ProviderNetwork` specifies per-node interfaces via `customInterfaces`, each `customInterfaces[].interface` **must also use the VLAN sub-interface** (parent interface name + VLAN suffix, e.g., `underlay0.341`), not the parent interface (e.g., `underlay0`). Leaving a parent interface in `customInterfaces` prevents MetalLB LoadBalancer traffic from reaching the backend Pods.
 
 > ⚠️ **Warning**: When modifying the `ProviderNetwork` or `Vlan` resources individually, the Underlay network connectivity will be interrupted. Network connectivity will only be restored after both resources are fully configured and in sync. Plan configuration changes during maintenance windows to minimize service disruption.
 


### PR DESCRIPTION
In step 1 (Configure ProviderNetwork), if `customInterfaces` is present, each `customInterfaces[].interface` must also be the VLAN sub-interface (e.g., `underlay0.341`), not the parent interface.