### PR TITLE
docs: point NPU site to v26.6

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -59,7 +59,7 @@
     en: Alauda Ascend NPU
     zh: Alauda Ascend NPU
   base: /npu
-  version: "main"
+  version: "26.6"
   repo: https://github.com/alauda/ascend-docs
 - name: mysql-pxc
   displayName:


### PR DESCRIPTION
## Summary

- point the NPU documentation subsite from `main` to the `26.6` release

## Validation

- pre-commit documentation lint passed
- `git diff --check origin/master..HEAD` passed
- PR diff contains only `sites.yaml`