### PR TITLE
AIT-71977: add ACP 4.4 admin gate upgrade docs

### DIFF
--- a/docs/en/ui/cli_tools/ac/upgrading-clusters.md
+++ b/docs/en/ui/cli_tools/ac/upgrading-clusters.md
@@ -226,6 +226,8 @@ Interpret the states as follows:
 
 If no preflight data is available yet, treat it as "no result yet", not as "all checks passed".
 
+If `AdminAckRequired` is `Failed`, an administrator acknowledgement gate applies to the current upgrade target. Review the gate, complete the required manual checks, write the acknowledgement, and then run `ac adm upgrade status --cluster=<cluster>` again to confirm that the check passes.
+
 ### Upgrade Stages
 
 After the upgrade enters execution, the status output shows stage and operation progress.
@@ -271,6 +273,29 @@ When `ac adm upgrade` shows a desired target but the upgrade is not moving:
 1. Run `ac adm upgrade status`.
 2. Check whether any preflight item is in `Retry` or `Failed`.
 3. Review whether upgrade stages have started.
+
+When `ac adm upgrade status --cluster=<cluster>` shows `AdminAckRequired` in `Failed` state:
+
+1. Inspect the release-provided gates from the global cluster:
+
+   ```bash
+   kubectl -n cpaas-system get configmap admin-gates -o yaml
+   ```
+
+2. For ACP 4.4 upgrades to Kubernetes 1.35, complete the [ACP 4.4 Kubernetes 1.35 node readiness checks](/upgrade/pre-upgrade.mdx#kubernetes-135-node-readiness) on every production node in the target cluster.
+
+3. Write the acknowledgement to the global-side `admin-acks` ConfigMap:
+
+   ```bash
+   kubectl -n cpaas-system patch configmap admin-acks --type merge \
+     -p '{"data":{"ack-4.4-kubernetes-1.35-kernel-update":"true"}}'
+   ```
+
+4. Confirm that the preflight check passes:
+
+   ```bash
+   ac adm upgrade status --cluster=<cluster>
+   ```
 
 When the upgrade is already in progress:
 

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -23,6 +23,37 @@ On Immutable Infrastructure (Huawei DCS, VMware vSphere, Huawei Cloud Stack, and
 * If any workload cluster is outside that compatible range, upgrade that workload cluster first until it enters the ACP 4.3 compatible range before upgrading the global tier.
 * A workload cluster can be upgraded only to a Distribution Version that the global tier has already reached.
 
+## ACP 4.4 Kubernetes 1.35 Node Readiness \{#kubernetes-135-node-readiness}
+
+ACP 4.4 upgrades clusters to Kubernetes 1.35. Before you acknowledge the Kubernetes 1.35 administrator gate, verify every production node that will run the target cluster.
+
+Run the checks through SSH on each node, or use an approved node shell. For example:
+
+```bash
+kubectl debug node/<node-name> -it --image=<approved-debug-image>
+chroot /host
+```
+
+On each node, verify the Linux kernel version:
+
+```bash
+uname -r
+```
+
+The kernel must be `5.8` or later and must also be within the ACP supported operating system and kernel matrix for the target release.
+
+Verify that the node uses cgroup v2:
+
+```bash
+stat -fc %T /sys/fs/cgroup/
+```
+
+The expected output is:
+
+```text
+cgroup2fs
+```
+
 ## Download the Packages for Offline Environments
 
 A production maintenance window typically upgrades **<Term name="productShort" /> Core**, the **Aligned plugins** (cluster plugins and operators released together with the same ACP version), and the in-use **Agnostic plugins** (independently released cluster plugins and operators) in the same window. Prepare every package the cluster currently uses before the upgrade starts, even when an Agnostic plugin upgrade is technically optional. Holding back an Agnostic plugin during the window often forces a second maintenance window later.

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -127,6 +127,7 @@ The default check set includes:
 
 - `ResourcePatchUpgradeable`
 - `ClusterVersionUpgradeable`
+- `AdminAckRequired`
 - `VersionUpgradePath`
 - `KubernetesVersionSupported`
 - `DockerRuntimeUnsupported`
@@ -157,6 +158,44 @@ The default annotation key is `config.cpaas.io/exempt-for-ver`.
 kubectl annotate resourcepatches <rp-name> \
   config.cpaas.io/exempt-for-ver=4.3.0 \
   --overwrite
+```
+
+### Handle administrator acknowledgement gates \{#handle-administrator-acknowledgement-gates}
+
+If `AdminAckRequired` fails, the target release contains an administrator acknowledgement gate that applies to the current cluster version. The release provides gate definitions in `cpaas-system/admin-gates`. Administrators record completed acknowledgements in `cpaas-system/admin-acks`.
+
+Inspect the current gates:
+
+```bash
+kubectl -n cpaas-system get configmap admin-gates -o yaml
+```
+
+For ACP 4.4 upgrades to Kubernetes 1.35, the built-in gate key is:
+
+```text
+ack-4.4-kubernetes-1.35-kernel-update
+```
+
+Before acknowledging this gate, complete the [ACP 4.4 Kubernetes 1.35 node readiness checks](./pre-upgrade.mdx#kubernetes-135-node-readiness) on every production node.
+
+After the node checks pass, write the acknowledgement:
+
+```bash
+kubectl -n cpaas-system patch configmap admin-acks --type merge \
+  -p '{"data":{"ack-4.4-kubernetes-1.35-kernel-update":"true"}}'
+```
+
+Run preflight again:
+
+```bash
+bash upgrade.sh --preflight
+```
+
+Confirm that `AdminAckRequired` passes:
+
+```bash
+kubectl -n cpaas-system get cvsh global \
+  -o jsonpath='{range .status.preflight.checks[?(@.name=="AdminAckRequired")]}{.state}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
 ```
 
 If temporary troubleshooting requires specific checks to be disabled, configure `cpaas-system/cvo-config`:

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -75,6 +75,30 @@ If preflight does not pass, do not submit the upgrade request until all blocking
 
 For preflight block handling patterns, see [Handle preflight blocks when needed](./upgrade_global_cluster.mdx#handle-preflight-blocks-when-needed).
 
+If `AdminAckRequired` fails, handle the administrator acknowledgement gate before the workload-cluster maintenance window continues. Workload-cluster preflight reads the gate definitions and acknowledgements from the global-side `cpaas-system/admin-gates` and `cpaas-system/admin-acks` ConfigMaps.
+
+Inspect the current gates from a global-cluster context:
+
+```bash
+kubectl -n cpaas-system get configmap admin-gates -o yaml
+```
+
+For ACP 4.4 upgrades to Kubernetes 1.35, complete the [ACP 4.4 Kubernetes 1.35 node readiness checks](./pre-upgrade.mdx#kubernetes-135-node-readiness) on every production node in the target workload cluster. Then write the acknowledgement in `admin-acks`:
+
+```bash
+kubectl -n cpaas-system patch configmap admin-acks --type merge \
+  -p '{"data":{"ack-4.4-kubernetes-1.35-kernel-update":"true"}}'
+```
+
+Run workload-cluster preflight again and confirm that `AdminAckRequired` passes:
+
+```bash
+bash upgrade.sh --cluster=<cluster> --preflight
+
+kubectl -n cpaas-system get cvsh <cluster> \
+  -o jsonpath='{range .status.preflight.checks[?(@.name=="AdminAckRequired")]}{.state}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+```
+
 ### Request the upgrade
 
 **When:** during the maintenance window, after preflight passes.

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -75,30 +75,6 @@ If preflight does not pass, do not submit the upgrade request until all blocking
 
 For preflight block handling patterns, see [Handle preflight blocks when needed](./upgrade_global_cluster.mdx#handle-preflight-blocks-when-needed).
 
-If `AdminAckRequired` fails, handle the administrator acknowledgement gate before the workload-cluster maintenance window continues. Workload-cluster preflight reads the gate definitions and acknowledgements from the global-side `cpaas-system/admin-gates` and `cpaas-system/admin-acks` ConfigMaps.
-
-Inspect the current gates from a global-cluster context:
-
-```bash
-kubectl -n cpaas-system get configmap admin-gates -o yaml
-```
-
-For ACP 4.4 upgrades to Kubernetes 1.35, complete the [ACP 4.4 Kubernetes 1.35 node readiness checks](./pre-upgrade.mdx#kubernetes-135-node-readiness) on every production node in the target workload cluster. Then write the acknowledgement in `admin-acks`:
-
-```bash
-kubectl -n cpaas-system patch configmap admin-acks --type merge \
-  -p '{"data":{"ack-4.4-kubernetes-1.35-kernel-update":"true"}}'
-```
-
-Run workload-cluster preflight again and confirm that `AdminAckRequired` passes:
-
-```bash
-bash upgrade.sh --cluster=<cluster> --preflight
-
-kubectl -n cpaas-system get cvsh <cluster> \
-  -o jsonpath='{range .status.preflight.checks[?(@.name=="AdminAckRequired")]}{.state}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
-```
-
 ### Request the upgrade
 
 **When:** during the maintenance window, after preflight passes.


### PR DESCRIPTION
## Summary
- Add ACP 4.4 Kubernetes 1.35 node readiness checks for the admin gate acknowledgement.
- Document `AdminAckRequired`, `admin-gates`, `admin-acks`, and the `ack-4.4-kubernetes-1.35-kernel-update` acknowledgement flow for global and workload upgrades.
- Expand AC CLI troubleshooting for `AdminAckRequired` preflight failures.

## Test Plan
- [x] `yarn lint`
- [x] `yarn build`
- [x] `git diff --check`