### PR TITLE
docs(storage): add PVC cloning guide

### DIFF
--- a/docs/en/configure/storage/functions/clone_pvc.mdx
+++ b/docs/en/configure/storage/functions/clone_pvc.mdx
@@ -1,0 +1,72 @@
+---
+weight: 52
+---
+
+# Cloning a PVC
+
+PVC cloning creates a new PersistentVolumeClaim (PVC) with a copy of the data in an existing PVC. Use a clone when an application needs an independent writable copy of data, for example, to prepare a test environment from existing application data.
+
+A clone is created directly from a source PVC. In contrast, a [volume snapshot](./using_volume_snapshot.mdx) captures the PVC at a point in time and can be retained or used later to create a PVC. Choose a clone for a direct copy and a volume snapshot when you need a recoverable point-in-time copy.
+
+:::note
+ACP does not currently provide a UI for cloning PVCs. Create the cloned PVC by applying a YAML manifest with `kubectl`.
+:::
+
+## Prerequisites
+
+- The CSI driver and storage class used by the source PVC support PVC cloning.
+- The target PVC is dynamically provisioned by a storage class backed by a clone-capable CSI driver. Static provisioning does not support PVC cloning.
+- The source PVC is in the `Bound` phase.
+- The source and target PVCs are in the same namespace.
+- The target PVC requests storage capacity that is at least the source PVC capacity.
+- The target PVC uses a volume mode and access mode that are compatible with the source PVC and the storage driver.
+
+For information about creating a source PVC, see [Creating PVCs](./create_pvc.mdx).
+
+## Create a cloned PVC
+
+Create a manifest named `clone-pvc.yaml`. Replace the namespace, storage class, access mode, volume mode, capacity, and PVC names with values supported by your storage driver.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cloned-pvc
+  namespace: application-space
+spec:
+  storageClassName: clone-capable-csi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 10Gi
+  dataSource:
+    apiGroup: ""
+    kind: PersistentVolumeClaim
+    name: source-pvc
+```
+
+Apply the manifest:
+
+```shell
+kubectl apply -f clone-pvc.yaml
+```
+
+## Verify the clone
+
+Check the status of the target PVC:
+
+```shell
+kubectl get pvc cloned-pvc -n application-space
+```
+
+When the `STATUS` column shows `Bound`, the storage driver has provisioned and bound the cloned volume. You can then mount `cloned-pvc` in a workload and verify that the expected source data is available.
+
+Inspect the PVC events for provisioning or cloning errors:
+
+```shell
+kubectl describe pvc cloned-pvc -n application-space
+```
+
+If the PVC remains in `Pending` or creation fails, review the events shown by this command. Confirm that the selected storage class supports PVC cloning and that the source PVC, namespace, requested capacity, volume mode, and access mode meet the prerequisites.

--- a/docs/en/configure/storage/functions/clone_pvc.mdx
+++ b/docs/en/configure/storage/functions/clone_pvc.mdx
@@ -14,18 +14,28 @@ ACP does not currently provide a UI for cloning PVCs. Create the cloned PVC by a
 
 ## Prerequisites
 
-- The CSI driver and storage class used by the source PVC support PVC cloning.
-- The target PVC is dynamically provisioned by a storage class backed by a clone-capable CSI driver. Static provisioning does not support PVC cloning.
-- The source PVC is in the `Bound` phase.
+- PVC cloning is available only for dynamically provisioned PVCs whose CSI driver supports cloning. Static provisioning does not support PVC cloning.
+- The source PVC is in the `Bound` phase and is not in use.
 - The source and target PVCs are in the same namespace.
 - The target PVC requests storage capacity that is at least the source PVC capacity.
-- The target PVC uses a volume mode and access mode that are compatible with the source PVC and the storage driver.
+- The source and target PVCs use the same volume mode. The target access mode must be supported by its storage class and CSI driver.
+
+## ACP storage support \{#acp-storage-support}
+
+The target PVC can use a different storage class only when the CSI driver and storage backend support cloning from the source volume to that storage class. Kubernetes does not validate this backend compatibility.
+
+| Storage type | PVC clone support | Storage class requirements |
+| ------------ | ----------------- | -------------------------- |
+| **CephRBD Block Storage** | Supported | The source and target must use compatible RBD storage classes in the same Ceph cluster. A different RBD storage class, including one that uses a different pool, can be used when Ceph CSI supports the selected backend configuration. |
+| **CephFS File Storage** | Supported | The source and target must use compatible storage classes for the same Ceph cluster and CephFS file system. |
+| **TopoLVM** | Supported for thin-provisioned volumes | Use the same storage class for the source and target. A clone created with a different storage class can fail to schedule when its device class differs from the source. |
+| **NFS Shared Storage** | Not supported | NFS Shared Storage does not support PVC cloning. |
 
 For information about creating a source PVC, see [Creating PVCs](./create_pvc.mdx).
 
 ## Create a cloned PVC
 
-Create a manifest named `clone-pvc.yaml`. Replace the namespace, storage class, access mode, volume mode, capacity, and PVC names with values supported by your storage driver.
+Create a manifest named `clone-pvc.yaml`. Replace the namespace, storage class, access mode, volume mode, capacity, and PVC names with values supported by your storage driver. See [ACP storage support](#acp-storage-support) before choosing a target storage class.
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
## Summary
- Add a YAML/CLI guide for cloning a PersistentVolumeClaim.
- Document prerequisites, verification, and current lack of UI support.

## Test plan
- [x] yarn lint
- [x] yarn build