### PR TITLE
docs(virtualization): fix the ISO guides on release-4.3 — live-migratable Windows VM + working upload procedure

### DIFF
--- a/docs/en/virtualization/virtualization/image/how_to/vm_iso_linux.mdx
+++ b/docs/en/virtualization/virtualization/image/how_to/vm_iso_linux.mdx
@@ -65,16 +65,25 @@ Upload the ISO file directly to the cluster storage using the CDI upload mechani
    # The PHASE column should show UploadReady
    ```
 
-4. Set up port-forwarding to the CDI upload proxy.
+4. Set up port-forwarding to the CDI upload proxy. The `cdi-uploadproxy` Service runs in the namespace the virtualization components are installed in, which is `kubevirt` by default.
 
    ```bash
-   kubectl port-forward -n cdi svc/cdi-uploadproxy 8443:443 &
+   kubectl port-forward -n kubevirt svc/cdi-uploadproxy 8443:443 &
    ```
 
-5. Obtain an authentication token.
+5. Request an upload token from CDI with an `UploadTokenRequest`. The token authorizes uploading to the `iso-upload-dv` PVC and is valid for 5 minutes, so run this immediately before the upload.
 
    ```bash
-   TOKEN=$(kubectl create token default -n default)
+   TOKEN=$(kubectl create -o jsonpath='{.status.token}' -f - <<'EOF'
+   apiVersion: upload.cdi.kubevirt.io/v1beta1
+   kind: UploadTokenRequest
+   metadata:
+     name: iso-upload-dv-upload
+     namespace: default
+   spec:
+     pvcName: iso-upload-dv
+   EOF
+   )
    ```
 
 6. Upload the ISO file using curl. Replace the file path with the actual path to your ISO.

--- a/docs/en/virtualization/virtualization/image/how_to/vm_iso_windows.mdx
+++ b/docs/en/virtualization/virtualization/image/how_to/vm_iso_windows.mdx
@@ -15,7 +15,7 @@ This document discusses a virtual machine solution based on the open-source comp
 
 - The `kubectl` command-line tool is installed and configured to access the cluster.
 
-- A StorageClass that supports `ReadWriteOnce` (RWO) access mode is available in the cluster.
+- A StorageClass that supports the `ReadWriteMany` (RWX) access mode is available in the cluster. Live migration requires every PVC attached to the virtual machine to be shared, so all DataVolumes in this document use RWX. If you do not need live migration, `ReadWriteOnce` (RWO) also works.
 
 ## Constraints and Limitations
 
@@ -60,7 +60,7 @@ Upload the Windows ISO and virtio-win ISO files directly to the cluster storage 
        upload: {}
      storage:
        accessModes:
-         - ReadWriteOnce
+         - ReadWriteMany
        resources:
          requests:
            storage: 8Gi
@@ -114,7 +114,7 @@ Upload the Windows ISO and virtio-win ISO files directly to the cluster storage 
        upload: {}
      storage:
        accessModes:
-         - ReadWriteOnce
+         - ReadWriteMany
        resources:
          requests:
            storage: 1Gi
@@ -217,7 +217,18 @@ Upload the Windows ISO and virtio-win ISO files directly to the cluster storage 
              name: rootfs
    ```
 
