### PR TITLE
docs(upgrade): backport PKCE hardening and L5 plugin upgrade notes to master

### DIFF
--- a/docs/en/upgrade/overview.mdx
+++ b/docs/en/upgrade/overview.mdx
@@ -70,6 +70,12 @@ On **Immutable Infrastructure** clusters (DCS, vSphere, HCS), Kube-OVN is driven
 - **Global clusters**: Follow the validated `upgrade.sh`-based procedure. After the preparation phase completes, request the upgrade from the Web Console through the two-step RPCH review flow, use ACP CLI, or update `ClusterVersionShadow.spec.desiredUpdate` directly.
 - **Workload clusters**: Use the Web Console through the two-step RPCH review flow or use ACP CLI after the target Distribution Version becomes available for the workload cluster.
 
+## Post-upgrade Security Hardening
+
+After the global cluster and all workload clusters have reached ACP 4.3, complete PKCE security hardening by following [Disabling the PKCE Plain Method](/security/platform_security_configurations/disable_pkce_plain_method.mdx).
+
+After the global cluster reaches ACP 4.3, complete the required L5 plugin compatibility upgrades in [Upgrade the global cluster](./upgrade_global_cluster.mdx).
+
 ## Related Documentation
 
 - [Pre-upgrade](./pre-upgrade.mdx)

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -393,6 +393,15 @@ If you skipped pushing an Agnostic plugin during pre-upgrade and the Marketplace
     children="Upgrade Alauda DevOps"
   />
 
+- After all workload clusters have also reached ACP 4.3, complete PKCE hardening by following [Disabling the PKCE Plain Method](/security/platform_security_configurations/disable_pkce_plain_method.mdx).
+
+- ACP 4.3 fixes an API authentication issue where specific APIs could previously be accessed without authentication. After the global cluster reaches ACP 4.3, upgrade the following L5 plugins to ACP v4.3-compatible versions. Otherwise, their UI pages may fail to open:
+  - `Alauda DevOps v3`
+  - `Alauda AI Essentials`
+  - `Alauda Hyperflux`
+  - `Alauda Container Platform Data Services Essentials`
+- After upgrading the plugins, verify that each listed plugin UI page opens successfully.
+
 ## Global DR Procedure \{#global-dr-procedure}
 
 Use this procedure when the environment includes both a primary global cluster and a standby global cluster. The DR-specific steps below are in addition to the standard CVO workflow.

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -169,6 +169,10 @@ kubectl -n cpaas-system get cvsh <cluster> \
 
 </Steps>
 
+## After All Workload Clusters Reach ACP 4.3
+
+After all workload clusters reach ACP 4.3, complete PKCE security hardening by following [Disabling the PKCE Plain Method](/security/platform_security_configurations/disable_pkce_plain_method.mdx).
+
 ## Related Documentation
 
 - [Overview](./overview.mdx)


### PR DESCRIPTION
## Summary
- Three post-upgrade docs on `master` were missing the PKCE plain-method hardening reminder that exists on `release-4.3` (added by #658), leaving `disable_pkce_plain_method.mdx` unreferenced from any page:
  - `docs/en/upgrade/upgrade_global_cluster.mdx` — added the PKCE hardening bullet and the L5 plugin upgrade list (Alauda DevOps v3, Alauda AI Essentials, Alauda Hyperflux, Alauda Container Platform Data Services Essentials).
  - `docs/en/upgrade/overview.mdx` — added the `## Post-upgrade Security Hardening` section (PKCE hardening + L5 plugin upgrade pointers).
  - `docs/en/upgrade/upgrade_workload_cluster.mdx` — added the `## After All Workload Clusters Reach ACP 4.3` section (PKCE hardening reminder).
- `docs/en/security/platform_security_configurations/disable_pkce_plain_method.mdx` already existed on `master` (content identical to `release-4.3`); this PR links it in from all three places it's linked from on `release-4.3`.
- Left `docs/en/overview/glossary.mdx` untouched: `master`'s OIDC glossary entry intentionally links to a dedicated OIDC Management page instead, and its whole glossary structure has diverged from `release-4.3` — not a simple missing-content gap.
- Version numbers kept as "ACP 4.3" to match the rest of `master`'s upgrade docs, which have not yet been bumped to ACP 4.4 anywhere.

## Test plan
- [x] `npx doom lint docs -g en/upgrade/upgrade_global_cluster.mdx -g en/upgrade/overview.mdx -g en/upgrade/upgrade_workload_cluster.mdx` passes with 0 errors/warnings
- [x] Diffed each section against `release-4.3` to confirm wording matches the existing shipped content