### PR TITLE
docs(kube-ovn): add U2O overlay-only routing option

### DIFF
--- a/docs/en/networking/how_to/kube_ovn/underlay_overlay_st.mdx
+++ b/docs/en/networking/how_to/kube_ovn/underlay_overlay_st.mdx
@@ -25,7 +25,7 @@ To achieve automatic interconnection between Underlay and Overlay subnets, you c
 
 ### Optional: Restrict U2O Routing to Overlay CIDRs
 
-By default, after `u2oInterconnection` is enabled, traffic from the Underlay subnet is rerouted through the U2O gateway. If the Underlay subnet should use U2O routing only for Overlay subnet CIDRs and continue to use the physical gateway for other destinations, enable `u2oFeatures.overlayOnlyRouting` on the same Underlay subnet.
+To route only traffic destined for Overlay subnet CIDRs through the U2O gateway, enable `u2oFeatures.overlayOnlyRouting` on the same Underlay subnet. Traffic to other destinations continues to use the physical gateway.
 
 ```yaml
 spec:
@@ -34,7 +34,7 @@ spec:
     overlayOnlyRouting: true
 ```
 
-This option can be enabled only when `u2oInterconnection` is `true`, and only on Underlay subnets with `spec.vlan` configured.
+This option requires `u2oInterconnection: true`.
 
 ## Isolation Between Underlay Subnets with u2oInterconnection Enabled
 

--- a/docs/en/networking/how_to/kube_ovn/underlay_overlay_st.mdx
+++ b/docs/en/networking/how_to/kube_ovn/underlay_overlay_st.mdx
@@ -23,6 +23,19 @@ To achieve automatic interconnection between Underlay and Overlay subnets, you c
 
 **Note**: Existing compute components in the Underlay subnet need to be recreated for the changes to take effect.
 
+### Optional: Restrict U2O Routing to Overlay CIDRs
+
+By default, after `u2oInterconnection` is enabled, traffic from the Underlay subnet is rerouted through the U2O gateway. If the Underlay subnet should use U2O routing only for Overlay subnet CIDRs and continue to use the physical gateway for other destinations, enable `u2oFeatures.overlayOnlyRouting` on the same Underlay subnet.
+
+```yaml
+spec:
+  u2oInterconnection: true
+  u2oFeatures:
+    overlayOnlyRouting: true
+```
+
+This option can be enabled only when `u2oInterconnection` is `true`, and only on Underlay subnets with `spec.vlan` configured.
+
 ## Isolation Between Underlay Subnets with u2oInterconnection Enabled
 
 When multiple Underlay subnets have `u2oInterconnection: true` enabled, traffic between them no longer goes through the physical gateway but is routed directly via the internal OVN network.


### PR DESCRIPTION
## Summary
- Document the optional `u2oFeatures.overlayOnlyRouting` switch for U2O interconnection.
- Explain that it restricts U2O routing to Overlay subnet CIDRs while other destinations continue to use the physical gateway.
- Add the required YAML snippet and constraints from kube-ovn commit `6c46042dc96959555759a3a8e4f9f760bf309277`.

## Validation
- `git diff --check`