### PR TITLE
chore: bump @alauda/doom 2.5.1 → 2.5.4 (align local lint with CI) [release-4.3]

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "update-ac-manual": "node scripts/update-ac-manual.js"
   },
   "dependencies": {
-    "@alauda/doom": "^2.5.1"
+    "@alauda/doom": "^2.5.4"
   },
   "devDependencies": {
     "prettier": "^3.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,29 +12,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alauda/doom-export@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@alauda/doom-export@npm:0.4.1"
+"@alauda/doom-export@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "@alauda/doom-export@npm:0.4.2"
   dependencies:
-    "@playwright/browser-chromium": "npm:1.57.0"
+    "@playwright/browser-chromium": "npm:1.61.0"
     cli-progress: "npm:^3.12.0"
     html-entities: "npm:^2.6.0"
     pdf-lib: "npm:^1.17.1"
     pdf-merger-js: "npm:^5.1.2"
-    playwright: "npm:1.57.0"
+    playwright: "npm:1.61.0"
     yoctocolors: "npm:^2.1.2"
-  checksum: 10c0/bd72806e270814d6245f08f549f062e6b8531b1d4a282db79dd00278d3d0750a45bec51800bb3671cab8eb3c0cb3e584871de2feac399e11694718200d9c3963
+  checksum: 10c0/cebd88d3a26f0e761ee22c9c2032500f0a5f67af83ed0bd3b795f14551a2ec4db5ee9f860a7188afb90ed4a6f53b3687d9b7a23cb625ae006c1dab183b51d57d
   languageName: node
   linkType: hard
 
-"@alauda/doom@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "@alauda/doom@npm:2.5.1"
+"@alauda/doom@npm:^2.5.4":
+  version: 2.5.4
+  resolution: "@alauda/doom@npm:2.5.4"
   dependencies:
     "@alauda/doc-stream-sdk": "npm:0.1.0"
-    "@alauda/doom-export": "npm:^0.4.1"
+    "@alauda/doom-export": "npm:^0.4.2"
     "@cspell/eslint-plugin": "npm:^10.0.0"
-    "@eslint-react/eslint-plugin": "npm:^5.7.6"
+    "@eslint-react/eslint-plugin": "npm:^5.8.3"
     "@eslint/js": "npm:^10.0.1"
     "@inquirer/prompts": "npm:^8.4.3"
     "@openapi-contrib/openapi-schema-to-json-schema": "npm:^5.1.0"
@@ -42,20 +42,20 @@ __metadata:
     "@rsbuild/plugin-sass": "npm:^1.5.2"
     "@rsbuild/plugin-svgr": "npm:^2.0.2"
     "@rsbuild/plugin-yaml": "npm:^1.0.4"
-    "@rspress/core": "npm:2.0.11"
-    "@rspress/plugin-algolia": "npm:2.0.11"
-    "@rspress/plugin-sitemap": "npm:2.0.11"
-    "@rspress/shared": "npm:2.0.11"
-    "@shikijs/transformers": "npm:^4.0.2"
+    "@rspress/core": "npm:2.0.12"
+    "@rspress/plugin-algolia": "npm:2.0.12"
+    "@rspress/plugin-sitemap": "npm:2.0.12"
+    "@rspress/shared": "npm:2.0.12"
+    "@shikijs/transformers": "npm:^4.1.0"
     "@total-typescript/ts-reset": "npm:^0.6.1"
-    "@types/react": "npm:^19.2.14"
+    "@types/react": "npm:^19.2.15"
     ab64: "npm:^0.1.6"
     chokidar: "npm:^5.0.0"
     clsx: "npm:^2.1.1"
     commander: "npm:^14.0.3"
     ejs: "npm:^5.0.2"
     es-toolkit: "npm:^1.46.1"
-    eslint: "npm:^10.3.0"
+    eslint: "npm:^10.4.0"
     eslint-plugin-mdx: "npm:^3.7.0"
     globals: "npm:^17.6.0"
     hastscript: "npm:^9.0.1"
@@ -68,13 +68,13 @@ __metadata:
     mdast-util-to-markdown: "npm:^2.1.2"
     mdast-util-to-string: "npm:^4.0.0"
     mermaid: "npm:^11.15.0"
-    openai: "npm:^6.37.0"
+    openai: "npm:^6.38.0"
     openapi-types: "npm:^12.1.3"
     p-ratelimit: "npm:^1.0.1"
     picomatch: "npm:^4.0.4"
     pluralize: "npm:^8.0.0"
     react-markdown: "npm:^10.1.0"
-    react-tooltip: "npm:^6.0.2"
+    react-tooltip: "npm:^6.0.3"
     rehype-raw: "npm:^7.0.0"
     rehype-sanitize: "npm:^6.0.0"
     remark-directive: "npm:^4.0.0"
@@ -95,7 +95,7 @@ __metadata:
     tinyglobby: "npm:^0.2.16"
     type-fest: "npm:^5.6.0"
     typescript: "npm:^6.0.3"
-    typescript-eslint: "npm:^8.59.3"
+    typescript-eslint: "npm:^8.59.4"
     unified: "npm:^11.0.5"
     unified-lint-rule: "npm:^3.0.1"
     unist-util-position: "npm:^5.0.0"
@@ -105,7 +105,7 @@ __metadata:
     yoctocolors: "npm:^2.1.2"
   bin:
     doom: lib/cli/index.js
-  checksum: 10c0/c7f317b39f2d58aac13ff7cfefab8873b5ba59a5449600df141b584a38957ac146e5aaae2188a64b31a733c98dc1146c2bc0d3bd460c087ee4906800f9257b51
+  checksum: 10c0/01ec566c5b1a6429c24b4f98cdc76de590e715d5e3591563d6b3f561457da9376b4419ae383f85de6bcbbd737fb469aa1a8b95b17f23236c7dcd9c9dc26a8108
   languageName: node
   linkType: hard
 
@@ -974,31 +974,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@emnapi/core@npm:1.10.0"
+"@emnapi/core@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/core@npm:1.11.1"
   dependencies:
-    "@emnapi/wasi-threads": "npm:1.2.1"
+    "@emnapi/wasi-threads": "npm:1.2.2"
     tslib: "npm:^2.4.0"
-  checksum: 10c0/f51d08227857b60632de7714d708124f0e100a1462dde6df8221760939aa3204a73193830371830fac0716f3ccd2129f2cac1b17cd7d7958bc4da9018a296edb
+  checksum: 10c0/2c6defdac2d1d26090384655d7d6c9614fa553853b1760597686749e9375dc2aa0dae80a2615b81c254600f5d531d07d8466cde0d331a8caae64b93f3ca5937e
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@emnapi/runtime@npm:1.10.0"
+"@emnapi/runtime@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/runtime@npm:1.11.1"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
+  checksum: 10c0/04332fb62076afc440aa23316c04bec42f584ca8b074e5507d08e2b33a47cbe0493b1aadb8f3c1057b64ae1e17f5bde1a7bc37f7facc9d0bc25c18197cbd366f
   languageName: node
   linkType: hard
 
-"@emnapi/wasi-threads@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@emnapi/wasi-threads@npm:1.2.1"
+"@emnapi/wasi-threads@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@emnapi/wasi-threads@npm:1.2.2"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
+  checksum: 10c0/f0dc8269d6b20ae5a7c7b36e7a6a333452009d461038ef4febb29da2f3f78c1e2b1576d7e8970a5c5789ed3caedc1f80f5b0c2a5373bdaf8d03b20432bb55747
   languageName: node
   linkType: hard
 
@@ -1020,118 +1020,118 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:5.7.7":
-  version: 5.7.7
-  resolution: "@eslint-react/ast@npm:5.7.7"
+"@eslint-react/ast@npm:5.13.1":
+  version: 5.13.1
+  resolution: "@eslint-react/ast@npm:5.13.1"
   dependencies:
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@typescript-eslint/types": "npm:^8.63.0"
+    "@typescript-eslint/typescript-estree": "npm:^8.63.0"
+    "@typescript-eslint/utils": "npm:^8.63.0"
     string-ts: "npm:^2.3.1"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/c2566f90041575d3910cb73e17528c0274ebd2ac84d09ead4f7ee722efd6ea4e96cbd8124c16570149dbce71788e95a0b226e911c2417876cb6858ca494b1db5
+  checksum: 10c0/3d2e5a4b4311974cf98699af7564e3121ef70caac4b19694c2b747857a29f2142f5a7e0b64b8089198cbfd0271a867db18b5bf5da605fc56ad61c8f218fba57f
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:5.7.7":
-  version: 5.7.7
-  resolution: "@eslint-react/core@npm:5.7.7"
+"@eslint-react/core@npm:5.13.1":
+  version: 5.13.1
+  resolution: "@eslint-react/core@npm:5.13.1"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.7"
-    "@eslint-react/eslint": "npm:5.7.7"
-    "@eslint-react/jsx": "npm:5.7.7"
-    "@eslint-react/shared": "npm:5.7.7"
-    "@eslint-react/var": "npm:5.7.7"
-    "@typescript-eslint/scope-manager": "npm:^8.59.3"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.13.1"
+    "@eslint-react/eslint": "npm:5.13.1"
+    "@eslint-react/jsx": "npm:5.13.1"
+    "@eslint-react/shared": "npm:5.13.1"
+    "@eslint-react/var": "npm:5.13.1"
+    "@typescript-eslint/scope-manager": "npm:^8.63.0"
+    "@typescript-eslint/types": "npm:^8.63.0"
+    "@typescript-eslint/utils": "npm:^8.63.0"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/2b5d4dc419015c5dd20b8a9615040a01af9b22a86ddab6492d22e15e267bd1a491bb1d40c1112cd3bd210b27e87c833fb2acce3c7bbcbd389848825bff6c5df4
+  checksum: 10c0/5a5293eb4f2ae9740524678a61dd6b37a2645bf6b8175f1b84c6e0746db869adfb40fc35827f4cb9d5faadc490e5b9fb44019c0bc3b6cb1aed6a41e272a25197
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^5.7.6":
-  version: 5.7.7
-  resolution: "@eslint-react/eslint-plugin@npm:5.7.7"
+"@eslint-react/eslint-plugin@npm:^5.8.3":
+  version: 5.13.1
+  resolution: "@eslint-react/eslint-plugin@npm:5.13.1"
   dependencies:
-    "@eslint-react/shared": "npm:5.7.7"
-    eslint-plugin-react-dom: "npm:5.7.7"
-    eslint-plugin-react-jsx: "npm:5.7.7"
-    eslint-plugin-react-naming-convention: "npm:5.7.7"
-    eslint-plugin-react-rsc: "npm:5.7.7"
-    eslint-plugin-react-web-api: "npm:5.7.7"
-    eslint-plugin-react-x: "npm:5.7.7"
+    "@eslint-react/shared": "npm:5.13.1"
+    eslint-plugin-react-dom: "npm:5.13.1"
+    eslint-plugin-react-jsx: "npm:5.13.1"
+    eslint-plugin-react-naming-convention: "npm:5.13.1"
+    eslint-plugin-react-rsc: "npm:5.13.1"
+    eslint-plugin-react-web-api: "npm:5.13.1"
+    eslint-plugin-react-x: "npm:5.13.1"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/bf9c6bac8e9f29d54499df894faa6e62ca6404f9ac9eb94fccca99c70f0f8b165d235997db3ae987dc6877a04dd5f892105126fbcff9d6fe0b8cbf1f26d84c03
+  checksum: 10c0/8e930635a4dbb06811b7fc5e0ea87b6f058a898a308400445c01d1d1e3cc3168f67feb509f02eb2b368e335412d7ba50b3f3b0e38fbdbd3e3a250be062b75485
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint@npm:5.7.7":
-  version: 5.7.7
-  resolution: "@eslint-react/eslint@npm:5.7.7"
+"@eslint-react/eslint@npm:5.13.1":
+  version: 5.13.1
+  resolution: "@eslint-react/eslint@npm:5.13.1"
   dependencies:
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.63.0"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/3fe088c4f46ca955b50e51924132bb1aa45eaf45d1156b4e7763ca70169179edce7ec662b2b4467ddc991fd143167e73f7571782bfde8ef80f46cdcd9f900930
+  checksum: 10c0/969b34446e0b81f6b857ea223083e6e06403869ca36f994beea50421078aa228394c47c878c3ebffb125e07918ba4973030dbc7bb8aed4728f422e43ae39e33a
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:5.7.7":
-  version: 5.7.7
-  resolution: "@eslint-react/jsx@npm:5.7.7"
+"@eslint-react/jsx@npm:5.13.1":
+  version: 5.13.1
+  resolution: "@eslint-react/jsx@npm:5.13.1"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.7"
-    "@eslint-react/eslint": "npm:5.7.7"
-    "@eslint-react/shared": "npm:5.7.7"
-    "@eslint-react/var": "npm:5.7.7"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.13.1"
+    "@eslint-react/eslint": "npm:5.13.1"
+    "@eslint-react/shared": "npm:5.13.1"
+    "@eslint-react/var": "npm:5.13.1"
+    "@typescript-eslint/types": "npm:^8.63.0"
+    "@typescript-eslint/utils": "npm:^8.63.0"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/3ad9c1ed77cfeb4cf78135efd77f828d53aca8c0e37d8a249f26a647c1bfeb403aee268321529c37775f32985ffe6db7e6c711503ce137a048f8294f88c81467
+  checksum: 10c0/43e9140b93f83f02e4432f4988b5ebd20ee6eeafbbe31bed4441e349842ac2bd93ebab6af2e4dcc81cfde5b340753e6110d2cb5db79b2b3c8cd2d5a577113a83
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:5.7.7":
-  version: 5.7.7
-  resolution: "@eslint-react/shared@npm:5.7.7"
+"@eslint-react/shared@npm:5.13.1":
+  version: 5.13.1
+  resolution: "@eslint-react/shared@npm:5.13.1"
   dependencies:
-    "@eslint-react/eslint": "npm:5.7.7"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/eslint": "npm:5.13.1"
+    "@typescript-eslint/utils": "npm:^8.63.0"
     ts-pattern: "npm:^5.9.0"
-    zod: "npm:^4.4.3"
+    zod: "npm:^3.25.0 || ^4.0.0"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/1072784e55b80af7063958ea732bea4adc92582d8000f556811d3a6d8918608a667ebaf4b421e5e24cfe61987992a02fac84923dedb6cce6f66680a89ea0b44e
+  checksum: 10c0/a54ddd82005a2bd00c37869c790b4b84442286c7f9110f0eb0df7e7408923339d9956497efce8599944bd47de46516d6e8ab8d22602abfcaa2756c9df8859a91
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:5.7.7":
-  version: 5.7.7
-  resolution: "@eslint-react/var@npm:5.7.7"
+"@eslint-react/var@npm:5.13.1":
+  version: 5.13.1
+  resolution: "@eslint-react/var@npm:5.13.1"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.7"
-    "@eslint-react/eslint": "npm:5.7.7"
-    "@typescript-eslint/scope-manager": "npm:^8.59.3"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.13.1"
+    "@eslint-react/eslint": "npm:5.13.1"
+    "@typescript-eslint/scope-manager": "npm:^8.63.0"
+    "@typescript-eslint/types": "npm:^8.63.0"
+    "@typescript-eslint/utils": "npm:^8.63.0"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/9dd32976606d95f91f7c0e55c689c2724a57cf6eb0c251ba7c68343ae425cef486e2fd4538f37bfb5443238fccc42aa4cc6696c4c8ed2d1147c4328a899c77fe
+  checksum: 10c0/7dccfa99fd1779237e7f6af1d477e0207119d77fce59d996d7d76c157d3d22e884b094b53f47625623675dcccfdb17551a928e76386cab34d6d3d9abe75c0756
   languageName: node
   linkType: hard
 
@@ -1146,12 +1146,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/config-helpers@npm:^0.5.5":
-  version: 0.5.5
-  resolution: "@eslint/config-helpers@npm:0.5.5"
+"@eslint/config-helpers@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@eslint/config-helpers@npm:0.6.0"
   dependencies:
     "@eslint/core": "npm:^1.2.1"
-  checksum: 10c0/18889c062cd6bdbd4cd92fe57318c44465ea66184aa0ba204a4420712c66764c64093a7905b6c2ffde23e51b268ca2cec1a39c605d336bebf17ee1ba4f0fc0bb
+  checksum: 10c0/f9af20e8b60b0ba27edb74b8eb40c0c5d51a9bf9baf9e053bb57833a87cb0a1c49b4dfaad88fc24d49c907ad1324c8a0b668684fa9c321351dac4bc9155ec10a
   languageName: node
   linkType: hard
 
@@ -1183,13 +1183,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/plugin-kit@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "@eslint/plugin-kit@npm:0.7.1"
+"@eslint/plugin-kit@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "@eslint/plugin-kit@npm:0.7.2"
   dependencies:
     "@eslint/core": "npm:^1.2.1"
     levn: "npm:^0.4.1"
-  checksum: 10c0/335b0c1c46fd906cb50bd5ce442b9cee18dc44342ce35c718ba4a63d1aa51d2797f16a517b2f4fe371ccd777b6862fafb2dc8195e00e69197ef4cb17ab32c01b
+  checksum: 10c0/aafba08077bcd6d7dde6c2e21db18086046a88f914f29971a84cac9ad2d48952ded1b293e665e523805297eff756522dafa16f0062195e2c7143dcd1d47d11ed
   languageName: node
   linkType: hard
 
@@ -1667,15 +1667,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
+"@napi-rs/wasm-runtime@npm:1.1.6":
+  version: 1.1.6
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.6"
   dependencies:
-    "@tybys/wasm-util": "npm:^0.10.1"
+    "@tybys/wasm-util": "npm:^0.10.3"
   peerDependencies:
     "@emnapi/core": ^1.7.1
     "@emnapi/runtime": ^1.7.1
-  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
+  checksum: 10c0/344518bf3ef65051dda4c00969f293aa4a21ab7dc7822b3f48519b17cd5eaa3f0bc34898d115d50ba59b1817a0cb905d46f7a7223c8249239cd14c28db388e10
   languageName: node
   linkType: hard
 
@@ -1977,29 +1977,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/browser-chromium@npm:1.57.0":
-  version: 1.57.0
-  resolution: "@playwright/browser-chromium@npm:1.57.0"
+"@playwright/browser-chromium@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@playwright/browser-chromium@npm:1.61.0"
   dependencies:
-    playwright-core: "npm:1.57.0"
-  checksum: 10c0/a997fb094279b26ff954cb1099ad28c32853e0259b129dc040af75f1eebf1b9aa25957b27e5c7b1f52a70c791944024bcb95139729ac3b9e4a9a033f6420e1ab
+    playwright-core: "npm:1.61.0"
+  checksum: 10c0/d2d15cfef07cbd09ffcb93cf03d99939ee8ad3e34cd24cc40e26e637df18f30a8324b0fbb9b8f83741296c5e34dc42ed5bb87fe23f3e23110388b9e2b5a83a16
   languageName: node
   linkType: hard
 
-"@rsbuild/core@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "@rsbuild/core@npm:2.0.5"
+"@rsbuild/core@npm:^2.0.6":
+  version: 2.1.5
+  resolution: "@rsbuild/core@npm:2.1.5"
   dependencies:
-    "@rspack/core": "npm:~2.0.2"
-    "@swc/helpers": "npm:^0.5.21"
+    "@rspack/core": "npm:~2.1.3"
+    "@swc/helpers": "npm:^0.5.23"
   peerDependencies:
     core-js: ">= 3.0.0"
   peerDependenciesMeta:
     core-js:
       optional: true
   bin:
-    rsbuild: bin/rsbuild.js
-  checksum: 10c0/675af0a11b17833d28891d47ec25cd13f612949552b52c6b6214a3faaa8ef943fedd20853c2aac0fe5a2019e830267bf14a6f9d4e79553075ac3fa5dbe4ed662
+    rsbuild: ./bin/rsbuild.js
+  checksum: 10c0/0200898540b67cd477ac6b91a51ab806ad79a6a9a6a1b5b2e9ec0c6e202caaf645dff74951bfb7a37db1b059f90f68ec61ae93dbb2d527d655514df4c7ddc50a
   languageName: node
   linkType: hard
 
@@ -2067,94 +2067,110 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rspack/binding-darwin-arm64@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-darwin-arm64@npm:2.0.3"
+"@rspack/binding-darwin-arm64@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-darwin-arm64@npm:2.1.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rspack/binding-darwin-x64@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-darwin-x64@npm:2.0.3"
+"@rspack/binding-darwin-x64@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-darwin-x64@npm:2.1.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-arm64-gnu@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-linux-arm64-gnu@npm:2.0.3"
+"@rspack/binding-linux-arm64-gnu@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-linux-arm64-gnu@npm:2.1.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-arm64-musl@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-linux-arm64-musl@npm:2.0.3"
+"@rspack/binding-linux-arm64-musl@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-linux-arm64-musl@npm:2.1.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-x64-gnu@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-linux-x64-gnu@npm:2.0.3"
+"@rspack/binding-linux-riscv64-gnu@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-linux-riscv64-gnu@npm:2.1.3"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-riscv64-musl@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-linux-riscv64-musl@npm:2.1.3"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-x64-gnu@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-linux-x64-gnu@npm:2.1.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-x64-musl@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-linux-x64-musl@npm:2.0.3"
+"@rspack/binding-linux-x64-musl@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-linux-x64-musl@npm:2.1.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rspack/binding-wasm32-wasi@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-wasm32-wasi@npm:2.0.3"
+"@rspack/binding-wasm32-wasi@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-wasm32-wasi@npm:2.1.3"
   dependencies:
-    "@emnapi/core": "npm:1.10.0"
-    "@emnapi/runtime": "npm:1.10.0"
-    "@napi-rs/wasm-runtime": "npm:1.1.4"
+    "@emnapi/core": "npm:1.11.1"
+    "@emnapi/runtime": "npm:1.11.1"
+    "@napi-rs/wasm-runtime": "npm:1.1.6"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-arm64-msvc@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-win32-arm64-msvc@npm:2.0.3"
+"@rspack/binding-win32-arm64-msvc@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-win32-arm64-msvc@npm:2.1.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-ia32-msvc@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-win32-ia32-msvc@npm:2.0.3"
+"@rspack/binding-win32-ia32-msvc@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-win32-ia32-msvc@npm:2.1.3"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-x64-msvc@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-win32-x64-msvc@npm:2.0.3"
+"@rspack/binding-win32-x64-msvc@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding-win32-x64-msvc@npm:2.1.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@rspack/binding@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding@npm:2.0.3"
+"@rspack/binding@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/binding@npm:2.1.3"
   dependencies:
-    "@rspack/binding-darwin-arm64": "npm:2.0.3"
-    "@rspack/binding-darwin-x64": "npm:2.0.3"
-    "@rspack/binding-linux-arm64-gnu": "npm:2.0.3"
-    "@rspack/binding-linux-arm64-musl": "npm:2.0.3"
-    "@rspack/binding-linux-x64-gnu": "npm:2.0.3"
-    "@rspack/binding-linux-x64-musl": "npm:2.0.3"
-    "@rspack/binding-wasm32-wasi": "npm:2.0.3"
-    "@rspack/binding-win32-arm64-msvc": "npm:2.0.3"
-    "@rspack/binding-win32-ia32-msvc": "npm:2.0.3"
-    "@rspack/binding-win32-x64-msvc": "npm:2.0.3"
+    "@rspack/binding-darwin-arm64": "npm:2.1.3"
+    "@rspack/binding-darwin-x64": "npm:2.1.3"
+    "@rspack/binding-linux-arm64-gnu": "npm:2.1.3"
+    "@rspack/binding-linux-arm64-musl": "npm:2.1.3"
+    "@rspack/binding-linux-riscv64-gnu": "npm:2.1.3"
+    "@rspack/binding-linux-riscv64-musl": "npm:2.1.3"
+    "@rspack/binding-linux-x64-gnu": "npm:2.1.3"
+    "@rspack/binding-linux-x64-musl": "npm:2.1.3"
+    "@rspack/binding-wasm32-wasi": "npm:2.1.3"
+    "@rspack/binding-win32-arm64-msvc": "npm:2.1.3"
+    "@rspack/binding-win32-ia32-msvc": "npm:2.1.3"
+    "@rspack/binding-win32-x64-msvc": "npm:2.1.3"
   dependenciesMeta:
     "@rspack/binding-darwin-arm64":
       optional: true
@@ -2163,6 +2179,10 @@ __metadata:
     "@rspack/binding-linux-arm64-gnu":
       optional: true
     "@rspack/binding-linux-arm64-musl":
+      optional: true
+    "@rspack/binding-linux-riscv64-gnu":
+      optional: true
+    "@rspack/binding-linux-riscv64-musl":
       optional: true
     "@rspack/binding-linux-x64-gnu":
       optional: true
@@ -2176,24 +2196,24 @@ __metadata:
       optional: true
     "@rspack/binding-win32-x64-msvc":
       optional: true
-  checksum: 10c0/7089971775d41224f2299189ae253eefff3533970b34008202f3e6b72776c9e238efc3412aca68aa95fec9c0f1155b25d96d40581332ecd0e35514718f5c612c
+  checksum: 10c0/b3e34d5cb373b6cfe4bd845231df6c50083f167177053f9819751d126eeab3a1296e85024a0c5c2fbf102e277d9c0a9eac376dfa8a608f1667547f644e43d2c7
   languageName: node
   linkType: hard
 
-"@rspack/core@npm:~2.0.2":
-  version: 2.0.3
-  resolution: "@rspack/core@npm:2.0.3"
+"@rspack/core@npm:~2.1.3":
+  version: 2.1.3
+  resolution: "@rspack/core@npm:2.1.3"
   dependencies:
-    "@rspack/binding": "npm:2.0.3"
+    "@rspack/binding": "npm:2.1.3"
   peerDependencies:
     "@module-federation/runtime-tools": ^0.24.1 || ^2.0.0
-    "@swc/helpers": ">=0.5.1"
+    "@swc/helpers": ^0.5.23
   peerDependenciesMeta:
     "@module-federation/runtime-tools":
       optional: true
     "@swc/helpers":
       optional: true
-  checksum: 10c0/767a1545f19cfc983994684c1725bcc4cefffc49095f7194376f840d1137cd4f9f93c40e58e091757da57a517f9219fd316c0e5c080f2b6040b11be976e6988b
+  checksum: 10c0/5da890b28cc1ef4d3ee5be5e2132ee4896c0e724b820d5b90882aec4b14a547bb98edd7603c43de5abaec5f4d7b4ffdda20e2aced3e8ada3f16036c02cdf4b6f
   languageName: node
   linkType: hard
 
@@ -2210,15 +2230,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rspress/core@npm:2.0.11":
-  version: 2.0.11
-  resolution: "@rspress/core@npm:2.0.11"
+"@rspress/core@npm:2.0.12":
+  version: 2.0.12
+  resolution: "@rspress/core@npm:2.0.12"
   dependencies:
     "@mdx-js/mdx": "npm:^3.1.1"
     "@mdx-js/react": "npm:^3.1.1"
-    "@rsbuild/core": "npm:^2.0.5"
+    "@rsbuild/core": "npm:^2.0.6"
     "@rsbuild/plugin-react": "npm:~2.0.0"
-    "@rspress/shared": "npm:2.0.11"
+    "@rspress/shared": "npm:2.0.12"
     "@shikijs/rehype": "npm:^4.0.2"
     "@types/unist": "npm:^3.0.3"
     "@unhead/react": "npm:^2.1.15"
@@ -2237,7 +2257,7 @@ __metadata:
     react-lazy-with-preload: "npm:^2.2.1"
     react-reconciler: "npm:0.33.0"
     react-render-to-markdown: "npm:19.0.1"
-    react-router-dom: "npm:^7.15.0"
+    react-router-dom: "npm:^7.15.1"
     rehype-external-links: "npm:^3.0.0"
     rehype-raw: "npm:^7.0.0"
     remark-cjk-friendly: "npm:^2.0.1"
@@ -2254,39 +2274,39 @@ __metadata:
     unist-util-visit-children: "npm:^3.0.0"
   bin:
     rspress: bin/rspress.js
-  checksum: 10c0/962d0ce4b401d6b82e9e0acedcc615832c29b76fbef8af983af343a08df5ffc85134cb3670dcc410ecb7ad192e858f5f7730256580e5754d2b42f248bee2ab32
+  checksum: 10c0/3de5e86107077e2ed769f59815e2804aedf3be616af3b14037bdbc9bbeea8c7106238d4912815848433f382f9c0708e546045ccb290b37d386035f86330b8dc8
   languageName: node
   linkType: hard
 
-"@rspress/plugin-algolia@npm:2.0.11":
-  version: 2.0.11
-  resolution: "@rspress/plugin-algolia@npm:2.0.11"
+"@rspress/plugin-algolia@npm:2.0.12":
+  version: 2.0.12
+  resolution: "@rspress/plugin-algolia@npm:2.0.12"
   dependencies:
     "@docsearch/css": "npm:^4.6.3"
     "@docsearch/react": "npm:^4.6.3"
   peerDependencies:
     "@rspress/core": ^2.0.10
-  checksum: 10c0/3693fa981c78b4e93816b08524b1e715ca8c03aa400461f271e405842f0a6f586e801b9560714398725fdbde60fc4cb7a0722213d93fe16e79cdb4d8f18ad6c2
+  checksum: 10c0/4ae7c5195decab8e259b4773386b28211bdfc3d13a06f87ea946592976e5a092214f0db82e0a3e74f589ba69236421859ee245afdbacaef5b551e2e821662c12
   languageName: node
   linkType: hard
 
-"@rspress/plugin-sitemap@npm:2.0.11":
-  version: 2.0.11
-  resolution: "@rspress/plugin-sitemap@npm:2.0.11"
+"@rspress/plugin-sitemap@npm:2.0.12":
+  version: 2.0.12
+  resolution: "@rspress/plugin-sitemap@npm:2.0.12"
   peerDependencies:
     "@rspress/core": ^2.0.10
-  checksum: 10c0/4583ceaa147713877f4ebaf5e74529d5569254b039d0bb7cd2be33f02c533bd4a82c4181d787da8e59c9adefdc4188337c0a277ee00f302f15f8f515cf5f2eb4
+  checksum: 10c0/86f4803df1abaaac140f7cfc7c8199bacbf2e900dc23f4a770223c9230e67731b4e6d97be6d313fc8e911c71bdd5f341b5f444163209b8dc8ddc9d7d68c315d4
   languageName: node
   linkType: hard
 
-"@rspress/shared@npm:2.0.11":
-  version: 2.0.11
-  resolution: "@rspress/shared@npm:2.0.11"
+"@rspress/shared@npm:2.0.12":
+  version: 2.0.12
+  resolution: "@rspress/shared@npm:2.0.12"
   dependencies:
-    "@rsbuild/core": "npm:^2.0.5"
+    "@rsbuild/core": "npm:^2.0.6"
     "@shikijs/rehype": "npm:^4.0.2"
     unified: "npm:^11.0.5"
-  checksum: 10c0/2d396c95019f8af01165e9506f4edc6033eb6e6609d6fa359c3a5b3a982cc15b39931eacb041cee67f4b16fdee896ccae0371a8ff4a139bf98b686015d48b115
+  checksum: 10c0/caeb2b513e44160d6664568223595308e89729974660f1ed0456b5b2d5351681fd5289acfeca46c51953fa4311920231dffca7810cc65083121f8480f521dca1
   languageName: node
   linkType: hard
 
@@ -2300,6 +2320,19 @@ __metadata:
     "@types/hast": "npm:^3.0.4"
     hast-util-to-html: "npm:^9.0.5"
   checksum: 10c0/0a8c56d50b2f67334e5e128b89f1e85844f60ae1dfbd4171e6e92242398678f6eaf91cd02f8418ac4abf4d81774e0ec9a83274a2e3f609c410e577520eadb0f5
+  languageName: node
+  linkType: hard
+
+"@shikijs/core@npm:4.3.1":
+  version: 4.3.1
+  resolution: "@shikijs/core@npm:4.3.1"
+  dependencies:
+    "@shikijs/primitive": "npm:4.3.1"
+    "@shikijs/types": "npm:4.3.1"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+    hast-util-to-html: "npm:^9.0.5"
+  checksum: 10c0/75faa9aba4251e412764844d2329862350ef31ac21d0f07658b8a975029bd25f192ef069e757e6689a8bd9f1b19999e6f47b308ce1dee7c352543f435dd5d189
   languageName: node
   linkType: hard
 
@@ -2344,6 +2377,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shikijs/primitive@npm:4.3.1":
+  version: 4.3.1
+  resolution: "@shikijs/primitive@npm:4.3.1"
+  dependencies:
+    "@shikijs/types": "npm:4.3.1"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10c0/33397d0d60842d74ce07db588dec3818241713c4812de6fe76c40a477e464d319f20f50f3dfa40ebc2c10964754a256d9bb4ac6f8b49a09fca1bc206a7c7b46f
+  languageName: node
+  linkType: hard
+
 "@shikijs/rehype@npm:^4.0.2":
   version: 4.0.2
   resolution: "@shikijs/rehype@npm:4.0.2"
@@ -2367,13 +2411,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/transformers@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@shikijs/transformers@npm:4.0.2"
+"@shikijs/transformers@npm:^4.1.0":
+  version: 4.3.1
+  resolution: "@shikijs/transformers@npm:4.3.1"
   dependencies:
-    "@shikijs/core": "npm:4.0.2"
-    "@shikijs/types": "npm:4.0.2"
-  checksum: 10c0/7c3ce7d356d1b02061b5ab4ff5d91098b45cca1f961e64a496c5fb9d2854fce6c7e033f113819b9290cd188efb4016f625fb70f590572ccb1f36983768fca3ff
+    "@shikijs/core": "npm:4.3.1"
+    "@shikijs/types": "npm:4.3.1"
+  checksum: 10c0/e36b8b15630c7c75ea75f455047260c2470a2de046a76c1f2d7053598503ea008b0740f8772a9a2436db7acf12b9458020aba80c7068be0af5daa23456b4cb27
   languageName: node
   linkType: hard
 
@@ -2384,6 +2428,16 @@ __metadata:
     "@shikijs/vscode-textmate": "npm:^10.0.2"
     "@types/hast": "npm:^3.0.4"
   checksum: 10c0/9df16cf9988fef0e8ac6e438bc90805ccea707700d169e8e16ab87617d14fb2eeac2a7ead310aa88398c04d1dde95f877c1b695567578e40e6845bce2f65fc73
+  languageName: node
+  linkType: hard
+
+"@shikijs/types@npm:4.3.1":
+  version: 4.3.1
+  resolution: "@shikijs/types@npm:4.3.1"
+  dependencies:
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10c0/e1586b7e8fc0610f9896c622307274c5876fe7f2a40919e08cde8947ef5022d545641c47763f29505eaad6e4b4f7c180890fd1c220146e5e75f69f384a4dc228
   languageName: node
   linkType: hard
 
@@ -2550,12 +2604,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:^0.5.21":
-  version: 0.5.21
-  resolution: "@swc/helpers@npm:0.5.21"
+"@swc/helpers@npm:^0.5.23":
+  version: 0.5.23
+  resolution: "@swc/helpers@npm:0.5.23"
   dependencies:
     tslib: "npm:^2.8.0"
-  checksum: 10c0/692018ec8a9f7ea5ea3fe576fea5af1a782c8bc1752fcb60f949b482fb2521609d1d3710908aebae67086f152e57d231d59b08f4653fd20a2e3e0fa4a34e6322
+  checksum: 10c0/02da7b4df465693933ecd4851cc193ec729c309939c8a84eccae5ec0010aafc3894e713b8ef8d13a6ba401759f0e900c88e2dcfef5872c27bb91e70f73275cce
   languageName: node
   linkType: hard
 
@@ -2566,12 +2620,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tybys/wasm-util@npm:^0.10.1":
-  version: 0.10.1
-  resolution: "@tybys/wasm-util@npm:0.10.1"
+"@tybys/wasm-util@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@tybys/wasm-util@npm:0.10.3"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10c0/b255094f293794c6d2289300c5fbcafbb5532a3aed3a5ffd2f8dc1828e639b88d75f6a376dd8f94347a44813fd7a7149d8463477a9a49525c8b2dcaa38c2d1e8
+  checksum: 10c0/fd2bd2a79c6cd8c79ed1cf7a0fa375c64589264c88a27acaf9756d556b453ea222b62a4f68dd2fbb8b3a78b6bab3b1f4fb2431b6afc6aeda8344b53a521a1cd3
   languageName: node
   linkType: hard
 
@@ -2966,12 +3020,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^19.2.14":
-  version: 19.2.14
-  resolution: "@types/react@npm:19.2.14"
+"@types/react@npm:^19.2.15":
+  version: 19.2.17
+  resolution: "@types/react@npm:19.2.17"
   dependencies:
     csstype: "npm:^3.2.2"
-  checksum: 10c0/7d25bf41b57719452d86d2ac0570b659210402707313a36ee612666bf11275a1c69824f8c3ee1fdca077ccfe15452f6da8f1224529b917050eb2d861e52b59b7
+  checksum: 10c0/bc2c4af96b3e480604424de70d5ebda90c5f4b485df471858c0bc2d7d70364b606ec3c4d8579f94f01aa0c6c0591f56bcf14cba5689f5eea4b74250ccdc3a232
   languageName: node
   linkType: hard
 
@@ -3003,105 +3057,105 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.3"
+"@typescript-eslint/eslint-plugin@npm:8.63.0":
+  version: 8.63.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.63.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.12.2"
-    "@typescript-eslint/scope-manager": "npm:8.59.3"
-    "@typescript-eslint/type-utils": "npm:8.59.3"
-    "@typescript-eslint/utils": "npm:8.59.3"
-    "@typescript-eslint/visitor-keys": "npm:8.59.3"
+    "@typescript-eslint/scope-manager": "npm:8.63.0"
+    "@typescript-eslint/type-utils": "npm:8.63.0"
+    "@typescript-eslint/utils": "npm:8.63.0"
+    "@typescript-eslint/visitor-keys": "npm:8.63.0"
     ignore: "npm:^7.0.5"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.59.3
+    "@typescript-eslint/parser": ^8.63.0
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/c316ba4af95c7408c65279005099386c1547c184929b7027a1041a2450537d5ce7bd9276e0d6774ae384f9e4482e392dc3305686442d64777c448d76f39fd665
+  checksum: 10c0/906a406d85ad80cbe06cb688d4382c34dfb36ebfbd710814f7f9651265b88cf53684ee5275a402eb0eb1243628c504019714f00c1331e54d499cdc7d7c14b5ba
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/parser@npm:8.59.3"
+"@typescript-eslint/parser@npm:8.63.0":
+  version: 8.63.0
+  resolution: "@typescript-eslint/parser@npm:8.63.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.59.3"
-    "@typescript-eslint/types": "npm:8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:8.59.3"
-    "@typescript-eslint/visitor-keys": "npm:8.59.3"
+    "@typescript-eslint/scope-manager": "npm:8.63.0"
+    "@typescript-eslint/types": "npm:8.63.0"
+    "@typescript-eslint/typescript-estree": "npm:8.63.0"
+    "@typescript-eslint/visitor-keys": "npm:8.63.0"
     debug: "npm:^4.4.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/a5e16163e6fdeff411272e8fa2e26b48c28aae3003ff2a6b52e7c7727061170afde11261feefba0b578399774a6c9b26e5d58d593e66b25f88a4552e6012d9e2
+  checksum: 10c0/28fd1db23ff16627936a0d630c6761df1d17046147b6e0ce6a144d60c0fbeddc756c3208e552f9e53c4d6a35f554205f7de3184b1ab45220a2fbc3bb8d1ac62b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/project-service@npm:8.59.3"
+"@typescript-eslint/project-service@npm:8.63.0":
+  version: 8.63.0
+  resolution: "@typescript-eslint/project-service@npm:8.63.0"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.59.3"
-    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.63.0"
+    "@typescript-eslint/types": "npm:^8.63.0"
     debug: "npm:^4.4.3"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/14caf773ce7198e097e7cf1ba65b0dfd0553696b5ffc1842f0f5bbc877450d1aab599dd0209b1bca66e4a03ba176051dfa13e30005b8f0a96453d7a01e8d8ba6
+  checksum: 10c0/d49ce51b128d83a0e87e01d7a30f2295d77713d913abddc817df7ac3aeb1333b5dbb0c634ad0d0941f51cdd84ad86a036178b90bb370aa819ff59082377ca0ee
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.59.3, @typescript-eslint/scope-manager@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/scope-manager@npm:8.59.3"
+"@typescript-eslint/scope-manager@npm:8.63.0, @typescript-eslint/scope-manager@npm:^8.63.0":
+  version: 8.63.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.63.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.3"
-    "@typescript-eslint/visitor-keys": "npm:8.59.3"
-  checksum: 10c0/716c342e3e4963431696f4a68c616e0afdb619a94fabf448d032a9a676d75d39d60926cd6b47ccd712c722f7cf549a2f623f97049017f36e953dd9b7b348e9bd
+    "@typescript-eslint/types": "npm:8.63.0"
+    "@typescript-eslint/visitor-keys": "npm:8.63.0"
+  checksum: 10c0/394245a25f852170adbdaaca9364d5d36a0e97e69e691e5594d5a3ced892a7eb78cf6e7a17cbc095490a168b60bb3ad6f6d48cd167c4b9cbc568bf0f785ab926
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.59.3, @typescript-eslint/tsconfig-utils@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.3"
+"@typescript-eslint/tsconfig-utils@npm:8.63.0, @typescript-eslint/tsconfig-utils@npm:^8.63.0":
+  version: 8.63.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.63.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/326c07ae30e04734b28830ff74fbc8478f58671f0111a540854064d5a1cd15ed22056453165200ce342de9758e4ce45c827068017701dfb8390ec1c6b3c990ab
+  checksum: 10c0/378a220fa5d0aaaf38887d667d1ddf8addfb7601af491230e77e32773158f9aad7723b8e25cebf0f95debc2217ca7b9ddf4e9ebd506e319fe1f9fe4244274013
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.59.3, @typescript-eslint/type-utils@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/type-utils@npm:8.59.3"
+"@typescript-eslint/type-utils@npm:8.63.0, @typescript-eslint/type-utils@npm:^8.63.0":
+  version: 8.63.0
+  resolution: "@typescript-eslint/type-utils@npm:8.63.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:8.59.3"
-    "@typescript-eslint/utils": "npm:8.59.3"
+    "@typescript-eslint/types": "npm:8.63.0"
+    "@typescript-eslint/typescript-estree": "npm:8.63.0"
+    "@typescript-eslint/utils": "npm:8.63.0"
     debug: "npm:^4.4.3"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/ff0dfb47fafe6046c0cf08b1790db41dc8e0b93dfa5bdd69f78d1cb58880b85bfb7930079c417664498a203b894381b228141efc27f427d1969c6aecc25e63b9
+  checksum: 10c0/36f6ba389d05e57f2f1de0f21406a46694e39da83248d7d5eefb1601d6a37a3d2382ee6f1b1b0e63b78465d8d830eeaec1503aaefbad70b1030e59fb15307aae
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.59.3, @typescript-eslint/types@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/types@npm:8.59.3"
-  checksum: 10c0/3f7836ce108c3098935180221abce6d9dbf3583216b895525b0a1fc8d0207ebe1ba9e571dbb45eddacd14ef99563350b9b51df3091258211f8d267f02b9a80c1
+"@typescript-eslint/types@npm:8.63.0, @typescript-eslint/types@npm:^8.63.0":
+  version: 8.63.0
+  resolution: "@typescript-eslint/types@npm:8.63.0"
+  checksum: 10c0/270bd2b2affdc173dd7e9e1bf1419a6f7a2fa8ff1fca5c613da88f6e44c433a1412887e513d24233a4a6112bdc3439d3e4cadc4f492eb1a6dc2a377495a38836
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.59.3, @typescript-eslint/typescript-estree@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/typescript-estree@npm:8.59.3"
+"@typescript-eslint/typescript-estree@npm:8.63.0, @typescript-eslint/typescript-estree@npm:^8.63.0":
+  version: 8.63.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.63.0"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.59.3"
-    "@typescript-eslint/tsconfig-utils": "npm:8.59.3"
-    "@typescript-eslint/types": "npm:8.59.3"
-    "@typescript-eslint/visitor-keys": "npm:8.59.3"
+    "@typescript-eslint/project-service": "npm:8.63.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.63.0"
+    "@typescript-eslint/types": "npm:8.63.0"
+    "@typescript-eslint/visitor-keys": "npm:8.63.0"
     debug: "npm:^4.4.3"
     minimatch: "npm:^10.2.2"
     semver: "npm:^7.7.3"
@@ -3109,32 +3163,32 @@ __metadata:
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/d23d4efa17ebfceaca741e0656f4cc69f6429fad0bba87fa79cf08b6b67e487282241fd4211ae69d1b9eae1e5746db849e2e29518a385ee981a55f297db58906
+  checksum: 10c0/84ca87141a0e7d59fb91e7baef36e20d4f00f1996aec6dfb1909c40496f13e54a13102c12b7cbe89285d04ca7975faa64d5683ff0d44ec9baa7be5207540142c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.59.3, @typescript-eslint/utils@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/utils@npm:8.59.3"
+"@typescript-eslint/utils@npm:8.63.0, @typescript-eslint/utils@npm:^8.63.0":
+  version: 8.63.0
+  resolution: "@typescript-eslint/utils@npm:8.63.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.9.1"
-    "@typescript-eslint/scope-manager": "npm:8.59.3"
-    "@typescript-eslint/types": "npm:8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:8.59.3"
+    "@typescript-eslint/scope-manager": "npm:8.63.0"
+    "@typescript-eslint/types": "npm:8.63.0"
+    "@typescript-eslint/typescript-estree": "npm:8.63.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/a8299781be03e43f9a0f4006e607cfaa1094e2d5b1a208e7f2b994841884f08b557ce51d97d128b892b335a99b1bffa151eb4c0173aafec5d012783656e222f0
+  checksum: 10c0/1b0bb66c2dc11d7c3ea4e840294e35062e5f85b6d1d7d94b37e94e52a2fa71e76adf277602a183832c23d3deeb1f129d7aeb3ce960c1fc9b6d1136a4d61bd54a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/visitor-keys@npm:8.59.3"
+"@typescript-eslint/visitor-keys@npm:8.63.0":
+  version: 8.63.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.63.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/types": "npm:8.63.0"
     eslint-visitor-keys: "npm:^5.0.0"
-  checksum: 10c0/124c1ecece3f1ea954a05b150f8ec89b1c790276baa6e60c542a006cf3e14ce2c6152f95f06740e73609c36c6db0eeba98caba572d19db0befaef8aaba6f9569
+  checksum: 10c0/595b47b08efecc35d93a8ac072798f9dc2371a371f03a1a03ab134a8505fe422fc647014bd096eac75a3d487c5eecf24393048ca88ed06f759d00115c11dd8bc
   languageName: node
   linkType: hard
 
@@ -3214,7 +3268,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "acp-docs@workspace:."
   dependencies:
-    "@alauda/doom": "npm:^2.5.1"
+    "@alauda/doom": "npm:^2.5.4"
     prettier: "npm:^3.8.3"
     prettier-plugin-pkg: "npm:^0.22.1"
     simple-git-hooks: "npm:^2.13.1"
@@ -4634,121 +4688,121 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:5.7.7":
-  version: 5.7.7
-  resolution: "eslint-plugin-react-dom@npm:5.7.7"
+"eslint-plugin-react-dom@npm:5.13.1":
+  version: 5.13.1
+  resolution: "eslint-plugin-react-dom@npm:5.13.1"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.7"
-    "@eslint-react/eslint": "npm:5.7.7"
-    "@eslint-react/jsx": "npm:5.7.7"
-    "@eslint-react/shared": "npm:5.7.7"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.13.1"
+    "@eslint-react/eslint": "npm:5.13.1"
+    "@eslint-react/jsx": "npm:5.13.1"
+    "@eslint-react/shared": "npm:5.13.1"
+    "@typescript-eslint/types": "npm:^8.63.0"
+    "@typescript-eslint/utils": "npm:^8.63.0"
     compare-versions: "npm:^6.1.1"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/e50ee5f9f5c8c40739fc744c7233daf4b885a4c478e3b78754d1fc9a68991206cf03b0207c755c2d70079b5357ef7dc7b525e69bf5f2b1b445db6e1bb856d493
+  checksum: 10c0/81a5a5600b2ee548292b558adc2483299ece605fc829aea240fe2bd5785c7f43c4d0dc19bcb33bf65e71398673c3d6b9ad26170107ca506430a28775afa0d418
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-jsx@npm:5.7.7":
-  version: 5.7.7
-  resolution: "eslint-plugin-react-jsx@npm:5.7.7"
+"eslint-plugin-react-jsx@npm:5.13.1":
+  version: 5.13.1
+  resolution: "eslint-plugin-react-jsx@npm:5.13.1"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.7"
-    "@eslint-react/core": "npm:5.7.7"
-    "@eslint-react/eslint": "npm:5.7.7"
-    "@eslint-react/jsx": "npm:5.7.7"
-    "@eslint-react/shared": "npm:5.7.7"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.13.1"
+    "@eslint-react/core": "npm:5.13.1"
+    "@eslint-react/eslint": "npm:5.13.1"
+    "@eslint-react/jsx": "npm:5.13.1"
+    "@eslint-react/shared": "npm:5.13.1"
+    "@typescript-eslint/types": "npm:^8.63.0"
+    "@typescript-eslint/utils": "npm:^8.63.0"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/d7ba393b388cc0e0af997433c69e319da9431275c24ec8e6e18b5e1c6fa26dfc422c3b7ffeaf8c1a40e2ddaf79e0ddd3dbaf198da135478bea8b5af687de6d56
+  checksum: 10c0/e2efd503ed5e4af113fed0a09d89b782f89348cdbffade19aa7bce4dc16f1c36092f9e78ca125275d8c65bf37ba5824db5c4b9dd6753f9ddffafadc2c7c0786b
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:5.7.7":
-  version: 5.7.7
-  resolution: "eslint-plugin-react-naming-convention@npm:5.7.7"
+"eslint-plugin-react-naming-convention@npm:5.13.1":
+  version: 5.13.1
+  resolution: "eslint-plugin-react-naming-convention@npm:5.13.1"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.7"
-    "@eslint-react/core": "npm:5.7.7"
-    "@eslint-react/eslint": "npm:5.7.7"
-    "@eslint-react/var": "npm:5.7.7"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.13.1"
+    "@eslint-react/core": "npm:5.13.1"
+    "@eslint-react/eslint": "npm:5.13.1"
+    "@eslint-react/var": "npm:5.13.1"
+    "@typescript-eslint/types": "npm:^8.63.0"
+    "@typescript-eslint/utils": "npm:^8.63.0"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/c62adb071e92157867b4392114fba0abd195043ace7a108be94ee2445ef730de4727631a0ee6943c0f3d0264d2e4dd34e367fd26965b2ca14f89939651fa61b5
+  checksum: 10c0/3aaf3bb311efe201a3215fc77d7f41d258691e9bcca78edb57d6d7546f4a2f73eea3f45bd72ee5951212c4afd22838e313d45894ce2ceee6291e267d59f292da
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-rsc@npm:5.7.7":
-  version: 5.7.7
-  resolution: "eslint-plugin-react-rsc@npm:5.7.7"
+"eslint-plugin-react-rsc@npm:5.13.1":
+  version: 5.13.1
+  resolution: "eslint-plugin-react-rsc@npm:5.13.1"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.7"
-    "@eslint-react/core": "npm:5.7.7"
-    "@eslint-react/eslint": "npm:5.7.7"
-    "@eslint-react/shared": "npm:5.7.7"
-    "@eslint-react/var": "npm:5.7.7"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.13.1"
+    "@eslint-react/core": "npm:5.13.1"
+    "@eslint-react/eslint": "npm:5.13.1"
+    "@eslint-react/shared": "npm:5.13.1"
+    "@eslint-react/var": "npm:5.13.1"
+    "@typescript-eslint/types": "npm:^8.63.0"
+    "@typescript-eslint/utils": "npm:^8.63.0"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/f2e0701cc57523066e0f7754ca729dee893fa606f721569ca06f0f35112d8a0d49d12366a33e14903f0c3b66fec1c77c6cb3e00d1a330577798ddd9aa47253b0
+  checksum: 10c0/00e280634a18e710a8270d9cdc2484048de4c4d49ad06529ad8810d151b2b4e594b57b3edbef82e57563485374d25919f5f0c131e823fcfbc40768365b0f7a24
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:5.7.7":
-  version: 5.7.7
-  resolution: "eslint-plugin-react-web-api@npm:5.7.7"
+"eslint-plugin-react-web-api@npm:5.13.1":
+  version: 5.13.1
+  resolution: "eslint-plugin-react-web-api@npm:5.13.1"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.7"
-    "@eslint-react/core": "npm:5.7.7"
-    "@eslint-react/eslint": "npm:5.7.7"
-    "@eslint-react/shared": "npm:5.7.7"
-    "@eslint-react/var": "npm:5.7.7"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.13.1"
+    "@eslint-react/core": "npm:5.13.1"
+    "@eslint-react/eslint": "npm:5.13.1"
+    "@eslint-react/shared": "npm:5.13.1"
+    "@eslint-react/var": "npm:5.13.1"
+    "@typescript-eslint/types": "npm:^8.63.0"
+    "@typescript-eslint/utils": "npm:^8.63.0"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/b5b67e36b7bd7711fbcf4d432ff9956ce7dca77f45dad12e6f46266e2774f068d88626568f9ff6f27fd83c49bcb146e647b29da18f9f97a4d0feed0ca76fbdc2
+  checksum: 10c0/2df43e84eae8b199ab8b0013ff72fd04afe14af17e40548526903bbbce7c9e9a5e540bc52ac2f757e9bde16b6cafcd850e78141f503c4593dcd270340245a778
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:5.7.7":
-  version: 5.7.7
-  resolution: "eslint-plugin-react-x@npm:5.7.7"
+"eslint-plugin-react-x@npm:5.13.1":
+  version: 5.13.1
+  resolution: "eslint-plugin-react-x@npm:5.13.1"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.7"
-    "@eslint-react/core": "npm:5.7.7"
-    "@eslint-react/eslint": "npm:5.7.7"
-    "@eslint-react/jsx": "npm:5.7.7"
-    "@eslint-react/shared": "npm:5.7.7"
-    "@eslint-react/var": "npm:5.7.7"
-    "@typescript-eslint/scope-manager": "npm:^8.59.3"
-    "@typescript-eslint/type-utils": "npm:^8.59.3"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.13.1"
+    "@eslint-react/core": "npm:5.13.1"
+    "@eslint-react/eslint": "npm:5.13.1"
+    "@eslint-react/jsx": "npm:5.13.1"
+    "@eslint-react/shared": "npm:5.13.1"
+    "@eslint-react/var": "npm:5.13.1"
+    "@typescript-eslint/scope-manager": "npm:^8.63.0"
+    "@typescript-eslint/type-utils": "npm:^8.63.0"
+    "@typescript-eslint/types": "npm:^8.63.0"
+    "@typescript-eslint/typescript-estree": "npm:^8.63.0"
+    "@typescript-eslint/utils": "npm:^8.63.0"
     compare-versions: "npm:^6.1.1"
     string-ts: "npm:^2.3.1"
     ts-api-utils: "npm:^2.5.0"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.3.0
+    eslint: "*"
     typescript: "*"
-  checksum: 10c0/0b30c09e7d20a3dd077f0b99b90119aa784433fa77bf7fbb40011b3ffdb24d61be8d97e38e5d3ef7988be81f87827a9e56256d08e616fa972f0be07320e3d595
+  checksum: 10c0/719d5f3b5a66d44b815b80843e737881188915bd6de114ca5e46a2a6d9556160e5f520e85a8ab0e3f1d9165fe114c08c8fbf1f0b6287b24050989f1ae3a32154
   languageName: node
   linkType: hard
 
@@ -4785,16 +4839,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^10.3.0":
-  version: 10.3.0
-  resolution: "eslint@npm:10.3.0"
+"eslint@npm:^10.4.0":
+  version: 10.6.0
+  resolution: "eslint@npm:10.6.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.8.0"
     "@eslint-community/regexpp": "npm:^4.12.2"
     "@eslint/config-array": "npm:^0.23.5"
-    "@eslint/config-helpers": "npm:^0.5.5"
+    "@eslint/config-helpers": "npm:^0.6.0"
     "@eslint/core": "npm:^1.2.1"
-    "@eslint/plugin-kit": "npm:^0.7.1"
+    "@eslint/plugin-kit": "npm:^0.7.2"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@humanwhocodes/retry": "npm:^0.4.2"
@@ -4826,7 +4880,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/81e3ceba949f62d1b530660279db86cf814f5dc43d7cc3759a8008fe4fc679d46568279fe1cceb7ddbbc98ab57a96ae524f6e811ffc6897b49b90ea08aa785e5
+  checksum: 10c0/ebe0261fc750afb7f1a0c5a14f5288e57b971e0bee9754b1620132d22ad0c23690183977b0c9514ffa7ad460768d689d3fb9792ad9267b6c6205e2e0c17d8563
   languageName: node
   linkType: hard
 
@@ -7310,20 +7364,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:^6.37.0":
-  version: 6.37.0
-  resolution: "openai@npm:6.37.0"
+"openai@npm:^6.38.0":
+  version: 6.45.0
+  resolution: "openai@npm:6.45.0"
   peerDependencies:
+    "@aws-sdk/credential-provider-node": ">=3.972.0 <4"
+    "@smithy/hash-node": ">=4.3.0 <5"
+    "@smithy/signature-v4": ">=5.4.0 <6"
     ws: ^8.18.0
     zod: ^3.25 || ^4.0
   peerDependenciesMeta:
+    "@aws-sdk/credential-provider-node":
+      optional: true
+    "@smithy/hash-node":
+      optional: true
+    "@smithy/signature-v4":
+      optional: true
     ws:
       optional: true
     zod:
       optional: true
-  bin:
-    openai: bin/cli
-  checksum: 10c0/31a506a79410a4e2a42bd4183143450fb468359733bf3458178bb8dd3ce4b125b2324940969a92862ad9e620e3a9be6710c875c856f9c422c9c35d6e81791848
+  checksum: 10c0/d59fdcb75d20e81f6b1d4c0a0591dfd10b8078ed6a0d2ae1abc7768efc70106a1e94ccbc9b9c01d31dcecc73285be767d7418a115647c631f4cb58202f55eafa
   languageName: node
   linkType: hard
 
@@ -7590,27 +7651,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.57.0":
-  version: 1.57.0
-  resolution: "playwright-core@npm:1.57.0"
+"playwright-core@npm:1.61.0":
+  version: 1.61.0
+  resolution: "playwright-core@npm:1.61.0"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/798e35d83bf48419a8c73de20bb94d68be5dde68de23f95d80a0ebe401e3b83e29e3e84aea7894d67fa6c79d2d3d40cc5bcde3e166f657ce50987aaa2421b6a9
+  checksum: 10c0/64cbf5e9f4ad81cbb005d59417e96435e324a6e3801f1c79b36850ad99f6bb90853c4b569a32c49b9eca1e07925bbb2a5a864babdba2178c3c395e0c589d5941
   languageName: node
   linkType: hard
 
-"playwright@npm:1.57.0":
-  version: 1.57.0
-  resolution: "playwright@npm:1.57.0"
+"playwright@npm:1.61.0":
+  version: 1.61.0
+  resolution: "playwright@npm:1.61.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.57.0"
+    playwright-core: "npm:1.61.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/ab03c99a67b835bdea9059f516ad3b6e42c21025f9adaa161a4ef6bc7ca716dcba476d287140bb240d06126eb23f889a8933b8f5f1f1a56b80659d92d1358899
+  checksum: 10c0/079dceebe8b745fa6062a3af928024d0c508177fbf15d61dba09ba173f277465ad3746fdc1b31788ade65428f4d3f92fc8083b44c07381b088721eaa2ea06513
   languageName: node
   linkType: hard
 
@@ -7797,21 +7858,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^7.15.0":
-  version: 7.15.0
-  resolution: "react-router-dom@npm:7.15.0"
+"react-router-dom@npm:^7.15.1":
+  version: 7.18.1
+  resolution: "react-router-dom@npm:7.18.1"
   dependencies:
-    react-router: "npm:7.15.0"
+    react-router: "npm:7.18.1"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
-  checksum: 10c0/bb234bc1082c045f6aee498e854b62738f9bbbef386d63e5a82a8de1580034e5499ee0861d47319c459909b11005109744625d281f6ab13f4fcbc8dd70b5b186
+  checksum: 10c0/5efb99f2f09cecf445788f3459a8f5ff952ed85061f2d40f8de25fdd6e2ce6aeea8e40e4bacad470ea42a45d0460feb6fb59c62f14d87720b43d5c96cd9b2cb6
   languageName: node
   linkType: hard
 
-"react-router@npm:7.15.0":
-  version: 7.15.0
-  resolution: "react-router@npm:7.15.0"
+"react-router@npm:7.18.1":
+  version: 7.18.1
+  resolution: "react-router@npm:7.18.1"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -7821,20 +7882,20 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/ce27ff25a0a53afec7f24385be89b779efd9f04d84c5b90c6a8f3fbbac28fc2f8c5f1bb26aff0588d41a225482365997082808f9e098c565435fad09426de114
+  checksum: 10c0/1a559de58d656bad5565f2232e4f4fab7e9f5282dfaf95bc24f195a06e7e85b281077fe5c21ed3ff527e3d90d930447e0d0bb0f0713950d2a56ad0f0377a7d09
   languageName: node
   linkType: hard
 
-"react-tooltip@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "react-tooltip@npm:6.0.2"
+"react-tooltip@npm:^6.0.3":
+  version: 6.0.8
+  resolution: "react-tooltip@npm:6.0.8"
   dependencies:
     "@floating-ui/dom": "npm:1.7.6"
     clsx: "npm:2.1.1"
   peerDependencies:
     react: ">=16.14.0"
     react-dom: ">=16.14.0"
-  checksum: 10c0/13c47bbfa8a1be8a1fb51aa9029405c903bfa5cb64f042c9695ef4e091b015138cfb0e77588072a108479f623ed399822d4358cb3c3feba716f94faf8bd16179
+  checksum: 10c0/7f8546801298b7f503e5740d8de563082d6bf704465b70b2c7b8f2bd72452e513231bcb2d316394988d0580d913ee3af5eadd06ae4d0a692f841da6ceb316fa4
   languageName: node
   linkType: hard
 
@@ -9134,18 +9195,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "typescript-eslint@npm:8.59.3"
+"typescript-eslint@npm:^8.59.4":
+  version: 8.63.0
+  resolution: "typescript-eslint@npm:8.63.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.59.3"
-    "@typescript-eslint/parser": "npm:8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:8.59.3"
-    "@typescript-eslint/utils": "npm:8.59.3"
+    "@typescript-eslint/eslint-plugin": "npm:8.63.0"
+    "@typescript-eslint/parser": "npm:8.63.0"
+    "@typescript-eslint/typescript-estree": "npm:8.63.0"
+    "@typescript-eslint/utils": "npm:8.63.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/7bd251921d583be5a29565118a5babc068e7c1e893d30a0dbea4215ed20cebcad186b419ba747e001b48339e18c4a2cf6c936e013a77b225692f7f48331839f6
+  checksum: 10c0/3b71c97c28502d463e8c562c741bfd4134e329c0d5580268dbf7aa7ac08db7ce72ae6fbc4fdd155042e1a65589f15cc1e88abae87103e4a904fe833c7d508c0c
   languageName: node
   linkType: hard
 
@@ -9836,7 +9897,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.4.3":
+"zod@npm:^3.25.0 || ^4.0.0":
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3


### PR DESCRIPTION
Backport of the doom bump to `release-4.3`.

## What
Bump `@alauda/doom` from 2.5.1 to 2.5.4 via `yarn up @alauda/doom` + `yarn install`.

## Why
`package.json` pinned `^2.5.1` / lockfile at 2.5.1, but CI installs the latest `@alauda/doom` (currently 2.5.4), which carries lint rules 2.5.1 lacks — so a local `yarn lint` could pass while CI failed. Pinning to 2.5.4 makes local lint reproduce CI.

## Verification
- `yarn lint` → 0 errors, 0 warnings.
- Diff limited to `package.json` and `yarn.lock`.