### PR TITLE
ACP-54319 docs: clarify VPC egress gateway BFD tuning

### DIFF
--- a/docs/en/networking/how_to/kube_ovn/configure_egress_gateway.mdx
+++ b/docs/en/networking/how_to/kube_ovn/configure_egress_gateway.mdx
@@ -538,6 +538,10 @@ Failover detection time depends on the BFD settings.
 Use the following formula: _break time = (multiplier + 1) * max(minRX, minTX)_.
 With this sample configuration, failover detection is approximately 500-600 ms.
 
+In environments with poor network quality or frequent link jitter, a 100 ms BFD interval might be too sensitive.
+You can increase _.spec.bfd.minRX_ and _.spec.bfd.minTX_ to 500-1000 ms to reduce false failure detection and frequent failover.
+Increasing these values also increases the failover detection time, so tune them based on the required balance between stability and failure detection latency.
+
 :::note
   Existing connections may be interrupted during failover and require reconnection. New connections can still be established normally.
 :::


### PR DESCRIPTION
## Summary
- Add guidance for tuning VPC Egress Gateway BFD intervals in poor network conditions.
- Document that 100 ms can be too sensitive and 500-1000 ms can reduce false failover.
- Clarify the tradeoff between stability and failover detection latency.

## Jira
- https://jira.alauda.cn/browse/ACP-54319

## Test Plan
- yarn lint
- git diff --check -- docs/en/networking/how_to/kube_ovn/configure_egress_gateway.mdx

Note: `yarn lint` completed with 0 errors and 0 warnings. The command printed a Node.js version warning because the local Node.js version is 20.18.0, while Rspack recommends 20.19+ or 22.12+.