### PR TITLE
[release-4.3] docs: update NetObserv and Kube-OVN guidance

### DIFF
--- a/docs/en/configure/networking/how_to/kube_ovn/configure_egress_gateway.mdx
+++ b/docs/en/configure/networking/how_to/kube_ovn/configure_egress_gateway.mdx
@@ -106,6 +106,11 @@ Before creating the gateway, prepare the following resources:
 - An external subnet
 - A Network Attachment Definition (NAD) for that subnet
 
+:::note
+  The NetworkAttachmentDefinition name MUST NOT contain a dot (`.`).
+  Each NetworkAttachmentDefinition can be used by only one subnet. Do not reuse the same NetworkAttachmentDefinition across multiple subnets.
+:::
+
 The following example uses a Kube-OVN underlay subnet as the external network.
 
 :::note

--- a/docs/en/configure/networking/how_to/kube_ovn/multiple_networks.mdx
+++ b/docs/en/configure/networking/how_to/kube_ovn/multiple_networks.mdx
@@ -32,6 +32,9 @@ Create an attachnet subnet according to the following example: `network-attachme
 
 :::note
 The provider format in config is `<NAME>.<NAMESPACE>.ovn`, where `<NAME>` and `<NAMESPACE>` are the name and namespace of this NetworkAttachmentDefinition CR respectively.
+
+The NetworkAttachmentDefinition name MUST NOT contain a dot (`.`).
+Each NetworkAttachmentDefinition can be used by only one subnet. Do not reuse the same NetworkAttachmentDefinition across multiple subnets.
 :::
 
 ```yaml

--- a/docs/en/networking/observability/operator-deployment.mdx
+++ b/docs/en/networking/observability/operator-deployment.mdx
@@ -78,15 +78,23 @@ metadata:
 spec:
   configuration:
     files:
-      disable-trace-log: |
+      99-disable-system-logs.xml: | # [!code callout]
         <clickhouse>
-          <trace_log remove="remove"/>
-          <query_thread_log remove="remove"/>
-          <query_log remove="remove"/>
-          <text_log remove="remove"/>
-          <metric_log remove="remove"/>
-          <asynchronous_metric_log remove="remove"/>
-          <part_log remove="remove"/>
+          <trace_log remove="1"/>
+          <text_log remove="1"/>
+          <query_log remove="1"/>
+          <query_thread_log remove="1"/>
+          <part_log remove="1"/>
+          <metric_log remove="1"/>
+          <asynchronous_metric_log remove="1"/>
+          <processors_profile_log remove="1"/>
+          <query_metric_log remove="1"/>
+          <error_log remove="1"/>
+          <crash_log remove="1"/>
+          <opentelemetry_span_log remove="1"/>
+          <session_log remove="1"/>
+          <transactions_info_log remove="1"/>
+          <backup_log remove="1"/>
         </clickhouse>
     clusters:
       - layout:
@@ -98,7 +106,7 @@ spec:
         - 127.0.0.1
         - 0.0.0.0/0
         - ::/0
-      clickhouse_root/password_sha256_hex: <SHA256_HEX_PASSWORD>
+      clickhouse_root/password_sha256_hex: <SHA256_HEX_PASSWORD> # [!code callout]
   defaults:
     templates:
       dataVolumeClaimTemplate: default
@@ -152,6 +160,26 @@ spec:
               storage: 15Gi
 ```
 
+<Callouts>
+
+1. Additional ClickHouse configuration file for disabling system logs that are not required by NetObserv. The `99-` prefix makes the file load after the default configuration, and `remove="1"` removes the corresponding log configuration entries.
+2. SHA-256 hash of the password for the ClickHouse user `clickhouse_root`. Generate the hash from the original plaintext password and replace `<SHA256_HEX_PASSWORD>` with the command output.
+
+</Callouts>
+
+For example, to use `NetObserv@123` as the ClickHouse password, run:
+
+```bash
+printf '%s' 'NetObserv@123' | sha256sum | awk '{print $1}'
+```
+
+Use the generated hash in `clickhouse_root/password_sha256_hex`.
+When you create the `ck-auth` secret later, use `clickhouse_root` as the username and the original plaintext password as the password.
+
+If you want to use a different ClickHouse username, replace `clickhouse_root` in both `clickhouse_root/networks/ip` and `clickhouse_root/password_sha256_hex`.
+For example, for a user named `netobserv_user`, use `netobserv_user/networks/ip` and `netobserv_user/password_sha256_hex`.
+Then use the same username in the `ck-auth` secret.
+
 After the ClickHouse instance is ready, get the service endpoint by inspecting field `.status.endpoint` of the ClickHouseInstallation instance.
 You can also run the following command to get the endpoint:
 
@@ -190,9 +218,12 @@ This secret is referenced by `.spec.clickhouse.authSecret.name` in the FlowColle
 1. Create a local file named _ck-auth.env_ with the following content:
 
     ```ini
-    username=<USERNAME>
-    password=<PASSWORD>
+    username=clickhouse_root
+    password=<PLAINTEXT_PASSWORD>
     ```
+
+    If you use the ClickHouseInstallation example in this section, set `password` to the original plaintext password that was used to generate `<SHA256_HEX_PASSWORD>`.
+    If you use a different ClickHouse username, set `username` to that value.
 
 2. Create the Kubernetes secret:
 


### PR DESCRIPTION
## Summary

- supersede the closed #911 with the reduced `release-4.3` scope requested for #877
- clarify ClickHouse system log configuration and password hash guidance for NetObserv
- document Kube-OVN NetworkAttachmentDefinition naming and subnet reuse constraints
- intentionally omit both the optional VPC Egress Gateway bandwidth limits and the validated BFD capacity guidance from #877

## Verification

- `node .yarn/releases/yarn-4.14.1.cjs lint`