### PR TITLE
docs(networking): add production risk and config guidance for NodeLocal DNSCache

### DIFF
--- a/docs/en/networking/functions/configure_node_local_dns.mdx
+++ b/docs/en/networking/functions/configure_node_local_dns.mdx
@@ -16,6 +16,17 @@ NodeLocal DNSCache is a cluster plugin that improves cluster DNS performance by 
 ## Important Notes
 
 :::warning
+**Production usage risk**
+
+NodeLocal DNSCache changes the DNS path of newly created Pods on each node. Before enabling it in a production cluster, evaluate the following risks:
+
+- NodeLocal DNSCache uses a local health check port on every node. The default health check port is `8080`, which is commonly used by business workloads.
+- If the node-local DNS Pod on a node is unavailable, DNS resolution for Pods on that node can fail. The traffic does not automatically fail over to CoreDNS unless the Pod resolver is configured with an additional DNS server and the resolver implementation retries the next server.
+
+Use this plugin in test or pre-production environments first. For production environments, confirm the port usage, monitoring, alerting, and emergency recovery plan before enabling the plugin.
+:::
+
+:::warning
 **Deployment Considerations:**
 
 1. **Kube-OVN Underlay Mode**: The plugin does not support deployment in Kube-OVN Underlay mode. If deployed, it may cause DNS query failures.
@@ -86,6 +97,61 @@ Pod → NodeLocal DNSCache → [Cache Hit] → Pod
 ```
 
 ## Configuration
+
+### Default Health Check Port
+
+NodeLocal DNSCache runs a `node-cache` process on each node. The process exposes a health check endpoint on port `8080` by default. The current plugin package does not provide an installation parameter to change this health check port.
+
+Before installing the plugin, check whether port `8080` is already used on each node:
+
+```bash
+ss -ltnp | grep ':8080'
+```
+
+If port `8080` is already used by a workload on the node, choose one of the following approaches:
+
+- Move the workload to another port before installing NodeLocal DNSCache.
+- Deploy the workload without binding to `0.0.0.0:8080` or `127.0.0.1:8080` on the node.
+- If the port must be changed for NodeLocal DNSCache, contact Alauda support to confirm whether your target version provides a supported configuration method.
+
+Avoid manually editing the generated ConfigMap or DaemonSet as a long-term solution. Manual changes can be overwritten when the plugin is upgraded, reinstalled, or reconciled by the platform.
+
+### DNS Availability Risk
+
+After NodeLocal DNSCache takes effect, newly created Pods use the node-local DNS address as their DNS server. If the `node-cache` Pod on a node is unavailable, for example during a crash, eviction, image pull failure, or plugin upgrade, Pods on that node can fail to resolve DNS names.
+
+To reduce the operational risk:
+
+- Monitor the NodeLocal DNSCache DaemonSet and alert when any `node-cache` Pod is not Ready.
+- Plan a maintenance window for plugin upgrades because DNS resolution on a node can be affected while the node-local DNS Pod is unavailable.
+- In an emergency, restore kubelet `cluster-dns` to the CoreDNS ClusterIP and recreate affected Pods so that their `/etc/resolv.conf` is regenerated.
+
+### Optional: Configure Multiple DNS Servers
+
+Kubelet supports multiple `cluster-dns` addresses. You can configure the CoreDNS ClusterIP as a secondary DNS server so that new Pods receive both DNS servers in `/etc/resolv.conf`.
+
+Example:
+
+```yaml
+cluster-dns: "169.254.20.10,10.96.0.10"
+```
+
+In this example, `169.254.20.10` is the NodeLocal DNSCache IP address and `10.96.0.10` is the CoreDNS ClusterIP. Replace both values with the addresses used by your cluster.
+
+This configuration can reduce the impact of a node-local DNS failure, but it is not a no-impact failover mechanism:
+
+- The failover behavior depends on the resolver implementation in the workload image. For example, the glibc resolver typically tries the next nameserver only after the current one times out, so DNS resolution can become slower during a failure. musl libc, which is used by Alpine Linux, can query multiple nameservers in parallel and may fail over faster.
+- Resolver options such as `timeout` and `attempts` also affect the failure delay.
+- If NetworkPolicy is enabled, allow Pods to access both the NodeLocal DNSCache IP address and the CoreDNS ClusterIP on TCP and UDP port `53`.
+
+Validation in an IPv4 cluster showed the following behavior when the node-local DNS process on the workload node was stopped:
+
+- A Pod with only the NodeLocal DNSCache IP address in `/etc/resolv.conf` failed to resolve DNS names.
+- A Pod with both the NodeLocal DNSCache IP address and the CoreDNS ClusterIP in `/etc/resolv.conf` could resolve DNS names through CoreDNS.
+- With the default glibc resolver behavior, failover to CoreDNS can take several seconds because the resolver waits for the first nameserver to time out.
+- With musl libc, such as in Alpine Linux images, DNS queries can be sent to multiple nameservers in parallel, so failover can be faster.
+
+If your cluster is upgraded by rebuilding nodes, add the multi-address `cluster-dns` value to each `kubeletExtraArgs` location described in the **Important Notes** section.
 
 ### Network Policy Configuration
 

--- a/docs/en/networking/functions/configure_node_local_dns.mdx
+++ b/docs/en/networking/functions/configure_node_local_dns.mdx
@@ -131,7 +131,13 @@ To reduce the operational risk:
 
 - Monitor the NodeLocal DNSCache DaemonSet and alert when any `node-cache` Pod is not Ready.
 - Plan a maintenance window for plugin upgrades because DNS resolution on a node can be affected while the node-local DNS Pod is unavailable.
-- In an emergency, restore kubelet `cluster-dns` to the CoreDNS ClusterIP and recreate affected Pods so that their `/etc/resolv.conf` is regenerated.
+- **Emergency recovery**: If DNS resolution on a node fails because the `node-cache` Pod is unavailable, restore kubelet `cluster-dns` to the CoreDNS ClusterIP and recreate the affected Pods so that their `/etc/resolv.conf` is regenerated. The CoreDNS ClusterIP is the `ClusterIP` of the DNS Service in the `kube-system` namespace. To find it:
+
+  ```bash
+  kubectl get svc -n kube-system
+  ```
+
+  Look for the DNS Service (commonly named `kube-dns` or `coredns`) and use its `ClusterIP`.
 
 ### Optional: Configure Multiple DNS Servers
 
@@ -143,7 +149,7 @@ Example:
 cluster-dns: "169.254.20.10,10.96.0.10"
 ```
 
