### PR TITLE
docs: add networking, storage, and virtualization 4.4 release notes

### DIFF
--- a/.cspell/brands.txt
+++ b/.cspell/brands.txt
@@ -5,3 +5,7 @@ topolvm
 cpaas
 cnpg
 cloudnativepg
+netapp
+oceanstor
+dorado
+forklift

--- a/.cspell/brands.txt
+++ b/.cspell/brands.txt
@@ -5,7 +5,4 @@ topolvm
 cpaas
 cnpg
 cloudnativepg
-netapp
-oceanstor
-dorado
 forklift

--- a/.cspell/k8s.txt
+++ b/.cspell/k8s.txt
@@ -8,3 +8,5 @@ moduleinfoes
 accesstokeninfoes
 tkestack
 hyperconvergeds
+ipvlan
+macvlan

--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -57,7 +57,7 @@ The next separately versioned component release in the ACP 4.4 delivery cycle wi
 
 #### Networking
 
-- **DPDK and SR-IOV support** — <Term name="productShort" /> 4.4 supports DPDK userspace networking and SR-IOV high-performance network attachments, so network-intensive workloads such as carrier core-network applications can run on the platform.
+- **SR-IOV support** — <Term name="productShort" /> 4.4 supports passing SR-IOV network interfaces directly through to Pods, so network-intensive workloads such as carrier core-network applications can run on the platform.
 
 - **OVN security group FQDN rules** — SecurityGroup rules support domain-name (FQDN) matching, so administrators can define egress policies with domain names instead of only static IP or CIDR targets.
 
@@ -75,13 +75,9 @@ The next separately versioned component release in the ACP 4.4 delivery cycle wi
 
 - **Unified storage component management** — The Alauda storage operator becomes the unified entry point for storage components, managing installation, upgrade, status, and dependencies of built-in Ceph, TopoLVM, local storage, and external Ceph.
 
-- **Expanded CSI driver catalog** — Adds certification for NetApp, Pure Storage, and Huawei OceanStor CSI drivers, and completes Huawei Dorado commercial certification.
-
 - **Ceph encryption in transit and at rest** — Ceph supports in-transit encryption and KMS-backed at-rest encryption. For details, see [In-Transit Encryption](../storage/storagesystem_ceph/how_to/in-transit-encryption.mdx) and [Persistent Volume Encryption](../storage/storagesystem_ceph/how_to/persistent-volume-encryption.mdx).
 
 - **Ceph multi-NIC networking** — The Ceph container network supports multiple network interfaces, separating client traffic from replication traffic.
-
-- **Independent Ceph cluster upgrade** — Ceph clusters can be upgraded independently of the platform upgrade flow.
 
 - **Object storage usability** — CephObjectStoreUser quota usage can be viewed, monitored, and alerted on. Bucket claim Secrets expose standard `accessKey`/`secretKey` fields that AWS SDKs and common tools can consume directly, and the console shows the Secret associated with each bucket claim.
 

--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -55,6 +55,44 @@ The next separately versioned component release in the ACP 4.4 delivery cycle wi
 
 - **VictoriaMetrics for Cost Management** — Cost Management and metering can use VictoriaMetrics as their metrics data source. Queries are scoped to the relevant cluster, helping ensure that cost and resource-usage data is returned for the correct cluster in multi-cluster environments. For details, see [Cost Management](../costmanagement/cost_management.mdx).
 
