### PR TITLE
docs: add CVO CRD API reference

### DIFF
--- a/docs/en/apis/kubernetes_apis/cluster_version/clusterversionshadow.mdx
+++ b/docs/en/apis/kubernetes_apis/cluster_version/clusterversionshadow.mdx
@@ -1,0 +1,11 @@
+---
+weight: 20
+queries:
+  - clusterversionshadow api reference
+  - clusterversionshadow crd
+  - clusterversionshadow kubernetes api
+---
+
+# ClusterVersionShadow [config.alauda.io/v1]
+
+<K8sAPI name="clusterversionshadows.config.alauda.io" />

--- a/docs/en/apis/kubernetes_apis/cluster_version/index.mdx
+++ b/docs/en/apis/kubernetes_apis/cluster_version/index.mdx
@@ -1,0 +1,10 @@
+---
+queries:
+  - cluster version api reference
+  - cvo kubernetes api
+  - cluster upgrade crd documentation
+---
+
+# Cluster Version APIs
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/apis/kubernetes_apis/cluster_version/productmanifest.mdx
+++ b/docs/en/apis/kubernetes_apis/cluster_version/productmanifest.mdx
@@ -1,0 +1,11 @@
+---
+weight: 10
+queries:
+  - productmanifest api reference
+  - productmanifest crd
+  - productmanifest kubernetes api
+---
+
+# ProductManifest [config.alauda.io/v1]
+
+<K8sAPI name="productmanifests.config.alauda.io" namespaced={false} />

