### PR TITLE
docs(kube-ovn): require strict ARP for MetalLB underlay

### DIFF
--- a/docs/en/networking/how_to/kube_ovn/config_metallb_underlay.mdx
+++ b/docs/en/networking/how_to/kube_ovn/config_metallb_underlay.mdx
@@ -10,6 +10,8 @@ This solution addresses the integration of MetalLB L2 mode with Kube-OVN Underla
 
 > ⚠️ **Critical**: The LoadBalancer VIP and the backend Pod IPs **must be in the same Underlay subnet**.
 
+> ⚠️ **Important**: ACP enables kube-proxy IPVS strict ARP mode by default. Keep this setting enabled; otherwise non-MetalLB speaker nodes can reply to VIP ARP requests and cause Underlay access failures.
+
 ## Prerequisites
 
 ### Environment Requirements


### PR DESCRIPTION
在 Kube-OVN Underlay + MetalLB 方案开头补充说明：ACP 默认启用 kube-proxy IPVS strict ARP，必须保持该配置开启。否则非 MetalLB speaker 节点可能回复 VIP ARP，导致 Underlay 访问失败。

验证：`yarn lint` 0 errors / 0 warnings。