-In this example, `169.254.20.10` is the NodeLocal DNSCache IP address and `10.96.0.10` is the CoreDNS ClusterIP. Replace both values with the addresses used by your cluster.
+In this example, `169.254.20.10` is the NodeLocal DNSCache IP address and `10.96.0.10` is the CoreDNS ClusterIP. Replace both values with the addresses used by your cluster. To find the CoreDNS ClusterIP, run `kubectl get svc -n kube-system` and use the `ClusterIP` of the DNS Service (commonly named `kube-dns` or `coredns`).
 
 This configuration can reduce the impact of a node-local DNS failure, but it is not a no-impact failover mechanism:
 

--- a/docs/en/networking/functions/configure_node_local_dns.mdx
+++ b/docs/en/networking/functions/configure_node_local_dns.mdx
@@ -20,7 +20,7 @@ NodeLocal DNSCache is a cluster plugin that improves cluster DNS performance by 
 
 NodeLocal DNSCache changes the DNS path of newly created Pods on each node. Before enabling it in a production cluster, evaluate the following risks:
 
-- NodeLocal DNSCache uses a local health check port on every node. The default health check port is `8080`, which is commonly used by business workloads.
+- The `node-cache` Pod runs with `hostNetwork: true` and exposes its health check endpoint on the node loopback `127.0.0.1:8080`. This can conflict with other `hostNetwork` Pods or node-host processes that also bind `127.0.0.1:8080` or `0.0.0.0:8080`. Regular Pods are not affected.
 - If the node-local DNS Pod on a node is unavailable, DNS resolution for Pods on that node can fail. The traffic does not automatically fail over to CoreDNS unless the Pod resolver is configured with an additional DNS server and the resolver implementation retries the next server.
 
 Use this plugin in test or pre-production environments first. For production environments, confirm the port usage, monitoring, alerting, and emergency recovery plan before enabling the plugin.
@@ -100,18 +100,25 @@ Pod → NodeLocal DNSCache → [Cache Hit] → Pod
 
 ### Default Health Check Port
 
-NodeLocal DNSCache runs a `node-cache` process on each node. The process exposes a health check endpoint on port `8080` by default. The current plugin package does not provide an installation parameter to change this health check port.
+The `node-cache` Pod runs with `hostNetwork: true` and exposes its health check endpoint on the node loopback `127.0.0.1:8080`. The current plugin package does not provide an installation parameter to change this health check port.
 