-8. Check the YAML file. The complete YAML after finishing the configuration is as follows.
+8. Add the following annotation under `spec.template.metadata.annotations`. The primary interface of this virtual machine uses `bridge` binding on the pod network, which KubeVirt refuses to live-migrate by default; this annotation declares that the underlying CNI can follow the migration and lifts that restriction. Kube-OVN, the default CNI of the platform, preserves the virtual machine IP address across a migration. Without this annotation, migration is rejected with `InterfaceNotLiveMigratable`.
+
+   ```yaml
+     template:
+       metadata:
+         annotations:
+           kubevirt.io/allow-pod-bridge-network-live-migration: "true"
+   ```
+
+   **Note**: KubeVirt only reports the first condition that blocks live migration, and the interface check runs before the disk check. If any PVC still uses `ReadWriteOnce`, the virtual machine remains non-migratable after adding this annotation, and the reason reported changes to `DisksNotLiveMigratable`. Both the annotation and RWX access modes are required.
+
+9. Check the YAML file. The complete YAML after finishing the configuration is as follows.
 
    ```yaml
    apiVersion: kubevirt.io/v1alpha3
@@ -249,7 +260,7 @@ Upload the Windows ISO and virtio-win ISO files directly to the cluster storage 
          spec:
            pvc:
              accessModes:
-               - ReadWriteOnce
+               - ReadWriteMany
              resources:
                requests:
                  storage: 100Gi
@@ -266,6 +277,7 @@ Upload the Windows ISO and virtio-win ISO files directly to the cluster storage 
            cpaas.io/updated-at: 2024-09-01T14:55:44Z
            kubevirt.io/latest-observed-api-version: v1
            kubevirt.io/storage-observed-api-version: v1
+           kubevirt.io/allow-pod-bridge-network-live-migration: "true"
          creationTimestamp: null
          labels:
            virtualization.cpaas.io/image-name: debian-2120-x86
@@ -339,11 +351,11 @@ Upload the Windows ISO and virtio-win ISO files directly to the cluster storage 
              name: rootfs
    ```
 
-9. Click **Create**.
+10. Click **Create**.
 
-10. Click **Actions** > **VNC Login**.
+11. Click **Actions** > **VNC Login**.
 
-11. When the prompt **press any key boot from CD or DVD** appears, press any key to enter the Windows installation program; if you do not see the prompt, click on **Send Remote Command** in the top left of the page, then select **Ctrl-Alt-Delete** from the dropdown menu to restart the server.
+12. When the prompt **press any key boot from CD or DVD** appears, press any key to enter the Windows installation program; if you do not see the prompt, click on **Send Remote Command** in the top left of the page, then select **Ctrl-Alt-Delete** from the dropdown menu to restart the server.
 
     **Note**: If a message appears at the top of the virtual machine details page stating **The current virtual machine has configuration changes that require a restart to take effect, please restart**, this message can be ignored; no restart is necessary.
 

--- a/docs/en/virtualization/virtualization/image/how_to/vm_iso_windows.mdx
+++ b/docs/en/virtualization/virtualization/image/how_to/vm_iso_windows.mdx
@@ -31,17 +31,13 @@ Upload the Windows ISO and virtio-win ISO files directly to the cluster storage 
 
 **Set up the CDI Upload Proxy**
 
-1. Set up port-forwarding to the CDI upload proxy. This port-forward session will be used for uploading both ISO files.
+1. Set up port-forwarding to the CDI upload proxy. This port-forward session will be used for uploading both ISO files. The `cdi-uploadproxy` Service runs in the namespace the virtualization components are installed in, which is `kubevirt` by default.
 
    ```bash
-   kubectl port-forward -n cdi svc/cdi-uploadproxy 8443:443 &
+   kubectl port-forward -n kubevirt svc/cdi-uploadproxy 8443:443 &
    ```
 
-2. Obtain an authentication token.
-
-   ```bash
-   TOKEN=$(kubectl create token default -n default)
-   ```
+   **Note**: Each upload needs its own authentication token, obtained from CDI with an `UploadTokenRequest`. A token authorizes uploading to **one specific PVC** and is valid for **5 minutes**, so the token is requested in each upload procedure below, immediately before the transfer starts, rather than once up front.
 
 **Upload the Windows ISO**
 
@@ -81,7 +77,22 @@ Upload the Windows ISO and virtio-win ISO files directly to the cluster storage 
    # The PHASE column should show UploadReady
    ```
 
-4. Upload the Windows ISO file using curl. Replace the file path with the actual path to your ISO.
+4. Request an upload token for the `win-iso-dv` PVC. The token is valid for 5 minutes, so run this immediately before the upload.
+
+   ```bash
+   TOKEN=$(kubectl create -o jsonpath='{.status.token}' -f - <<'EOF'
+   apiVersion: upload.cdi.kubevirt.io/v1beta1
+   kind: UploadTokenRequest
+   metadata:
+     name: win-iso-dv-upload
+     namespace: default
+   spec:
+     pvcName: win-iso-dv
+   EOF
+   )
+   ```
+
+5. Upload the Windows ISO file using curl. Replace the file path with the actual path to your ISO.
 
    ```bash
    curl -v --insecure \
