### PR TITLE
docs: clarify Global DR network requirements

### DIFF
--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -77,7 +77,24 @@ The roles of **Primary Cluster** and **Standby Cluster** are relative: the clust
 * A unified domain which will be the `Platform Access Address`, and the TLS certificate plus private key for serving HTTPS on that domain;
 * A dedicated virtual IP address for each cluster — one for the **Primary Cluster** and another for the Standby Cluster;
 
-  * Preconfigure the load balancer to route TCP traffic on ports `80`, `443`, `6443`, `2379`, and `11443` to the control-plane nodes behind the corresponding VIP.
+### Network Requirements
+
+The unified domain is a prerequisite for disaster recovery. During normal operation, the domain resolves only to the **Primary Cluster** VIP. The Standby Cluster therefore reaches services on the Primary Cluster through the domain or the Primary Cluster VIP.
+
+Before installing either cluster, complete both of the following network preparations:
+
+* Configure each cluster's load balancer to forward the required TCP ports on its VIP to the control plane nodes behind that VIP. Configure port `80` only when users access the platform over HTTP.
+* Allow the required TCP ports in **both directions** between the Primary Cluster and Standby Cluster networks. Apply the rules to firewalls, security groups, router ACLs, and any other inter-site network controls.
+
+| TCP port | Service | Why it is required |
+|----------|---------|--------------------|
+| `443` | <Term name="productShort" /> platform HTTPS | The Standby Cluster uses the Platform Access Address to reach the active platform. The etcd synchronization plugin uses this address, and logging and monitoring components send alert callbacks to it. |
+| `80` | <Term name="productShort" /> platform HTTP | Required only when users access the platform over HTTP. The connectivity requirement is otherwise the same as for port `443`. |
+| `6443` | Kubernetes API server | During installation or reinstallation of the etcd synchronization plugin, the Standby Cluster connects to the active cluster API server to obtain the etcd CA material required for synchronization. |
+| `11443` | Built-in image registry | The Standby Cluster pulls platform and plugin images from the registry configured through the Platform Access Address. |
+| `2379` | etcd | The etcd synchronization plugin on the Standby Cluster reads etcd data from the Primary Cluster and writes it to the local standby etcd. |
+
+The network policy must be bidirectional because the cluster roles are reversed after failover. Before failover, the effective service traffic is normally from Standby to Primary. After failover, the former Primary becomes the new Standby and must reach the new Primary on the same ports. This requirement does not make etcd replication bidirectional: only the current Standby Cluster runs synchronization toward its local etcd.
 
 ## Procedure
 

--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -77,7 +77,7 @@ The roles of **Primary Cluster** and **Standby Cluster** are relative: the clust
 * A unified domain which will be the `Platform Access Address`, and the TLS certificate plus private key for serving HTTPS on that domain;
 * A dedicated virtual IP address for each cluster — one for the **Primary Cluster** and another for the Standby Cluster;
 
-### Network Requirements
+### Network Requirements \{#network-requirements}
 
 The unified domain is a prerequisite for disaster recovery. During normal operation, the domain resolves only to the **Primary Cluster** VIP. The Standby Cluster uses the domain to access platform services on the Primary Cluster.
 

--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -68,7 +68,7 @@ The roles of **Primary Cluster** and **Standby Cluster** are relative: the clust
 2. Point the domain to the **Primary Cluster's** VIP and install the **Primary Cluster**;
 3. Temporarily switch DNS resolution to the standby VIP to install the Standby Cluster;
 4. Copy the ETCD encryption key of the **Primary Cluster** to the nodes that will later be the control plane nodes of Standby Cluster;
-5. Install and enable the etcd synchronization plugin;
+5. Install and enable **<Term name="product" /> etcd Synchronizer**;
 6. Verify sync status and perform regular checks;
 7. In case of failure, switch DNS to the standby cluster to complete disaster recovery.
 
@@ -79,7 +79,7 @@ The roles of **Primary Cluster** and **Standby Cluster** are relative: the clust
 
 ### Network Requirements
 
-The unified domain is a prerequisite for disaster recovery. During normal operation, the domain resolves only to the **Primary Cluster** VIP. The Standby Cluster therefore reaches services on the Primary Cluster through the domain or the Primary Cluster VIP.
+The unified domain is a prerequisite for disaster recovery. During normal operation, the domain resolves only to the **Primary Cluster** VIP. The Standby Cluster uses the domain to access platform services on the Primary Cluster.
 
 Before installing either cluster, complete both of the following network preparations:
 
@@ -88,13 +88,13 @@ Before installing either cluster, complete both of the following network prepara
 
 | TCP port | Service | Why it is required |
 |----------|---------|--------------------|
-| `443` | <Term name="productShort" /> platform HTTPS | The Standby Cluster uses the Platform Access Address to reach the active platform. The etcd synchronization plugin uses this address, and logging and monitoring components send alert callbacks to it. |
+| `443` | <Term name="productShort" /> platform HTTPS | The Standby Cluster uses the Platform Access Address to reach the active platform. **<Term name="product" /> etcd Synchronizer** uses this address, and logging and monitoring components send alert callbacks to it. |
 | `80` | <Term name="productShort" /> platform HTTP | Required only when users access the platform over HTTP. The connectivity requirement is otherwise the same as for port `443`. |
-| `6443` | Kubernetes API server | During installation or reinstallation of the etcd synchronization plugin, the Standby Cluster connects to the active cluster API server to obtain the etcd CA material required for synchronization. |
+| `6443` | Kubernetes API server | During installation or reinstallation of **<Term name="product" /> etcd Synchronizer**, the Standby Cluster connects to the active cluster API server to obtain the etcd CA material required for synchronization. |
 | `11443` | Built-in image registry | The Standby Cluster pulls platform and plugin images from the registry configured through the Platform Access Address. |