-Before installing the plugin, check whether port `8080` is already used on each node:
+Because `node-cache` uses the node network namespace, the `127.0.0.1:8080` it occupies is the **node's** loopback, not a pod's. Conflict only happens with workloads that share the node network namespace or run directly on the node host:
+
+- A `hostNetwork: true` Pod that binds `127.0.0.1:8080` or `0.0.0.0:8080`.
+- A process running directly on the node host that binds `127.0.0.1:8080` or `0.0.0.0:8080`.
+
+Regular Pods (each in its own network namespace) are not affected, even if they listen on `8080`.
+
+Before installing the plugin, check whether `127.0.0.1:8080` is already used on each node:
 
 ```bash
-ss -ltnp | grep ':8080'
+ss -ltnp | grep '127.0.0.1:8080'
 ```
 
-If port `8080` is already used by a workload on the node, choose one of the following approaches:
+If the port is already used by a `hostNetwork` Pod or a node-host process, choose one of the following approaches:
 
-- Move the workload to another port before installing NodeLocal DNSCache.
-- Deploy the workload without binding to `0.0.0.0:8080` or `127.0.0.1:8080` on the node.
+- Move the conflicting workload to another port before installing NodeLocal DNSCache.
+- Run the workload as a regular Pod (not `hostNetwork`), or bind it to a specific node IP other than `127.0.0.1` or `0.0.0.0`.
 - If the port must be changed for NodeLocal DNSCache, contact Alauda support to confirm whether your target version provides a supported configuration method.
 
 Avoid manually editing the generated ConfigMap or DaemonSet as a long-term solution. Manual changes can be overwritten when the plugin is upgraded, reinstalled, or reconciled by the platform.
@@ -143,6 +150,7 @@ This configuration can reduce the impact of a node-local DNS failure, but it is 
 - The failover behavior depends on the resolver implementation in the workload image. For example, the glibc resolver typically tries the next nameserver only after the current one times out, so DNS resolution can become slower during a failure. musl libc, which is used by Alpine Linux, can query multiple nameservers in parallel and may fail over faster.
 - Resolver options such as `timeout` and `attempts` also affect the failure delay.
 - If NetworkPolicy is enabled, allow Pods to access both the NodeLocal DNSCache IP address and the CoreDNS ClusterIP on TCP and UDP port `53`.
+- When the CNI is Kube-OVN, the `--node-local-dns-ip` parameter on `kube-ovn-controller` does not conflict with a multi-address `cluster-dns` on kubelet. `--node-local-dns-ip` lets Kube-OVN deliver traffic to the node-local DNS IP, while the secondary CoreDNS ClusterIP still reaches CoreDNS through the normal Service path.
 
 Validation in an IPv4 cluster showed the following behavior when the node-local DNS process on the workload node was stopped:
 

--- a/docs/en/networking/functions/configure_node_local_dns.mdx
+++ b/docs/en/networking/functions/configure_node_local_dns.mdx
@@ -16,28 +16,23 @@ NodeLocal DNSCache is a cluster plugin that improves cluster DNS performance by 
 ## Important Notes
 
 :::warning
-**Production usage risk**
+**Production and Deployment Considerations:**
 
-NodeLocal DNSCache changes the DNS path of newly created Pods on each node. Before enabling it in a production cluster, evaluate the following risks:
-
-- The `node-cache` Pod runs with `hostNetwork: true` and exposes its health check endpoint on the node loopback `127.0.0.1:8080`. This can conflict with other `hostNetwork` Pods or node-host processes that also bind `127.0.0.1:8080` or `0.0.0.0:8080`. Regular Pods are not affected.
-- If the node-local DNS Pod on a node is unavailable, DNS resolution for Pods on that node can fail. The traffic does not automatically fail over to CoreDNS unless the Pod resolver is configured with an additional DNS server and the resolver implementation retries the next server.
-
-Use this plugin in test or pre-production environments first. For production environments, confirm the port usage, monitoring, alerting, and emergency recovery plan before enabling the plugin.
-:::
-
-:::warning
-**Deployment Considerations:**
+Use NodeLocal DNSCache cautiously in production or production-like clusters. Before enabling it for business workloads, evaluate the following host port and node-level DNS availability risks. If these risks are not acceptable for your workload, continue to use CoreDNS directly instead of enabling NodeLocal DNSCache.
 
 1. **Kube-OVN Underlay Mode**: The plugin does not support deployment in Kube-OVN Underlay mode. If deployed, it may cause DNS query failures.
 
 2. **Kubelet Restart**: Deploying this plugin will cause the kubelet to restart.
 