+#### Networking
+
+- **DPDK and SR-IOV support** — <Term name="productShort" /> 4.4 supports DPDK userspace networking and SR-IOV high-performance network attachments, so network-intensive workloads such as carrier core-network applications can run on the platform.
+
+- **OVN security group FQDN rules** — SecurityGroup rules support domain-name (FQDN) matching, so administrators can define egress policies with domain names instead of only static IP or CIDR targets.
+
+- **OVN database SSL encryption** — Connections to the OVN database can be encrypted with SSL, including certificate-based access and certificate rotation, improving control-plane communication security.
+
+- **AdminNetworkPolicy GA** — AdminNetworkPolicy adapts to the new API version and is now generally available, with web console management. For details, see [Admin Network Policy](../networking/security/admin_network_policy.mdx).
+
+- **IPVLAN CNI binary** — The Kube-OVN delivery now ships the `ipvlan` CNI binary alongside `macvlan`, enabling secondary-network-interface scenarios such as VIP egress over an underlay BGP fabric.
+
+- **Gateway and Ingress observability** — New monitoring dashboards cover the Ingress Controller and Gateway, and MetalLB dashboards add BGP session state and IP address pool utilization. `ingress-nginx` adds OpenTelemetry support and authenticated access to its metrics endpoint.
+
+- **Visual IP pool management** — Create and manage IP pools from the web console for fine-grained IP management in multi-VLAN clusters.
+
+#### Storage
+
+- **Unified storage component management** — The Alauda storage operator becomes the unified entry point for storage components, managing installation, upgrade, status, and dependencies of built-in Ceph, TopoLVM, local storage, and external Ceph.
+
+- **Expanded CSI driver catalog** — Adds certification for NetApp, Pure Storage, and Huawei OceanStor CSI drivers, and completes Huawei Dorado commercial certification.
+
+- **Ceph encryption in transit and at rest** — Ceph supports in-transit encryption and KMS-backed at-rest encryption. For details, see [In-Transit Encryption](../storage/storagesystem_ceph/how_to/in-transit-encryption.mdx) and [Persistent Volume Encryption](../storage/storagesystem_ceph/how_to/persistent-volume-encryption.mdx).
+
+- **Ceph multi-NIC networking** — The Ceph container network supports multiple network interfaces, separating client traffic from replication traffic.
+
+- **Independent Ceph cluster upgrade** — Ceph clusters can be upgraded independently of the platform upgrade flow.
+
+- **Object storage usability** — CephObjectStoreUser quota usage can be viewed, monitored, and alerted on. Bucket claim Secrets expose standard `accessKey`/`secretKey` fields that AWS SDKs and common tools can consume directly, and the console shows the Secret associated with each bucket claim.
+
+#### Virtualization
+
+- **CPU and memory hotplug** — Add CPU and memory to a running virtual machine without shutting it down. For procedures and guest OS support details, see [CPU and Memory Hotplug](../virtualization/virtualization/virtual_machine/how_to/vm_cpu_memory_hotplug.mdx).
+
+- **Physical GPU passthrough** — Attach a physical GPU directly to a virtual machine for GPU-accelerated workloads.
+
+- **Virtual machine migration (V2V)** — Integrates the forklift plugin to migrate virtual machines from traditional virtualization platforms to <Term name="productShort" />.
+
 #### Global Cluster Disaster Recovery Enhancements
 
 Global Cluster Disaster Recovery remains supported for both traditional operating system deployments and Alauda OS-based Immutable Infrastructure deployments. In 4.4, the synchronization path is more resilient and covers more of the `global` cluster lifecycle. This capability protects the `global` control plane; it does not protect application data.
@@ -97,6 +135,11 @@ For your provider and exact supported version, see [About Immutable Infrastructu
 The following updates are planned for separately versioned provider releases in the ACP 4.4 delivery cycle. Upgrading ACP to 4.4.0 alone does not install them; use the matching provider release when it becomes available. Provider product documentation and release notes will publish the detailed support boundaries and procedures.
 
 - **VMware vSphere fixed-address node lifecycle** — The VMware vSphere Provider update improves MachineConfigPool health and bootstrap diagnostics, persistent and ephemeral disk handling, and rolling-update safeguards for fixed-address nodes. A virtual machine that an administrator intentionally powers off for maintenance can remain powered off.
+
+### Deprecations and Removals
+
+- **System ALB removed** — The platform-level system ALB is removed in 4.4.
+- **MinIO Operator removed** — The MinIO Operator is no longer shipped with the platform starting in 4.4. Use Ceph object storage for S3-compatible object storage.
 
 ### Known Issues
 


### PR DESCRIPTION
## Summary

Adds the networking, storage, and virtualization feature notes to the ACP 4.4.0 release notes (`docs/en/overview/release_notes.mdx`), compiled from the completed 4.4.0 Epics in Jira (net / storage labels), trimmed to customer-visible features only.

- **Networking**: SR-IOV Pod passthrough, OVN security group FQDN rules, OVN-DB SSL encryption, AdminNetworkPolicy GA, IPVLAN CNI binary, Gateway/Ingress observability (dashboards, OpenTelemetry, authenticated metrics), visual IP pool management
- **Storage**: unified storage component management, Ceph encryption in transit and at rest, Ceph multi-NIC networking, object storage usability
- **Virtualization**: VM CPU/memory hotplug, physical GPU passthrough, V2V migration (forklift)
- **Deprecations and Removals**: system ALB removed, MinIO Operator removed
- Adds new product terms to the cspell dictionaries

Excluded by design: cancelled / not-completed Epics, and UI features that depend on the new web console (which did not ship with 4.4.0).

`doom lint` passes with 0 errors and 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)