### PR TITLE
docs: point ACP 4.4 cnpg subsite at the 1.29 release docs

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -115,7 +115,7 @@
     en: Alauda support for CloudNativePG
     zh: Alauda support for CloudNativePG
   base: /cnpg
-  version: "main"
+  version: "1.29"
   repo: https://github.com/alauda/cnpg-docs
 - name: costmanagement
   displayName:


### PR DESCRIPTION
## What

On `release-4.4`, `sites.yaml` still resolved the CloudNativePG subsite to the **main** branch docs of `alauda/cnpg-docs`:

```yaml
- name: cnpg
  base: /cnpg
  version: "main"   # -> "1.29"
  repo: https://github.com/alauda/cnpg-docs
```

`version` is the URL path segment doom uses to build cross-site links (`<base><version>/...`, see `ExternalSiteLink`), so `<ExternalSite name="cnpg" href="/intro" />` in `docs/en/appservice/postgresql/cnpg.mdx` pointed ACP 4.4 readers at `/cnpg/main/` — the in-development docs — instead of the released ones.

## Fix

Point it at the released subsite version `1.29` (built from `cnpg-docs` `release-1.29`), matching what `release-4.3` already carries and the convention used by the other data-service subsites (`mysql-mgr: 4.4`, `postgresql: 4.3`, …).

Release branches must never reference a subsite's development branch.

## Note

`master` still has `version: "main"` for this entry; it should be bumped the same way when the next ACP docs release branch is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)