-3. **Pod Restart Required**: After the plugin is successfully deployed, it will not affect running Pods, but will only take effect on newly created Pods. When the CNI is Kube-OVN, you need to manually add the parameter "--node-local-dns-ip=(IP address of the local DNS cache server)" to the kube-ovn-controller.
+3. **Host Port 8080 Usage**: The `node-cache` container uses `hostNetwork: true` and listens on `127.0.0.1:8080` for its health endpoint. This can conflict with node-level services or workloads that use `hostNetwork` or `hostPort` and bind `127.0.0.1:8080` or `0.0.0.0:8080`.
 
-4. **NetworkPolicy Configuration**: If NetworkPolicy is configured in the cluster, you need to additionally allow both from and to directions for the node CIDR and nodeLocalDNSIP in the networkPolicy to ensure proper communication.
+4. **Node-Level DNS Availability**: After the plugin takes effect, Pods on a node use the local NodeLocal DNSCache endpoint for DNS resolution. If the NodeLocal DNSCache Pod on that node crashes, is evicted, cannot pull its image, or is restarted during an upgrade, DNS resolution for all Pods on that node may fail. Pods do not automatically fall back to CoreDNS.
 
-5. **Cluster Upgrade via Rebuilding**: If the cluster is upgraded by rebuilding nodes (re-provisioning), kubelet configuration changes will be lost. To make the NodeLocal DNS configuration persistent across upgrades, you need to add the `--cluster-dns` parameter to `kubeletExtraArgs` in the following three places of the cluster template:
+5. **Pod Restart Required**: After the plugin is successfully deployed, it will not affect running Pods, but will only take effect on newly created Pods. When the CNI is Kube-OVN, you need to manually add the parameter "--node-local-dns-ip=(IP address of the local DNS cache server)" to the kube-ovn-controller.
+
+6. **NetworkPolicy Configuration**: If NetworkPolicy is configured in the cluster, you need to additionally allow both from and to directions for the node CIDR and nodeLocalDNSIP in the networkPolicy to ensure proper communication.
+
+7. **Cluster Upgrade via Rebuilding**: If the cluster is upgraded by rebuilding nodes (re-provisioning), kubelet configuration changes will be lost. To make the NodeLocal DNS configuration persistent across upgrades, you need to add the `--cluster-dns` parameter to `kubeletExtraArgs` in the following three places of the cluster template:
    - `KubeadmControlPlane` → `initConfiguration` → `nodeRegistration` → `kubeletExtraArgs`
    - `KubeadmControlPlane` → `joinConfiguration` → `nodeRegistration` → `kubeletExtraArgs`
    - `KubeadmConfigTemplate` → `template` → `spec` → `joinConfiguration` → `nodeRegistration` → `kubeletExtraArgs`