--- a/docs/shared/crds/config.alauda.io_clusterversionshadows.yaml
+++ b/docs/shared/crds/config.alauda.io_clusterversionshadows.yaml
@@ -1,0 +1,415 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: clusterversionshadows.config.alauda.io
+spec:
+  group: config.alauda.io
+  names:
+    categories:
+    - clusterversion
+    kind: ClusterVersionShadow
+    listKind: ClusterVersionShadowList
+    plural: clusterversionshadows
+    shortNames:
+    - cvsh
+    singular: clusterversionshadow
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.current.version
+      name: Current
+      type: string
+    - jsonPath: .status.desired.version
+      name: Desired
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the cluster upgrade.
+            properties:
+              desiredUpdate:
+                description: |-
+                  desiredUpdate is an optional field that indicates the desired value of
+                  the cluster version. Setting this value will trigger an upgrade (if
+                  the current version does not match the desired version).
+                properties:
+                  force:
+                    description: |-
+                      force allows an administrator to update to an image that has failed
+                      checks that are designed to keep the cluster safe.
+
+                      Use only if:
+                      * testing
+                      * working around a known bug
+                    type: boolean
+                  image:
+                    description: image is a container image reference that contains
+                      the update.
+                    type: string
+                  version:
+                    description: version is the container image tag that identifies
+                      the update.
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: exactly one of the fields in [image version] must be set
+                  rule: '[has(self.image),has(self.version)].filter(x,x==true).size()
+                    == 1'
+            type: object
+          status:
+            description: status contains information about cluster upgrade.
+            properties:
+              availableUpdates:
+                description: availableUpdates contains available updates. This list
+                  may be
+                items:
+                  description: Release represents an ACP release image and associated
+                    metadata.
+                  properties:
+                    image:
+                      description: |-
+                        image is a container image location that contains the update. When this
+                        field is part of spec, image is optional if version is specified.
+                      minLength: 1
+                      type: string
+                    version:
+                      description: |-
+                        version is a semantic version identifying the update version. When this
+                        field is part of spec, version is optional if image is specified.
+                      minLength: 1
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                  - message: at least one of the fields in [image version] must be
+                      set
+                    rule: '[has(self.image),has(self.version)].filter(x,x==true).size()
+                      >= 1'
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              conditions:
+                description: |-
+                  conditions provides information about the cluster version. The condition
+                  "Ready" is set to true if the desiredUpdate has been reached. The
+                  condition "Reconciling" is set to true if an update is being applied.
+                  The condition "Degraded" is set to true if an update is currently blocked
+                  by a temporary or permanent error.
+
+                  Conditions are only valid for the current desiredUpdate when
+                  metadata.generation is equal to status.generation.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              current:
+                description: current is the currently applied release version and
+                  image of the cluster.
+                properties:
+                  image:
+                    description: |-
+                      image is a container image location that contains the update. When this
+                      field is part of spec, image is optional if version is specified.
+                    minLength: 1
+                    type: string
+                  version:
+                    description: |-
+                      version is a semantic version identifying the update version. When this
+                      field is part of spec, version is optional if image is specified.
+                    minLength: 1
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: at least one of the fields in [image version] must be set
+                  rule: '[has(self.image),has(self.version)].filter(x,x==true).size()
+                    >= 1'
+              desired:
+                description: |-
+                  desired is the version that the cluster is reconciling towards.
+                  If the cluster is not yet fully initialized, desired will be set
+                  with the information available, which may be an image or a tag.
+                properties:
+                  image:
+                    description: |-
+                      image is a container image location that contains the update. When this
+                      field is part of spec, image is optional if version is specified.
+                    minLength: 1
+                    type: string
+                  version:
+                    description: |-
+                      version is a semantic version identifying the update version. When this
+                      field is part of spec, version is optional if image is specified.
+                    minLength: 1
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: at least one of the fields in [image version] must be set
+                  rule: '[has(self.image),has(self.version)].filter(x,x==true).size()
+                    >= 1'
+              history:
+                description: |-
+                  history contains a list of the most recent versions applied to the cluster.
+                  This value may be empty during cluster startup, and then will be updated
+                  when a new update is being applied. The newest update is first in the
+                  list and it is ordered by recency. Updates in the history have state
+                  Completed if the rollout completed - if an update was failing or halfway
+                  applied the state will be Partial. Only a limited amount of update history
+                  is preserved.
+                items:
+                  description: UpdateHistory is a single attempted update to the cluster.
+                  properties:
+                    acceptedRisks:
+                      description: acceptedRisks records risks which were accepted
+                        to initiate the update.
+                      type: string
+                    completionTime:
+                      description: |-
+                        completionTime if set, is when the update was fully applied. The update
+                        that is currently being applied will have a null completion time.
+                        Completion time will always be set for entries that are not the current
+                        update (usually to the started time of the next update).
+                      format: date-time
+                      type: string
+                    image:
+                      description: |-
+                        image is a container image location that contains the update. This value
+                        is always populated.
+                      minLength: 1
+                      type: string
+                    startedTime:
+                      description: startedTime is the time at which the update was
+                        started.
+                      format: date-time
+                      type: string
+                    state:
+                      description: |-
+                        state reflects whether the update was fully applied. The Partial state
+                        indicates the update is not fully applied, while the Completed state
+                        indicates the update was successfully rolled out at least once (all
+                        parts of the update successfully applied).
+                      enum:
+                      - Completed
+                      - Partial
+                      type: string
+                    version:
+                      description: |-
+                        version is a semantic version identifying the update version. If the
+                        requested image does not define a version, or if a failure occurs
+                        retrieving the image, this value may be empty.
+                      type: string
+                  required:
+                  - image
+                  - startedTime
+                  - state
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              observedGeneration:
+                description: |-
+                  observedGeneration of the object.
+                  When this matches the object's metadata.generation, it indicates the status is up-to-date.
+                format: int64
+                type: integer
+              preflight:
+                description: |-
+                  preflight records information used during an in-progress upgrade to
+                  support deterministic preflight reentry behavior.
+                properties:
+                  checks:
+                    description: checks records the latest evaluation result for each
+                      preflight check.
+                    items:
+                      description: PreflightCheckStatus records the latest result
+                        of a single preflight check.
+                      properties:
+                        message:
+                          description: message contains human-readable details for
+                            the last result.
+                          type: string
+                        name:
+                          description: name is the preflight check name.
+                          minLength: 1
+                          type: string
+                        policy:
+                          description: policy indicates how the check behaves on reentry.
+                          type: string
+                        reason:
+                          description: reason is a programmatic identifier for the
+                            last result.
+                          type: string
+                        state:
+                          description: state is the latest result state for the check.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  observedAt:
+                    description: observedAt is the time when preflight was last evaluated.
+                    format: date-time
+                    type: string
+                type: object
+              stages:
+                description: |-
+                  stages expose the execution stages and per-operation DAG for the current update.
+                  Stages are executed sequentially; operations within a stage form a DAG.
+                items:
+                  properties:
+                    name:
+                      description: name is the stage display name.
+                      minLength: 1
+                      type: string
+                    operations:
+                      description: operations are the DAG nodes in this stage.
+                      items:
+                        properties:
+                          action:
+                            description: action is Install/Upgrade/Delete (omit for
+                              no-op/unknown).
+                            enum:
+                            - Install
+                            - Upgrade
+                            - Delete
+                            type: string
+                          currentVersion:
+                            description: currentVersion is the observed value at build/progress
+                              time.
+                            type: string
+                          dependsOn:
+                            description: dependsOn lists direct predecessor operation
+                              names within this stage.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          moduleInfo:
+                            description: moduleInfo is the backing ModuleInfo name
+                              (if any).
+                            type: string
+                          name:
+                            description: name is the operation/component identifier
+                              (stable ID).
+                            minLength: 1
+                            type: string
+                          phase:
+                            description: phase is the current operation phase string
+                              (e.g. Running/UpgradePending/Failed).
+                            type: string
+                          targetVersion:
+                            description: targetVersion is the desired value at build/progress
+                              time.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    phase:
+                      description: phase is the lifecycle status of this stage.
+                      enum:
+                      - Pending
+                      - Running
+                      - Finished
+                      type: string
+                    priority:
+                      description: priority is the stage execution order (ascending).
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/config.alauda.io_productmanifests.yaml
+++ b/docs/shared/crds/config.alauda.io_productmanifests.yaml
@@ -1,0 +1,298 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: productmanifests.config.alauda.io
+spec:
+  group: config.alauda.io
+  names:
+    kind: ProductManifest
+    listKind: ProductManifestList
+    plural: productmanifests
+    shortNames:
+    - pdman
+    singular: productmanifest
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec selects the product manifest source to resolve.
+            properties:
+              image:
+                description: image is a container image reference that contains the
+                  update payload.
+                type: string
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              version:
+                description: version is the container image tag that identifies the
+                  update payload.
+                type: string
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+            type: object
+            x-kubernetes-validations:
+            - message: field version is immutable once set
+              rule: '!has(oldSelf.version) || has(self.version)'
+            - message: field image is immutable once set
+              rule: '!has(oldSelf.image) || has(self.image)'
+            - message: exactly one of the fields in [version image] must be set
+              rule: '[has(self.version),has(self.image)].filter(x,x==true).size()
+                == 1'
+          status:
+            description: status reports resolved artifacts for the requested manifest
+              source.
+            properties:
+              artifacts:
+                description: artifacts reports channel-level artifact metadata and
+                  availability.
+                items:
+                  description: Artifact describes one manifest component and its channels.
+                  properties:
+                    channels:
+                      description: channels lists all channels reported by the manifest
+                        for this component.
+                      items:
+                        description: ArtifactChannel describes one artifact channel
+                          from product.yaml.
+                        properties:
+                          artifactStatus:
+                            description: artifactStatus is the channel artifact probe
+                              result.
+                            enum:
+                            - Ready
+                            - Absent
+                            - Failed
+                            type: string
+                          brief:
+                            description: brief is the localized short channel summary.
+                            properties:
+                              en:
+                                description: en is the English variant.
+                                type: string
+                              zh:
+                                description: zh is the Simplified Chinese variant.
+                                type: string
+                            type: object
+                          catalogSource:
+                            description: catalogSource is the OLM catalog source name.
+                            type: string
+                          categories:
+                            description: categories is the category set of this channel.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          channel:
+                            description: channel is the channel name in product.yaml.
+                            minLength: 1
+                            type: string
+                          default:
+                            description: default indicates whether this channel is
+                              the default channel.
+                            type: boolean
+                          description:
+                            description: description is the localized channel description.
+                            properties:
+                              en:
+                                description: en is the English variant.
+                                type: string
+                              zh:
+                                description: zh is the Simplified Chinese variant.
+                                type: string
+                            type: object
+                          digest:
+                            description: digest is the optional OCI digest of this
+                              channel package.
+                            type: string
+                          displayName:
+                            description: displayName is the localized channel display
+                              name.
+                            properties:
+                              en:
+                                description: en is the English variant.
+                                type: string
+                              zh:
+                                description: zh is the Simplified Chinese variant.
+                                type: string
+                            type: object
+                          hidden:
+                            description: hidden indicates this channel should be hidden
+                              from normal display.
+                            type: boolean
+                          packIgnore:
+                            description: packIgnore controls whether this channel
+                              is excluded by packaging workflows.
+                            type: boolean
+                          provider:
+                            description: provider is the localized provider name.
+                            properties:
+                              en:
+                                description: en is the English variant.
+                                type: string
+                              zh:
+                                description: zh is the Simplified Chinese variant.
+                                type: string
+                            type: object
+                          providerType:
+                            description: providerType is the provider classification.
+                            type: string
+                          repository:
+                            description: repository is the OCI repository of this
+                              channel package.
+                            minLength: 1
+                            type: string
+                          supportedArchitectures:
+                            description: supportedArchitectures is the architecture
+                              set this channel supports.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          supportedPlatformVersions:
+                            description: supportedPlatformVersions is the ACP platform
+                              version set this channel supports.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          supportedProtocolStacks:
+                            description: supportedProtocolStacks is the protocol stack
+                              set this channel supports.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          tag:
+                            description: tag is the OCI tag of this channel package.
+                            minLength: 1
+                            type: string
+                        required:
+                        - channel
+                        - repository
+                        - tag
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: name is the manifest component name.
+                      minLength: 1
+                      type: string
+                    packageType:
+                      description: packageType is the manifest package type.
+                      enum:
+                      - ModulePlugin
+                      - OperatorBundle
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              conditions:
+                description: conditions reports reconciliation state for this ProductManifest.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: |-
+                  observedGeneration of the object.
+                  When this matches the object's metadata.generation, it indicates the status is up-to-date.
+                format: int64
+                type: integer
+              resolvedImageDigest:
+                description: resolvedImageDigest is the digest resolved from the desired
+                  release image.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
## Summary

- add a Cluster Version APIs section under Kubernetes APIs
- publish ProductManifest and ClusterVersionShadow schemas from Astrolabe generated CRDs
- keep ModulePluginConfig internal and leave existing upgrade guides unchanged

## Verification

- yarn lint
- yarn build
- generated CRD files match the Astrolabe source manifests byte-for-byte