### PR TITLE
docs(upgrade): add PXC removal warning to appservice upgrade page

### DIFF
--- a/docs/en/appservice/upgrade.mdx
+++ b/docs/en/appservice/upgrade.mdx
@@ -5,6 +5,15 @@ en: Upgrade
 
 # Upgrade
 
+:::warning
+PXC Removal in Alauda Database Service for MySQL v4.3.0
+
+**MySQL-PXC is deprecated** and **removed** starting from Alauda Database Service for MySQL v4.3.0. Existing PXC instances will continue running but are no longer managed by the MySQL operator. If you have PXC instances, you **must migrate them to MySQL-MGR before upgrading** to MySQL Operator v4.3.0 or later.
+
+- **Migration Guide**: See <ExternalSiteLink name="mysql-mgr" href="/how_to/35-migrate-from-pxc" children="Migrate MySQL-PXC to MySQL-MGR" /> for comprehensive step-by-step instructions covering schema compatibility, character sets, users, and privileges.
+- **MySQL Operator Upgrade Guide**: See <ExternalSiteLink name="mysql-mgr" href="/upgrade" children="Upgrade Guide" /> for pre-upgrade checklists, upgrade scenarios, and emergency response procedures.
+:::
+
 Alauda Container Platform Data Services Essentials requires a manual upgrade. After upgrading the platform, follow the steps below to upgrade the plugin:
 
 1. Log in to the platform and navigate to **Marketplace** > **Cluster Plugins**.


### PR DESCRIPTION
## What

Adds the MySQL-PXC removal `:::warning` block to the App Services **Upgrade** page (`docs/en/appservice/upgrade.mdx`) on `master`.

## Why

`release-4.3` already carries this warning, but `master` does not — PR #612, which was meant to add the PXC deprecation banners to `master`, remains unmerged. As a result, users reading the App Services upgrade guide on the current docs branch are not told that MySQL-PXC is removed in MySQL v4.3.0 and that PXC instances must be migrated to MySQL-MGR before upgrading.

This change uses the exact wording already published on `release-4.3` for consistency, including the migration-guide and operator-upgrade-guide `<ExternalSiteLink>` references.

## Note

The four platform-level `upgrade/*` pages (`pre-upgrade`, `upgrade_global_cluster`, `upgrade_workload_cluster`) also lack the banner on `master` (part of PR #612's original scope). This PR intentionally covers only the App Services upgrade page; the platform pages can follow separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)