### PR TITLE
docs: clarify DCS Provider compatibility for Alauda OS

### DIFF
--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -9,6 +9,14 @@ title: Release Notes
 
 Issued: 2026-07-04
 
+### Important Compatibility Notice
+
+#### Huawei DCS Provider and Alauda OS
+
+For Huawei DCS clusters that use the Alauda OS image for ACP `v4.3.2` or later, install Huawei DCS Provider `v1.0.21` or later. This requirement also applies to ACP `v4.4.0` and later.
+
+Select the Alauda OS image from the OS Support Matrix row for the same ACP release. Do not pair DCS Provider `v1.0.21` or later with an Alauda OS image for an ACP release earlier than `v4.3.2`. For the complete compatibility requirement, see <ExternalSiteLink name="immutable-infra" href="/overview/providers/huawei-dcs.html#alauda-os-and-provider-compatibility" children="Alauda OS and Provider Compatibility for Huawei DCS" />.
+
 ### Fixed Issues
 
 {/* release-notes-for-bugs?template=acp_fixed_issues_4.3.2 */}


### PR DESCRIPTION
## Summary

- Add the Huawei DCS and Alauda OS compatibility notice to the ACP 4.3.2 release notes.
- State that DCS Provider v1.0.21 or later is required for Alauda OS images paired with ACP v4.3.2 and later, including ACP v4.4.0 and later.
- Link the immutable infrastructure documentation for the complete pairing requirement.

## Validation

- yarn lint