@@ -90,7 +101,7 @@ Upload the Windows ISO and virtio-win ISO files directly to the cluster storage 
      "https://localhost:8443/v1beta1/upload"
    ```
 
-5. Verify that the DataVolume status changes to `Succeeded`.
+6. Verify that the DataVolume status changes to `Succeeded`.
 
    ```bash
    kubectl get dv win-iso-dv
@@ -135,7 +146,22 @@ Upload the Windows ISO and virtio-win ISO files directly to the cluster storage 
    # The PHASE column should show UploadReady
    ```
 
-4. Upload the virtio-win ISO file using curl.
+4. Request an upload token for the `virtio-iso-dv` PVC. This is a separate token from the one used for the Windows ISO, because a token authorizes uploading to a single PVC.
+
+   ```bash
+   TOKEN=$(kubectl create -o jsonpath='{.status.token}' -f - <<'EOF'
+   apiVersion: upload.cdi.kubevirt.io/v1beta1
+   kind: UploadTokenRequest
+   metadata:
+     name: virtio-iso-dv-upload
+     namespace: default
+   spec:
+     pvcName: virtio-iso-dv
+   EOF
+   )
+   ```
+
+5. Upload the virtio-win ISO file using curl.
 
    ```bash
    curl -v --insecure \
@@ -144,7 +170,7 @@ Upload the Windows ISO and virtio-win ISO files directly to the cluster storage 
      "https://localhost:8443/v1beta1/upload"
    ```
 
-5. Verify that the DataVolume status changes to `Succeeded`.
+6. Verify that the DataVolume status changes to `Succeeded`.
 
    ```bash
    kubectl get dv virtio-iso-dv


### PR DESCRIPTION
Backport of #959 to `release-4.3`.

Cherry-picks both commits from the master-targeting PR onto `release-4.3`. The 4.3 pages keep their own `apiVersion: kubevirt.io/v1alpha3` (that line is untouched); everything else is identical to the master fix.

Fixes three defects in the ISO install guides (`vm_iso_windows.mdx`, `vm_iso_linux.mdx`), all verified live on a KubeVirt 4.x cluster:

### 1. The example VMs cannot live-migrate (Windows guide)
The customer-facing Windows VM used a `bridge` interface with no annotation and RWO disks, so it could never be evacuated during node maintenance. Fixed by:
- Adding `kubevirt.io/allow-pod-bridge-network-live-migration: "true"` on the VMI template (kube-ovn preserves the VM IP across migration — verified unchanged after a real migration).
- Switching all DataVolumes / rootfs PVC to `ReadWriteMany`.
- A Note explaining that **both** are required, because KubeVirt reports only the *first* blocking condition (the interface check runs before the disk check), so fixing only the interface silently leaves `DisksNotLiveMigratable`.

### 2. Wrong upload token (both guides)
The doc's `kubectl create token default` is not a valid CDI upload credential. Replaced with an `UploadTokenRequest` (`upload.cdi.kubevirt.io/v1beta1`). The CDI-issued token is **bound to one PVC** and valid for **5 minutes**, so each upload now requests its own token immediately before the transfer (verified: old command → HTTP 401; new command → HTTP 200 → `Succeeded`).

### 3. Wrong upload-proxy namespace (both guides)
`cdi-uploadproxy` lives in the `kubevirt` namespace on ACP (HCO installs there), not `cdi`. Fixed the `port-forward` target. Matches the rest of the doc set (`image/intro.mdx`, `how_to/upload_local_image.mdx`).

## Validation
- `doom lint` — 0 errors / 0 warnings.
- `doom build` — the two changed pages build clean; the only build error is the unrelated Jira-backed `overview/release_notes.mdx` page, which needs Jira network access unavailable in the sandbox (identical to pristine `release-4.3`, untouched here).
- End-to-end tested every changed command on a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)