-| `2379` | etcd | The etcd synchronization plugin on the Standby Cluster reads etcd data from the Primary Cluster and writes it to the local standby etcd. |
+| `2379` | etcd | **<Term name="product" /> etcd Synchronizer** on the Standby Cluster reads etcd data from the Primary Cluster and writes it to the local standby etcd. |
 
-The network policy must be bidirectional because the cluster roles are reversed after failover. Before failover, the effective service traffic is normally from Standby to Primary. After failover, the former Primary becomes the new Standby and must reach the new Primary on the same ports. This requirement does not make etcd replication bidirectional: only the current Standby Cluster runs synchronization toward its local etcd.
+The network policy must be bidirectional because the cluster roles are reversed after failover. Before failover, the effective service traffic is normally from Standby to Primary. After failover, the former Primary becomes the new Standby and must reach the new Primary on the same ports. This requirement does not make etcd replication bidirectional: **<Term name="product" /> etcd Synchronizer** runs only on the current Standby Cluster and writes synchronized data to its local etcd.
 
 ## Procedure
 
@@ -250,8 +250,8 @@ If the following components are installed, restart their services:
 
 ## Disaster Recovery Process
 
-<Directive type="danger" title="Verify primary/standby consistency before uninstalling the etcd synchronization plugin">
-This procedure uninstalls the etcd synchronization plugin. Before you uninstall it, confirm that the standby cluster data is consistent with the primary cluster. Uninstalling the plugin while the standby is missing data that the primary holds can cause owner references to resolve incorrectly, and workload-cluster node `Machine` objects — including immutable-OS clusters, where this destroys the backing virtual machine — may be deleted. If the consistency check reports missing or surplus keys, do not uninstall the plugin; resolve the inconsistency or contact technical support first.
+<Directive type="danger" title="Verify primary/standby consistency before uninstalling Alauda Container Platform etcd Synchronizer">
+This procedure uninstalls **<Term name="product" /> etcd Synchronizer**. Before you uninstall it, confirm that the standby cluster data is consistent with the primary cluster. Uninstalling the plugin while the standby is missing data that the primary holds can cause owner references to resolve incorrectly, and workload-cluster node `Machine` objects — including immutable-OS clusters, where this destroys the backing virtual machine — may be deleted. If the consistency check reports missing or surplus keys, do not uninstall the plugin; resolve the inconsistency or contact technical support first.
 </Directive>
 
 1. Restart Elasticsearch on the standby cluster in case it is necessary:
@@ -281,7 +281,7 @@ This procedure uninstalls the etcd synchronization plugin. Before you uninstall 
     kubectl get machines.platform.tkestack.io
     ```
 
-3. Uninstall the etcd synchronization plugin;
+3. Uninstall **<Term name="product" /> etcd Synchronizer**;
 4. Remove port forwarding for `2379` from both VIPs;
 5. Switch the platform domain DNS to the standby VIP, which now becomes the Primary Cluster;
 6. Verify DNS resolution:

--- a/docs/en/install/prepare/prerequisites.mdx
+++ b/docs/en/install/prepare/prerequisites.mdx
@@ -227,6 +227,6 @@ This rule is designed to ensure that the `global` cluster can receive traffic fr
 
 <Directive type="tip" title="TIP">
 - It is recommended to configure health checks on the LoadBalancer to monitor the port status.
-- If you plan to implement a disaster recovery plan for the `global` cluster, you need to open port `2379` for all control plane nodes for ETCD data synchronization between the primary and disaster recovery clusters.
+- Global Cluster Disaster Recovery requires load balancer listeners on both cluster VIPs and bidirectional network access between the Primary and Standby Cluster networks. See [Network Requirements](../global_dr.mdx#network-requirements).
 - The platform only supports HTTPS by default. If HTTP support is required, you need to open the HTTP port for all control plane nodes.
 </Directive>


### PR DESCRIPTION
## What changed

- Added explicit network prerequisites for the Primary and Standby Global Clusters.
- Documented the purpose of TCP ports 443, optional 80, 6443, 11443, and 2379.
- Added a direct link from the general LoadBalancer Forwarding Rules to the Global DR Network Requirements section.
- Clarified that the Standby Cluster uses the platform domain to access platform services on the Primary Cluster.
- Clarified that both cluster VIPs need the required listeners and that inter-cluster firewall, security-group, routing, and ACL rules must allow the ports in both directions.
- Used the official plugin name, Alauda Container Platform etcd Synchronizer, in customer-facing descriptions.
- Clarified that the network policy is bidirectional while etcd synchronization remains one-way from the current Primary to the current Standby.

## Why

The platform domain normally resolves only to the Primary Cluster, so steady-state traffic is normally initiated from Standby to Primary. A failover swaps the cluster roles and reverses the required connection direction. The existing documentation listed the ports but did not explain this bidirectional network prerequisite, which could lead to a one-way configuration that fails after switchover. The cross-reference ensures that users configuring general load balancer rules discover the complete Global DR requirements before installation.

## Where to backport

This PR targets master only. Do not backport yet. After the master PR is reviewed and merged, backport to applicable release branches only after separate authorization from Chao.

## Validation

- yarn lint docs/en/install: 0 errors, 0 warnings
- Customer-facing terminology, internal-token, and EN-only checks passed

## Review level

Technical correctness and customer-operable Global DR network prerequisites.