@@ -97,75 +92,6 @@ Pod → NodeLocal DNSCache → [Cache Hit] → Pod
 ```
 
 ## Configuration
-
-### Default Health Check Port
-
-The `node-cache` Pod runs with `hostNetwork: true` and exposes its health check endpoint on the node loopback `127.0.0.1:8080`. The current plugin package does not provide an installation parameter to change this health check port.
-
-Because `node-cache` uses the node network namespace, the `127.0.0.1:8080` it occupies is the **node's** loopback, not a pod's. Conflict only happens with workloads that share the node network namespace or run directly on the node host:
-
-- A `hostNetwork: true` Pod that binds `127.0.0.1:8080` or `0.0.0.0:8080`.
-- A process running directly on the node host that binds `127.0.0.1:8080` or `0.0.0.0:8080`.
-
-Regular Pods (each in its own network namespace) are not affected, even if they listen on `8080`.
-
-Before installing the plugin, check whether `127.0.0.1:8080` is already used on each node:
-
-```bash
-ss -ltnp | grep '127.0.0.1:8080'
-```
-
-If the port is already used by a `hostNetwork` Pod or a node-host process, choose one of the following approaches:
-
-- Move the conflicting workload to another port before installing NodeLocal DNSCache.
-- Run the workload as a regular Pod (not `hostNetwork`), or bind it to a specific node IP other than `127.0.0.1` or `0.0.0.0`.
-- If the port must be changed for NodeLocal DNSCache, contact Alauda support to confirm whether your target version provides a supported configuration method.
-
-Avoid manually editing the generated ConfigMap or DaemonSet as a long-term solution. Manual changes can be overwritten when the plugin is upgraded, reinstalled, or reconciled by the platform.
-
-### DNS Availability Risk
-
-After NodeLocal DNSCache takes effect, newly created Pods use the node-local DNS address as their DNS server. If the `node-cache` Pod on a node is unavailable, for example during a crash, eviction, image pull failure, or plugin upgrade, Pods on that node can fail to resolve DNS names.
-
-To reduce the operational risk:
-
-- Monitor the NodeLocal DNSCache DaemonSet and alert when any `node-cache` Pod is not Ready.
-- Plan a maintenance window for plugin upgrades because DNS resolution on a node can be affected while the node-local DNS Pod is unavailable.
-- **Emergency recovery**: If DNS resolution on a node fails because the `node-cache` Pod is unavailable, restore kubelet `cluster-dns` to the CoreDNS ClusterIP and recreate the affected Pods so that their `/etc/resolv.conf` is regenerated. The CoreDNS ClusterIP is the `ClusterIP` of the DNS Service in the `kube-system` namespace. To find it:
-
-  ```bash
-  kubectl get svc -n kube-system
-  ```
-
-  Look for the DNS Service (commonly named `kube-dns` or `coredns`) and use its `ClusterIP`.
-
-### Optional: Configure Multiple DNS Servers
-
-Kubelet supports multiple `cluster-dns` addresses. You can configure the CoreDNS ClusterIP as a secondary DNS server so that new Pods receive both DNS servers in `/etc/resolv.conf`.
-
-Example:
-
-```yaml
-cluster-dns: "169.254.20.10,10.96.0.10"
-```
-
-In this example, `169.254.20.10` is the NodeLocal DNSCache IP address and `10.96.0.10` is the CoreDNS ClusterIP. Replace both values with the addresses used by your cluster. To find the CoreDNS ClusterIP, run `kubectl get svc -n kube-system` and use the `ClusterIP` of the DNS Service (commonly named `kube-dns` or `coredns`).
-
-This configuration can reduce the impact of a node-local DNS failure, but it is not a no-impact failover mechanism:
-
-- The failover behavior depends on the resolver implementation in the workload image. For example, the glibc resolver typically tries the next nameserver only after the current one times out, so DNS resolution can become slower during a failure. musl libc, which is used by Alpine Linux, can query multiple nameservers in parallel and may fail over faster.
-- Resolver options such as `timeout` and `attempts` also affect the failure delay.
-- If NetworkPolicy is enabled, allow Pods to access both the NodeLocal DNSCache IP address and the CoreDNS ClusterIP on TCP and UDP port `53`.
-- When the CNI is Kube-OVN, the `--node-local-dns-ip` parameter on `kube-ovn-controller` does not conflict with a multi-address `cluster-dns` on kubelet. `--node-local-dns-ip` lets Kube-OVN deliver traffic to the node-local DNS IP, while the secondary CoreDNS ClusterIP still reaches CoreDNS through the normal Service path.
-
-Validation in an IPv4 cluster showed the following behavior when the node-local DNS process on the workload node was stopped:
-
-- A Pod with only the NodeLocal DNSCache IP address in `/etc/resolv.conf` failed to resolve DNS names.
-- A Pod with both the NodeLocal DNSCache IP address and the CoreDNS ClusterIP in `/etc/resolv.conf` could resolve DNS names through CoreDNS.
-- With the default glibc resolver behavior, failover to CoreDNS can take several seconds because the resolver waits for the first nameserver to time out.
-- With musl libc, such as in Alpine Linux images, DNS queries can be sent to multiple nameservers in parallel, so failover can be faster.
-
-If your cluster is upgraded by rebuilding nodes, add the multi-address `cluster-dns` value to each `kubeletExtraArgs` location described in the **Important Notes** section.
 
 ### Network Policy Configuration
 


### PR DESCRIPTION
## What / Why

Add production-readiness and operational guidance to the NodeLocal DNSCache doc. The current page only describes installation; it does not warn about the operational risks that come with changing every new Pod's DNS path on a node.

## Changes

- **Production usage risk** warning at the top of *Important Notes*: default health-check port \`8080\` conflicts with common workloads, and a failed \`node-cache\` Pod breaks DNS for all Pods on that node without automatic failover to CoreDNS.
- **Default Health Check Port**: how to check \`8080\` usage (\`ss -ltnp\`), three remediation options, and a note not to hand-edit the generated ConfigMap/DaemonSet long-term.
- **DNS Availability Risk**: monitoring/alerting, upgrade maintenance window, emergency recovery (revert kubelet \`cluster-dns\` to the CoreDNS ClusterIP and recreate affected Pods).
- **Optional: Configure Multiple DNS Servers**: set CoreDNS ClusterIP as a secondary \`cluster-dns\` so new Pods get both nameservers, with glibc vs musl failover behavior notes and IPv4 test-cluster observations.

## Notes

- No Chinese version of this file exists; only \`docs/en/...\` is updated.
- Out of scope: installation steps unchanged.