### PR TITLE
docs: clarify ACP 4.5 extension delivery

### DIFF
--- a/docs/en/extend/download_package.mdx
+++ b/docs/en/extend/download_package.mdx
@@ -54,6 +54,12 @@ mv -f violet_darwin_arm64 /usr/bin/violet && chmod +x /usr/bin/violet
 
 > **Note**: If the tool path is not added to your environment variables, you must specify the full path when running commands.
 
+The `violet ac` commands require **Violet v4.2.9 or later**. After installing the binary, verify its version:
+
+```bash
+violet version
+```
+
 ## Prerequisites
 
 **Permission requirements**
@@ -93,7 +99,7 @@ List available scenarios
 Output: A formatted table listing `ID`, `Name` and `Description`.
 
 ```bash
-violet ac scenarios --arch=amd64 --platformVersion=v4.1 --upgrade=true
+violet ac scenarios --arch=amd64 --platformVersion=v4.5.0
 ```
 
 #### Optional Flags
@@ -101,10 +107,32 @@ violet ac scenarios --arch=amd64 --platformVersion=v4.1 --upgrade=true
 ```
 --arch               target architecture (`amd64` , `arm64` , `hybrid`, default: `amd64`)
 --platformVersion    target platform version
---upgrade            boolean flag to filter for upgrade-related scenarios (default: `false`)
 ```
 
-> **Note**: The `--upgrade` flag is required only when upgrading from ACP 3.x to ACP 4.x. For ACP 4.x and later, this flag is not required.
+#### ACP 4.5 Installation and Upgrade Scenarios
+
+Use the following scenarios when preparing <Term name="productShort" /> 4.5 packages:
+
+| Scenario | Use |
+| --- | --- |
+| `Common ACP Extensions` | Download the package set that contains the eight Aligned applications required for a new <Term name="productShort" /> 4.5 installation, together with other Extensions. |
+| `ACP Upgrade to v4.5` | Download the Aligned Extension packages required when upgrading an existing environment to <Term name="productShort" /> 4.5. |
+
+Set `<target-platform-version>` to the exact ACP Distribution Version of the Core Package, such as `v4.5.0`. Set `<arch>` to `amd64`, `arm64`, or `hybrid` to match the Core Package.
+
+First list the available scenarios to confirm that the expected scenario is published for the target version and architecture. Then download the required scenario:
+
+```bash
+violet ac scenarios --arch=<arch> --platformVersion=<target-platform-version>
+
+# New installation
+violet ac download-app --arch=<arch> --platformVersion=<target-platform-version> --scenario="Common ACP Extensions"
+
+# Upgrade to ACP 4.5
+violet ac download-app --arch=<arch> --platformVersion=<target-platform-version> --scenario="ACP Upgrade to v4.5"
+```
+
+Downloading a scenario does not add its packages to the Core Package. Extract the Core Package and manually copy the packages required by the installation or upgrade procedure into its `plugins/` directory. For the exact application names and copy steps, see [Download](/install/prepare/download.mdx#required-aligned-extensions) and [Pre-Upgrade Preparation](/upgrade/pre-upgrade.mdx#download-acp-upgrade-to-v45).
 
 ### violet ac packages
 

--- a/docs/en/install/installing.mdx
+++ b/docs/en/install/installing.mdx
@@ -4,13 +4,13 @@ weight: 30
 
 # Installing
 
-This section describes how to install <Term name="productShort" /> Core and deploy the `global` cluster.
+This section describes how to install <Term name="productShort" /> Core and the required Aligned Extensions, and deploy the `global` cluster.
 
 <Directive type="info" title="Installation Path">
 This installation path applies to clusters running on a **traditional operating system**. If your environment uses Alauda OS, see <ExternalSiteLink name="immutable-infra" href="/global/install.html" children="Installing the global Cluster on Immutable Infrastructure" /> instead.
 </Directive>
 
-Before starting the installation, please ensure that you have completed the prerequisite checks, installation package download and verification, node preprocessing, and other preparatory work.
+Before starting the installation, ensure that you have completed the prerequisite checks, downloaded and verified the Core Package and required Aligned Extension packages, completed node preprocessing, and finished the other preparation work.
 
 ## Process
 
@@ -28,8 +28,24 @@ cd /root/cpaas-install/installer || exit 1
 <Directive type="info" title="INFO">
 - This machine will become the first control plane node after the `global` cluster installation is complete.
 - After the Core Package is extracted, at least **100GB** of disk space is required. Please ensure sufficient storage resources.
-- If you have already downloaded extensions, complete the <Term name="productShort" /> Core installation first, and then follow [Extend](../extend/index.mdx) to upload and install them.
+- The Core Package does not contain the required Aligned Extension packages. Prepare them separately as described in [Download](./prepare/download.mdx#required-aligned-extensions).
 </Directive>
+
+### Prepare the Required Aligned Extension Packages
+
+Copy each of the eight packages listed in [Required Aligned Extensions](./prepare/download.mdx#required-aligned-extensions) into the `plugins/` directory of the extracted Core Package. Run the following command once for each package:
+
+```shell
+cp <path-to-extension-package> /root/cpaas-install/installer/plugins/
+```
+
+Confirm that the directory contains the eight required packages before starting the installer:
+
+```shell
+ls -1 /root/cpaas-install/installer/plugins/
+```
+
+Do not copy other packages from **Common ACP Extensions** into this directory. The installer processes only the packages that you manually place in `plugins/`; it does not download packages from the Customer Portal.
 
 ### Start the Installer \{#start_installer}
 
@@ -63,7 +79,7 @@ After completing the installation parameter configuration according to the page 
 
 ## Validate the Installation
 
-After the installer reports that <Term name="productShort" /> Core installation is complete, validate the platform before continuing with post-install tasks. For the checklist and commands, see [Validation](./validation.mdx).
+After the installer reports that the installation is complete, validate Core and the required Aligned Extensions before continuing with post-install tasks. For the checklist and commands, see [Validation](./validation.mdx).
 
 ## Parameter Description \{#parameters}
 

--- a/docs/en/install/next_steps.mdx
+++ b/docs/en/install/next_steps.mdx
@@ -4,13 +4,13 @@ weight: 50
 
 # Next Steps
 
-After <Term name="productShort" /> Core validation succeeds, complete the following post-install tasks according to your scenario.
+After Core and the required Aligned Extensions pass validation, complete the following post-install tasks according to your scenario.
 
 | Priority | Task | When to use | Continue with |
 | --- | --- | --- | --- |
 | Recommended immediately | Install the Product Docs plugin. | Install this plugin so in-console help links can open product documentation. | [Install Product Docs Plugin](#install_product_docs_plugin) |
 | Conditional | Create workload clusters or connect existing clusters. | Use this path when your architecture requires workload clusters separate from the `global` cluster. | [Clusters](../configure/clusters/index.mdx) |
-| Conditional | Upload and install Extensions Packages. | Use this path when you need additional platform capabilities after <Term name="productShort" /> Core is installed. | [Extend](../extend/index.mdx) |
+| Conditional | Upload and install additional Extensions Packages. | Use this path for packages from **Common ACP Extensions** that were not part of the eight required installation packages, or when you need other platform capabilities. | [Extend](../extend/index.mdx) |
 | Recommended before broad user onboarding | Configure identity providers, users, roles, projects, and project membership. | Use this path before onboarding administrators, project users, or application teams. | [Users and Roles](../security/users_and_roles/index.mdx) and [Projects](../security/project/index.mdx) |
 | Recommended before application workloads | Prepare storage, networking, registry access, and workload prerequisites. | Use this path before application teams deploy workloads. | [Storage](../configure/storage/index.mdx), [Networking](../networking/index.mdx), [Registry](../developer/registry/index.mdx), and [Clusters](../configure/clusters/index.mdx) |
 | Recommended before production operation | Review backup, upgrade, monitoring, and operational documentation. | Use this path before operating the platform for production workloads. | [Backup](../configure/backup/index.mdx), [Upgrade](../upgrade/index.mdx), and [Observability](../observability/index.mdx) |

--- a/docs/en/install/overview.mdx
+++ b/docs/en/install/overview.mdx
@@ -4,11 +4,11 @@ weight: 10
 
 # Overview
 
-Use the Install section to plan and complete **<Term name="productShort" /> Core** installation.
+Use the Install section to plan and complete an <Term name="productShort" /> 4.5 installation.
 
-<Term name="productShort" /> Core installation deploys the `global` cluster, which provides the platform management plane for web console access, cluster management, users and roles, and extension management. For the platform architecture and definitions of `global` cluster and workload cluster, see [Architecture](../overview/architecture.mdx) and [Glossary](../overview/glossary.mdx).
+The installation deploys <Term name="productShort" /> Core and the required Aligned Extensions on the `global` cluster. Core provides the platform management plane, cluster management, users and roles, and Extension management frameworks. The required Aligned Extensions provide the Web Console and other platform-facing capabilities. For the platform architecture and definitions of `global` cluster and workload cluster, see [Architecture](../overview/architecture.mdx) and [Glossary](../overview/glossary.mdx).
 
-<Term name="productShort" /> Core installation does not create workload clusters, import existing clusters, or install Extensions Packages. Operators and Cluster Plugins that are delivered as Extensions are installed after <Term name="productShort" /> Core through the [Extend](../extend/index.mdx) workflow.
+The Core Package and the required Aligned Extension packages are separate downloads. Before starting the installer, copy the eight required Extension packages listed in [Download](./prepare/download.mdx#required-aligned-extensions) into the `plugins/` directory of the extracted Core Package. Other Extensions are installed after the platform installation through the [Extend](../extend/index.mdx) workflow.
 
 <Directive type="info" title="INFO">
 <Term name="productShort" /> Core installation does not support direct installation of the `global` cluster into an existing Kubernetes environment. Prepare new nodes that meet the hardware, network, storage, and OS requirements before you start installation.
@@ -16,35 +16,35 @@ Use the Install section to plan and complete **<Term name="productShort" /> Core
 
 ## Installation Scope
 
-<Term name="productShort" /> Core installation provides the foundation for the platform management plane. After <Term name="productShort" /> Core is installed and verified, you can create or connect workload clusters and install Extensions according to your platform scenario.
+The installation provides the platform management plane and the required Aligned Extensions. After the installation is verified, you can create or connect workload clusters and install additional Extensions according to your platform scenario.
 
 <Directive type="info" title="Installation Path">
 The procedure described in this section installs the `global` cluster onto a **traditional operating system** such as Ubuntu or RHEL. If the `global` cluster uses Alauda OS, see <ExternalSiteLink name="immutable-infra" href="/global/install.html" children="Installing the global Cluster on Immutable Infrastructure" /> instead.
 </Directive>
 
-The following work is outside the <Term name="productShort" /> Core installation flow:
+The following work is outside this installation flow:
 
 - Creating workload clusters.
 - Connecting existing Kubernetes clusters.
-- Uploading and installing Extensions Packages.
-- Installing Operators or Cluster Plugins that are delivered as Extensions.
+- Uploading and installing Extensions other than the eight required Aligned Extensions.
+- Installing optional Operators or Cluster Plugins.
 - Configuring optional platform capabilities such as storage, monitoring, backup, registry, or identity integrations.
 
 ## Installation Workflow
 
-<Term name="productShort" /> Core installation follows this high-level path:
+The installation follows this high-level path:
 
 1. [Plan](./planning.mdx). Choose the deployment architecture and confirm install-time decisions.
 2. [Prepare for installation](./prepare/index.mdx). Prepare resources, network access, storage, and nodes.
-3. [Download](./prepare/download.mdx). Obtain the official Core Package from the <Term name="company" /> Customer Portal.
-4. [Installing](./installing.mdx). Upload the Core Package, start the installer, and configure installation parameters.
-5. [Validation](./validation.mdx). Confirm that the platform Web UI, core applications, and Pods are healthy.
+3. [Download](./prepare/download.mdx). Download the Core Package and the `Common ACP Extensions` package set separately from the <Term name="company" /> Customer Portal.
+4. [Installing](./installing.mdx). Extract the Core Package, copy the eight required Aligned Extension packages into `plugins/`, start the installer, and configure installation parameters.
+5. [Validation](./validation.mdx). Confirm that the platform Web UI, Core, required Aligned Extensions, and Pods are healthy.
 6. [Next Steps](./next_steps.mdx). Install the Product Docs plugin and follow scenario-based next steps.
 
 The Customer Portal is the official source for <Term name="productShort" /> installation packages. For download requirements and package architecture options, see [Download](./prepare/download.mdx).
 
-<Directive type="info" title="INFO">
-If you have already downloaded Extensions Packages, install <Term name="productShort" /> Core first. Upload and install Extensions Packages only after <Term name="productShort" /> Core installation is complete.
+<Directive type="info" title="Separate Downloads">
+The Core Package does not contain the required Aligned Extension packages. Download them separately and manually copy only the eight packages listed in [Download](./prepare/download.mdx#required-aligned-extensions) into the `plugins/` directory of the extracted Core Package before starting the installer.
 </Directive>
 
 ## Related Documentation

--- a/docs/en/install/planning.mdx
+++ b/docs/en/install/planning.mdx
@@ -7,7 +7,7 @@ weight: 15
 Before you start the installer, choose the deployment architecture and confirm the installation settings that affect later operations.
 
 <Directive type="info" title="INFO">
-<Term name="productShort" /> Core installation deploys the `global` cluster on prepared nodes. It does not support direct installation of the `global` cluster into an existing Kubernetes environment.
+The <Term name="productShort" /> installation deploys the `global` cluster on prepared nodes. It does not support direct installation of the `global` cluster into an existing Kubernetes environment.
 </Directive>
 
 ## Choose a Deployment Architecture
@@ -28,7 +28,7 @@ Confirm the following decisions before running the installer:
 
 | Decision | What to confirm | Continue with |
 | --- | --- | --- |
-| Package architecture | Choose an x86, ARM, or hybrid Core Package. | [Download](./prepare/download.mdx) |
+| Installation packages | Choose an x86, ARM, or hybrid Core Package and download the required Aligned Extension packages for the same <Term name="productShort" /> version and architecture. | [Download](./prepare/download.mdx) |
 | Cluster network protocol | Choose IPv4, IPv6, or dual stack before starting the installer. | [Installing](./installing.mdx#start_installer) |
 | Cluster Endpoint and Platform Access Address | Prepare the access addresses that cluster components, administrators, and users will use. | [Prerequisites](./prepare/prerequisites.mdx#network-resources) and [Parameter Description](./installing.mdx#parameters) |
 | Load balancing | Decide whether to use an external load balancer or Self-built VIP. | [Prerequisites](./prepare/prerequisites.mdx#network-resources) and [LoadBalancer Forwarding Rules](./prepare/prerequisites.mdx#port-forward) |
@@ -46,6 +46,6 @@ Use the following pages as the source of truth before running the installer:
 - [Prerequisites](./prepare/prerequisites.mdx): Prepare resource, network, and storage requirements.
 - [Disk Configuration Requirements](../configure/scalability/disk_configuration.mdx): Confirm disk capacity and performance requirements.
 - [Node Preprocessing](./prepare/node_preprocessing.mdx): Check and prepare each node before installation.
-- [Download](./prepare/download.mdx): Download the Core Package and select the package architecture.
+- [Download](./prepare/download.mdx): Download the Core Package and `Common ACP Extensions` separately, and verify that their version and architecture match.
 - [Global Cluster Disaster Recovery](./global_dr.mdx): Plan primary and standby `global` clusters if disaster recovery is required.
 - [Installing](./installing.mdx): Upload the Core Package, start the installer, and configure parameters.

--- a/docs/en/install/prepare/download.mdx
+++ b/docs/en/install/prepare/download.mdx
@@ -4,7 +4,7 @@ weight: 20
 
 # Download \{#download_core_package}
 
-Before installation, download the **Core Package** from the **<Term name="company" /> Customer Portal**.
+Before installation, download the **Core Package** and the required Aligned Extension packages separately from the **<Term name="company" /> Customer Portal**.
 
 ## About the Customer Portal
 
@@ -20,15 +20,52 @@ The Customer Portal provides access to the following resources:
 
 Use an authorized account to download the package required for your environment. If you do not have a registered account, contact technical support.
 
-<Directive type="info" title="INFO">
-Starting from <Term name="product" /> v4.1, if you download both the **Core Package** and the **Extensions Packages**, you must complete the installation of the **Core Package** before uploading and installing **Extensions Packages**.
+For customer delivery and production environments, use the package versions and documentation published on the Customer Portal as the official deployment and maintenance baseline.
+
+## Download the Installation Packages
+
+1. Download the <Term name="productShort" /> 4.5 **Core Package** that matches your target architecture.
+2. Download **Common ACP Extensions** for the same <Term name="productShort" /> version and architecture. The Violet CLI is the recommended method because it can locate and download the scenario packages directly.
+
+### Download with Violet CLI (Recommended)
+
+Install **Violet v4.2.9 or later**, run `violet version` to verify the version, and use `violet ac login` to log in to the <Term name="company" /> Customer Portal. For installation and login instructions, see [Download Packages](/extend/download_package.mdx).
+
+Set `<target-platform-version>` to the exact ACP Distribution Version of the Core Package, such as `v4.5.0`. Set `<arch>` to `amd64`, `arm64`, or `hybrid` to match the Core Package. List the scenarios first, and then download **Common ACP Extensions**:
+
+```bash
+violet ac scenarios --arch=<arch> --platformVersion=<target-platform-version>
+violet ac download-app --arch=<arch> --platformVersion=<target-platform-version> --scenario="Common ACP Extensions"
+```
+
+Confirm that **Common ACP Extensions** appears in the scenario list before downloading it.
+
+### Download from the Customer Portal
+
+As an alternative to Violet, in the Customer Portal, go to **Marketplace > Batch Download > Install**. On the page, select the Core Package version from **Your ACP Version**, select the matching **Architecture**, select **Common ACP Extensions** from **Scenarios**, and download the packages.
+
+<Directive type="warning" title="Separate Packages">
+The Core Package contains Core artifacts only. It does not contain any of the Extension packages downloaded through **Common ACP Extensions**. After extracting the Core Package, you must manually copy the required Extension packages into its `plugins/` directory before starting the installer.
 </Directive>
 
-For customer delivery and production environments, use the package versions and documentation published on the Customer Portal as the official deployment and maintenance baseline.
+## Required Aligned Extensions \{#required-aligned-extensions}
+
+Copy the packages for the following applications into the `plugins/` directory of the extracted Core Package:
+
+- **Alauda Container Platform Web Console**
+- **Alauda Container Platform Web Console Central**
+- **Alauda Container Platform Marketplace Web Console**
+- **Alauda Container Platform Helm Application Catalog**
+- **Alauda Container Platform Observability Essentials**
+- **Alauda Container Platform Essentials**
+- **Alauda Container Platform Cluster Essentials**
+- **Alauda Container Platform GatewayAPI Plugin**
+
+Do not copy other packages from **Common ACP Extensions** into the extracted Core Package's `plugins/` directory. Install those Extensions after the platform installation by following [Extend](../../extend/index.mdx).
 
 ## Choose a Package Architecture
 
-Packages are available for **x86**, **ARM**, and **hybrid** architectures. The hybrid package includes images for both x86 and ARM, resulting in a larger package size. Select the package that best matches your environment.
+Packages are available for **x86**, **ARM**, and **hybrid** architectures. The hybrid package includes images for both x86 and ARM, resulting in a larger package size. Select the package that best matches your environment, and use Extension packages that match the Core Package architecture.
 
 ## Migrating from Single-Architecture to Hybrid
 

--- a/docs/en/install/validation.mdx
+++ b/docs/en/install/validation.mdx
@@ -4,11 +4,11 @@ weight: 35
 
 # Validation
 
-Validate <Term name="productShort" /> Core after the installer completes and before you continue with post-install tasks.
+Validate <Term name="productShort" /> Core and the required Aligned Extensions after the installer completes and before you continue with post-install tasks.
 
 ## Prerequisites
 
-- <Term name="productShort" /> Core installation completed.
+- The <Term name="productShort" /> installation completed.
 - You can access the platform Web UI address shown by the installer.
 - You can run `kubectl` from the installation node.
 
@@ -16,7 +16,7 @@ Validate <Term name="productShort" /> Core after the installer completes and bef
 
 After the installation is complete, the installer displays the platform access URL. Click **Access** to open the platform Web UI and verify that the platform login page is reachable.
 
-## Validate Core Applications and Pods
+## Validate Core Applications, Extensions, and Pods
 
 Run the following commands on a control plane node of the new `global` cluster to confirm the installed state:
 
@@ -30,6 +30,9 @@ kubectl get clustermodule global -o jsonpath='{.status.phase}'
 # No AppRelease is in a failed state
 kubectl get apprelease -A
 
+# Core and Aligned modules report their current phase and version
+kubectl get moduleinfo -l cpaas.io/cluster-name=global
+
 # No Pod is stuck outside Running or Completed
 kubectl get pod --all-namespaces | awk '{if ($4 != "Running" && $4 != "Completed")print}' | awk -F'[/ ]+' '{if ($3 != $4)print}'
 ```
@@ -39,7 +42,18 @@ The installation is healthy when:
 - All `global` cluster nodes are `Ready`.
 - `ClusterModule/global` reports a healthy phase.
 - Every AppRelease is in a non-failed state.
+- The following applications are installed, and their corresponding `ModuleInfo` resources report `Running` at the target version:
+  - **Alauda Container Platform Web Console**
+  - **Alauda Container Platform Web Console Central**
+  - **Alauda Container Platform Marketplace Web Console**
+  - **Alauda Container Platform Helm Application Catalog**
+  - **Alauda Container Platform Observability Essentials**
+  - **Alauda Container Platform Essentials**
+  - **Alauda Container Platform Cluster Essentials**
+  - **Alauda Container Platform GatewayAPI Plugin**
 - Critical Pods in `cpaas-system` are `Running` or `Completed`.
+
+In the Web Console, open **Administrator > Marketplace > Cluster Plugins** and confirm that the required applications are available without an installation failure.
 
 ## Next Step
 

--- a/docs/en/overview/core-and-extensions.mdx
+++ b/docs/en/overview/core-and-extensions.mdx
@@ -4,15 +4,21 @@ weight: 60
 
 # Core and Extensions
 
-<Term name="productShort" /> capabilities are delivered through <Term name="productShort" /> Core and separately installed Extensions. Understanding this boundary helps you plan installation, upgrade, compatibility checks, and troubleshooting.
+<Term name="productShort" /> capabilities are delivered through <Term name="productShort" /> Core and Extensions that are distributed as separate packages. Understanding this boundary helps you plan installation, upgrade, compatibility checks, and troubleshooting.
 
 ## Core
 
-<Term name="productShort" /> Core is installed first and deploys the `global` cluster. It provides the platform management plane for web console access, platform API and CLI access, cluster management, project and namespace management, users and RBAC, Extension management frameworks, and core communication paths such as Cluster Proxy.
+<Term name="productShort" /> Core deploys the `global` cluster and provides the platform management plane, platform API and CLI access, cluster management, project and namespace management, users and RBAC, Extension management frameworks, and core communication paths such as Cluster Proxy. Customer-facing capabilities such as the Web Console are delivered by Aligned Extensions.
 
 Core capabilities are installed with <Term name="productShort" /> Core or are part of the platform management plane deployed with the `global` cluster. Capabilities that require a separate installation flow, Operator, Cluster Plugin, or separate product are not default Core functionality.
 
 For installation scope, see [Install Overview](../install/overview.mdx).
+
+## Package Boundary
+
+The <Term name="productShort" /> Core Package contains Core artifacts only. It does not include Aligned or Agnostic Extension packages.
+
+Some installation and upgrade procedures require you to download specific Aligned Extension packages separately and copy them into the `plugins/` directory of the extracted Core Package. This is a manual artifact preparation step. Placing an Extension package in that directory does not make the Extension part of Core or change its lifecycle type.
 
 ## Extension Types
 

--- a/docs/en/ui/cli_tools/violet.mdx
+++ b/docs/en/ui/cli_tools/violet.mdx
@@ -4,6 +4,6 @@ weight: 20
 
 # violet CLI
 
-The platform provides the **`violet`** command-line tool for uploading packages downloaded from the Custom Portal Marketplace.
+The platform provides the **`violet`** command-line tool for downloading packages from the Customer Portal and uploading packages to <Term name="productShort" />.
 
-For details, see [Upload Packages](/extend/upload_package).
+For details, see [Download Packages](/extend/download_package) and [Upload Packages](/extend/upload_package).

--- a/docs/en/upgrade/overview.mdx
+++ b/docs/en/upgrade/overview.mdx
@@ -20,7 +20,7 @@ A workload cluster can be upgraded only to a Distribution Version that the globa
 - **Distribution Version**: The ACP version currently reached by a cluster. A workload cluster can be upgraded only to a Distribution Version that the global tier has already reached.
 - **Preflight**: Validation checks that run before the upgrade starts applying the target version. For workload clusters, review preflight results from the upgrade status output after the upgrade request is submitted.
 - **Available upgrade targets**: The upgrade versions that are currently offered for a cluster. In the Web Console, the target version for the current upgrade flow is determined by the platform.
-- **upgrade.sh**: The preparation script for global cluster upgrades. Artifact synchronization and preflight checks can be run ahead of the maintenance window; the cluster version operator is deployed inside the window, just before the upgrade is requested.
+- **upgrade.sh**: The preparation script for global cluster upgrades. It synchronizes Core artifacts and any required Aligned Extension packages that you manually place in the extracted Core Package's `plugins/` directory. Artifact synchronization and preflight checks can be run ahead of the maintenance window; the cluster version operator is deployed inside the window, just before the upgrade is requested.
 - **Global DR environment**: An environment with both a primary global cluster and a standby global cluster.
 - **Primary global cluster**: The global cluster that the platform access domain currently resolves to.
 - **Standby global cluster**: The other global cluster in the DR pair. After a failover, the roles of the two clusters are swapped.
@@ -34,15 +34,15 @@ A single cluster upgrade window covers four kinds of work:
 | Work item | Required? | How it is upgraded | If you run immutable OS |
 |---|---|---|---|
 | <Term name="productShort" /> Core (the platform itself) | Required | CVO, driven by `upgrade.sh`-prepared artifacts | Same control flow; the Kubernetes step is handled separately, see below |
-| Aligned plugins (cluster plugins and operators released together with the matching ACP version) | Required for each installed plugin | Publish the target-version package with `violet` before the cluster upgrade. CVO then upgrades each installed Aligned plugin as part of the cluster upgrade. To upgrade only one plugin, follow that plugin's own upgrade procedure. | Same |
+| Aligned plugins (cluster plugins and operators released together with the matching ACP version) | Required for each installed plugin | For the Aligned applications provided through **ACP Upgrade to v4.5**, manually copy their separately downloaded packages into the extracted Core Package's `plugins/` directory and synchronize them with `upgrade.sh`. Publish other installed Aligned packages with `violet`. CVO then upgrades each installed Aligned plugin as part of the cluster upgrade. | Same |
 | Kubernetes | Required in the same window | On traditional-OS clusters, CVO upgrades Kubernetes in place on the existing nodes as part of the same cluster upgrade; nodes are not replaced. | Kubernetes is rolled out by replacing nodes from a new Alauda OS-based image through Cluster API rolling updates, not upgraded in place. The procedure lives in the immutable infrastructure documentation; see <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/huawei-dcs.html" children="Upgrading Clusters on Huawei DCS" />, <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/vmware-vsphere.html" children="Upgrading Clusters on VMware vSphere" />, or <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/huawei-cloud-stack.html" children="Upgrading Clusters on Huawei Cloud Stack" /> |
 | Agnostic plugins (independently released cluster plugins and operators) | Optional, per plugin | Upgrade each cluster plugin or operator from **Marketplace > Cluster Plugins** or the operator's own workflow after the cluster reaches the target Distribution Version | Same |
 
 A few rules govern when each piece moves:
 
 - The platform requires that a cluster's Kubernetes version is upgraded together with its Core and Aligned versions; mixing a new Core release with an old Kubernetes minor version is not validated.
-- Before requesting an upgrade, publish the target-version package for every Aligned plugin already installed on that cluster. A missing package for an installed Aligned plugin stalls the CVO upgrade. Packages for Aligned plugins that are not installed on the cluster are not required and do not block the upgrade.
-- Cluster plugins are global resources. Pushing a cluster plugin to the global tier makes it installable and upgradable on every cluster in the platform; you do not push the same cluster plugin again per workload cluster.
+- Before requesting an upgrade, make the target-version package available for every Aligned plugin already installed on that cluster. Use `upgrade.sh` for the packages from **ACP Upgrade to v4.5**, and use `violet` for other Aligned packages. A missing package for an installed Aligned plugin stalls the CVO upgrade. Packages for Aligned plugins that are not installed on the cluster do not cause those plugins to be installed.
+- Cluster plugins are global resources. A package made available through the global-tier `upgrade.sh` or `violet` workflow can be used by every cluster in the platform; you do not publish the same cluster plugin again per workload cluster.
 - Operators are scoped to each cluster. Pushing operators to the global tier is recommended but not sufficient on its own; the same operator must be available on each workload cluster before the workload upgrade. If you forgot to push an operator during the global window, you can push it again before the workload upgrade as a fallback.
 - Workload-cluster upgrades are only required when a workload cluster falls outside the target ACP release's [Kubernetes Support Matrix](../overview/kubernetes-support-matrix.html). Workload clusters that stay within the supported range can keep their existing Kubernetes version after the global tier moves; the platform will continue to manage them.
 
@@ -75,7 +75,7 @@ On **Immutable Infrastructure** clusters (DCS, vSphere, HCS), Kube-OVN is driven
 
 If the environment is upgrading from a release earlier than ACP 4.3 and has not completed PKCE security hardening, complete [Disabling the PKCE Plain Method](/security/platform_security_configurations/disable_pkce_plain_method.mdx) after the global cluster and all workload clusters reach the target Distribution Version.
 
-If the environment is upgrading from a release earlier than ACP 4.3, complete the required L5 plugin compatibility upgrades in [Upgrade the global cluster](./upgrade_global_cluster.mdx).
+If the environment is upgrading from a release earlier than ACP 4.3, complete the required Agnostic plugin compatibility upgrades in [Upgrade the global cluster](./upgrade_global_cluster.mdx).
 
 ## Related Documentation
 

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -75,22 +75,51 @@ cgroup2fs
 
 ## Download the Packages for Offline Environments
 
-A production maintenance window typically upgrades **<Term name="productShort" /> Core**, the **Aligned plugins** (cluster plugins and operators released together with the same ACP version), and the in-use **Agnostic plugins** (independently released cluster plugins and operators) in the same window. Prepare the target-version package for every installed Aligned plugin before the upgrade starts. Also prepare the Agnostic plugins you plan to upgrade in the same window, even though they do not gate the CVO upgrade. Holding back an Agnostic plugin often forces a second maintenance window later.
+A production maintenance window typically upgrades **<Term name="productShort" /> Core**, the **Aligned plugins** (cluster plugins and operators released together with the same ACP version), and the in-use **Agnostic plugins** (independently released cluster plugins and operators) in the same window. Core and Extension packages are separate downloads. Prepare all three package sets before the maintenance window so that artifact synchronization can finish early.
 
 ### Step 1: Download the Core Package
 
-From the **<Term name="company" /> Customer Portal**, download the **<Term name="productShort" /> Core Package**. The Core package carries **only the Core artifacts** that `upgrade.sh` will prepare for the CVO-driven Core upgrade.
+From the **<Term name="company" /> Customer Portal**, download the **<Term name="productShort" /> 4.5 Core Package** that matches your target architecture. The Core Package contains Core artifacts only; it does not contain any Aligned or Agnostic Extension package.
 
-The Core package does not bundle the Aligned plugin packages, even though CVO knows which Aligned plugin versions correspond to the target ACP release. Aligned plugin packages must be downloaded separately from the Customer Portal and pushed with `violet`; the next step covers that workflow alongside the Agnostic plugins.
+### Step 2: Download ACP Upgrade to v4.5 \{#download-acp-upgrade-to-v45}
 
-### Step 2: Inventory the plugins on every cluster in scope
+Use **Violet v4.2.9 or later** to download the scenario packages directly. Run `violet version` to verify the version, and use `violet ac login` to log in to the <Term name="company" /> Customer Portal. For installation and login instructions, see [Download Packages](/extend/download_package.mdx).
+
+Set `<target-platform-version>` to the exact ACP Distribution Version of the Core Package, such as `v4.5.0`. Set `<arch>` to `amd64`, `arm64`, or `hybrid` to match the Core Package. List the scenarios first, and then download **ACP Upgrade to v4.5**:
+
+```bash
+violet ac scenarios --arch=<arch> --platformVersion=<target-platform-version>
+violet ac download-app --arch=<arch> --platformVersion=<target-platform-version> --scenario="ACP Upgrade to v4.5"
+```
+
+Confirm that **ACP Upgrade to v4.5** appears in the scenario list before downloading it.
+
+As an alternative to Violet, in the Customer Portal, go to **Marketplace > Batch Download > Install**. On the page, select the target Core Package version from **Your ACP Version**, select the matching **Architecture**, select **ACP Upgrade to v4.5** from **Scenarios**, and download the packages.
+
+This package set provides the target-version packages for the following Aligned applications. These packages remain separate from the Core Package:
+
+- **Alauda Container Platform Web Console**
+- **Alauda Container Platform Web Console Central**
+- **Alauda Container Platform Marketplace Web Console**
+- **Alauda Container Platform Helm Application Catalog**
+- **Alauda Container Platform Observability Essentials**
+- **Alauda Container Platform Essentials**
+- **Alauda Container Platform Cluster Essentials**
+- **Alauda Container Platform GatewayAPI Plugin**
+- **Alauda Container Platform Monitoring for Prometheus**
+- **Alauda Language Pack for Chinese**
+- **Alauda Container Platform Networking for Calico**
+
+Before running `upgrade.sh`, manually copy all eleven packages into the `plugins/` directory of the extracted Core Package. [Upgrade the global cluster](./upgrade_global_cluster.mdx#sync-upgrade-artifacts) describes the copy and synchronization steps.
+
+### Step 3: Inventory other Extensions on every cluster in scope
 
 Cluster plugins and operators are managed by different mechanisms. Both are needed in this step:
 
 - **Cluster plugins** are global resources. A cluster plugin pushed to the global tier becomes installable and upgradable on every cluster in the platform; you only push each cluster plugin once.
 - **Operators** are scoped to each cluster. Pushing an operator to the global tier is the recommended starting point, but the same operator package must be available on each workload cluster before that cluster's upgrade.
 
-Navigate to the **CLI Tools** section in the **<Term name="company" /> Customer Portal** and download the `violet` tool. `violet` is required for uploading Aligned and Agnostic plugin packages. For more information about `violet`, see [Upload Packages](/extend/upload_package.html).
+Use the same `violet` installation from Step 2 to inventory installed Extensions and publish packages that are not part of **ACP Upgrade to v4.5**. For more information, see [Download Packages](/extend/download_package.html) and [Upload Packages](/extend/upload_package.html).
 
 On any machine with network access to the **<Term name="company" />** platform endpoint, run `violet list` to list the plugins (both Aligned and Agnostic) installed in the current environment and export the result to `./apps.yaml`:
 
@@ -103,18 +132,18 @@ violet list \
 
 Prefer `--platform-token` over `--platform-password` to avoid exposing passwords in shell history and process listings (`ps aux`).
 
-### Step 3: Align the Customer Portal package list
+### Step 4: Download the other Extension packages
 
-Import the exported `apps.yaml` file into the **<Term name="company" /> Customer Portal** to align the package list with what your clusters currently run. The portal then exposes the matching target-version packages — Core, Aligned plugins, and the Agnostic plugins your clusters use — for download.
+Import the exported `apps.yaml` file into the **<Term name="company" /> Customer Portal** to align the package list with what your clusters currently run. Download the matching target-version packages for the other Aligned and Agnostic Extensions that your clusters use.
 
-Download every package you will need so they are all available locally before the upgrade window starts. The next page, [Upgrade the global cluster](./upgrade_global_cluster.mdx), describes how `upgrade.sh` and `violet` push these packages into the platform. That push uploads images to the registry and registers the target versions in the platform catalog so they become available to install or upgrade; it does not upgrade any already-running plugin, so it can be completed any time before the maintenance window.
+If the result includes one of the eleven applications from **ACP Upgrade to v4.5**, do not publish that duplicate with `violet`. Use the package from **ACP Upgrade to v4.5** through the Core Package's `plugins/` directory instead. Use `violet push` only for the remaining Extension packages.
+
+Download every package you will need so they are all available locally before the upgrade window starts. The next page, [Upgrade the global cluster](./upgrade_global_cluster.mdx), describes how `upgrade.sh` synchronizes Core and the eleven manually staged packages, and how `violet` publishes the other Extensions. Artifact synchronization and package publication do not upgrade any already-running plugin, so complete them before the maintenance window.
 
 :::warning Required Aligned Plugin Packages
-Starting with ACP 4.3, every Aligned plugin installed on a cluster being upgraded must have its target-version package published with `violet` before the upgrade request. Use the package that the Customer Portal provides for the target ACP Distribution Version; the plugin's own version number does not need to match the ACP version string.
+Every Aligned plugin installed on a cluster being upgraded must have its target-version package available before the upgrade request. CVO does not require target packages for Aligned plugins that are not installed, and synchronizing a package does not install an absent plugin.
 
-Publish a cluster plugin package once to the global tier. Publish an operator package to every cluster where that operator is installed. CVO does not require target packages for Aligned plugins that are not installed on the cluster.
-
-If a required package is missing or is not ready, CVO stalls the cluster upgrade. You can publish the package after the block occurs; CVO detects the newly available package and continues the existing upgrade request automatically.
+If a required package is missing or is not ready, CVO stalls the cluster upgrade. Add packages from **ACP Upgrade to v4.5** through the `plugins/` directory and `upgrade.sh`; publish other packages with `violet`. CVO detects newly available packages and continues the existing upgrade request automatically.
 :::
 
 :::warning

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -29,7 +29,7 @@ A global cluster upgrade is staged across a timeline. Most of the work is comple
 
 | Phase | When | What happens | Cluster impact |
 | --- | --- | --- | --- |
-| 1. Sync artifacts | Any time before the window | `upgrade.sh --only-sync-image` uploads Core artifacts; `violet` publishes the target packages for installed Aligned plugins and any Agnostic plugins planned for the window. | None — images and catalog entries are published, but no running plugin is changed; no downtime. |
+| 1. Sync artifacts | Any time before the window | `upgrade.sh --only-sync-image` uploads Core artifacts and the eleven packages that you manually place in `plugins/`; `violet` publishes the other Aligned and Agnostic packages needed for the window. | None — images and catalog entries are published, but no running plugin is changed; no downtime. |
 | 2. Preflight | 1–2 weeks before the window | `upgrade.sh --preflight` validates upgrade readiness. Resolve every blocking item before the window opens. | None — read-only validation. |
 | 3. Upgrade | During the maintenance window | `upgrade.sh --skip-sync-image` deploys or updates the cluster version operator (CVO); the upgrade is then requested and observed. | The cluster is upgraded. |
 
@@ -41,13 +41,25 @@ Phase 1 and Phase 2 do not change cluster state — run them early so the mainte
 
 **When:** any time before the maintenance window. This step uploads artifacts to the registry and does not change cluster state.
 
-From the extracted core package directory, run `upgrade.sh` in sync-only mode:
+The Core Package does not contain the Aligned packages from **ACP Upgrade to v4.5**. Copy each of the eleven separately downloaded packages listed in [Pre-Upgrade Preparation](./pre-upgrade.mdx#download-acp-upgrade-to-v45) into the `plugins/` directory of the extracted Core Package. Run the following command once for each package:
+
+```bash
+cp <path-to-upgrade-extension-package> ./plugins/
+```
+
+Confirm that the directory contains all eleven packages before synchronization:
+
+```bash
+ls -1 ./plugins/
+```
+
+From the extracted Core Package directory, run `upgrade.sh` in sync-only mode:
 
 ```bash
 bash upgrade.sh --only-sync-image
 ```
 
-`--only-sync-image` uploads images and plugin artifacts without deploying the cluster version operator. The CVO is deployed later, inside the maintenance window — see [Deploy the cluster version operator](#deploy-the-cluster-version-operator).
+`--only-sync-image` uploads Core images and the packages that you manually placed in `plugins/`, without deploying the cluster version operator or changing running applications. The CVO is deployed later, inside the maintenance window — see [Deploy the cluster version operator](#deploy-the-cluster-version-operator).
 
 `upgrade.sh` synchronizes the artifacts required by the CVO-based workflow, including:
 
@@ -57,21 +69,24 @@ bash upgrade.sh --only-sync-image
 | CVO image        | `cluster-version-operator` | Used to deploy or update the cluster version operator.                     |
 | Plugin artifacts | `plugins/*.tgz`            | Used by the upgrade plan when plugin artifacts are required.               |
 
-`upgrade.sh` covers <Term name="productShort" /> Core. Aligned and Agnostic plugins are not pushed by `upgrade.sh`; push them with `violet` before the upgrade request, using the packages downloaded in [Pre-Upgrade Preparation](./pre-upgrade.mdx).
+For the eleven Aligned applications from **ACP Upgrade to v4.5**, the `plugins/` directory and `upgrade.sh` workflow is the supported publication path. CVO upgrades an application only when it is already installed; synchronizing a package for an application that is not installed does not install it.
 
-| Lifecycle type | Push tool | Cluster plugins | Operators |
-| --- | --- | --- | --- |
-| Aligned plugins | `violet push` | Required for every installed Aligned cluster plugin. Push the package selected for the target ACP Distribution Version once to the global tier; it then becomes available to every cluster. | Required for every installed Aligned operator. Push the target package to the global tier and to each workload cluster that runs the operator. |
-| Agnostic plugins | `violet push` | Push when you plan to upgrade the plugin in the same window. Missing Agnostic packages do not block CVO. | Same; push the package to each cluster where you plan to upgrade the operator. |
+Use `violet push` for the other packages downloaded from the `violet list` inventory:
+
+| Package group | Publication path | Requirement |
+| --- | --- | --- |
+| Other Aligned cluster plugins | `violet push` to the global tier | Required for each installed plugin that is not part of **ACP Upgrade to v4.5**. |
+| Other Aligned operators | `violet push` to the global tier and each workload cluster where the operator is installed | Required before upgrading each cluster that runs the operator. |
+| Agnostic cluster plugins and operators | `violet push` to the clusters where you plan to upgrade them | Optional for CVO; required before starting their separate Marketplace or operator upgrade. |
 
 ```bash
-# Push Aligned plugins (cluster plugins) — global only
-violet push <path/to/aligned-cluster-plugin-package> \
+# Publish another cluster plugin to the global tier
+violet push <path-to-other-cluster-plugin-package> \
   --platform-address "https://<your-platform-domain>" \
   --platform-token "<platform_token>"
 
-# Push Aligned or Agnostic operators — to global, and to each workload cluster that runs the operator
-violet push <path/to/operator-package> \
+# Publish another operator to global and each workload cluster that runs it
+violet push <path-to-other-operator-package> \
   --platform-address "https://<your-platform-domain>" \
   --platform-token "<platform_token>" \
   --clusters "global,<workload-cluster-1>,<workload-cluster-2>"
@@ -80,7 +95,7 @@ violet push <path/to/operator-package> \
 Pushing every operator package to every <Term name="productShort" /> cluster from the global window is the recommended pattern. If the global window has already passed and you discover a workload cluster missing an operator package, you can still push to that workload cluster before the workload upgrade — see [Upgrade workload clusters](./upgrade_workload_cluster.mdx#operator-push-fallback).
 
 :::warning
-Before requesting the upgrade, publish the target package for every Aligned plugin installed on the cluster. CVO does not require packages for Aligned plugins that are not installed. If an installed Aligned cluster plugin's package is missing or has not become ready, CVO stalls the upgrade and reports a message such as `required ModulePluginConfig "<component>-<version>" not found` or `ModulePluginConfig "<component>-<version>" is not Ready`.
+Before requesting the upgrade, make the target package available for every Aligned plugin installed on the cluster. Use `upgrade.sh` for applications from **ACP Upgrade to v4.5**, and `violet` for the other Aligned packages. CVO does not install an absent plugin merely because its package was synchronized. If an installed Aligned cluster plugin's package is missing or has not become ready, CVO stalls the upgrade and reports a missing or not-ready `ModulePluginConfig`.
 :::
 
 Registry behavior depends on how the environment is configured:
@@ -359,10 +374,10 @@ kubectl -n cpaas-system get cvsh global \
 
 If `Stalled=True` and the condition message names a missing or not-ready `ModulePluginConfig`, an installed Aligned cluster plugin does not yet have its target package available:
 
-1. Identify the component and required version from the `Stalled` condition message.
-2. Download the package that the Customer Portal provides for the target ACP Distribution Version.
-3. Use `violet push` as described in [Sync upgrade artifacts](#sync-upgrade-artifacts) to publish the cluster plugin package to the global tier.
-4. Continue observing the existing upgrade request. CVO watches the package readiness and resumes automatically after the package becomes ready; do not clear or resubmit `desiredUpdate`.
+1. Identify the application and required version from the `Stalled` condition and the Customer Portal.
+2. If the application is listed in **ACP Upgrade to v4.5**, download its package, copy it into the extracted Core Package's `plugins/` directory, and rerun `upgrade.sh --only-sync-image`.
+3. For another Aligned cluster plugin, publish the package to the global tier with `violet push` as described in [Sync upgrade artifacts](#sync-upgrade-artifacts).
+4. Continue observing the existing upgrade request. CVO watches package readiness and resumes automatically after the package becomes ready; do not clear or resubmit `desiredUpdate`.
 
 The commands above track the cluster-level (Core and Aligned) upgrade. To observe an individual plugin or operator module — for example while upgrading an Agnostic plugin — read its `ModuleInfo` instead:
 
@@ -408,7 +423,7 @@ If you skipped pushing an Agnostic plugin during pre-upgrade and the Marketplace
 
 - If the source release is earlier than ACP 4.3 and PKCE hardening has not already been completed, wait until all workload clusters reach the target Distribution Version, then follow [Disabling the PKCE Plain Method](/security/platform_security_configurations/disable_pkce_plain_method.mdx).
 
-- When upgrading from a release earlier than ACP 4.3, an API authentication change introduced in ACP 4.3 requires the following L5 plugins to be upgraded to versions compatible with the target ACP release. Otherwise, their UI pages may fail to open:
+- When upgrading from a release earlier than ACP 4.3, an API authentication change introduced in ACP 4.3 requires the following Agnostic plugins to be upgraded to versions compatible with the target ACP release. Otherwise, their UI pages may fail to open:
   - `Alauda DevOps v3`
   - `Alauda AI Essentials`
   - `Alauda Hyperflux`

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -38,7 +38,7 @@ Before requesting the upgrade, verify that:
 
 The recommended pattern in [Upgrade the global cluster](./upgrade_global_cluster.mdx) pushes operator packages to every <Term name="productShort" /> cluster during the global upgrade window. If the recommendation was followed, the workload cluster already has every operator package it needs and you can skip this section.
 
-Cluster plugins do not need a per-workload-cluster push. A cluster plugin pushed once to the global tier is installable and upgradable on every cluster in the platform.
+Cluster plugins do not need a per-workload-cluster publication. A cluster plugin made available to the global tier through `upgrade.sh` or `violet` is installable and upgradable on every cluster in the platform.
 
 If the global window did not push operator packages to this workload cluster — for example, the cluster was offline during the global window or was added later — push the target-version package for each Aligned operator installed on this workload cluster before the upgrade request:
 
@@ -49,7 +49,7 @@ violet push <path/to/operator-package> \
   --clusters "<workload-cluster-name>"
 ```
 
-You only need to push packages for Aligned operators actually installed on the workload cluster. Aligned cluster plugin packages published to the global tier are available to all workload clusters and do not need a per-cluster push.
+You only need to push packages for Aligned operators actually installed on the workload cluster. Aligned cluster plugin packages made available to the global tier are available to all workload clusters and do not need per-cluster publication.
 
 If an installed Aligned operator's target package is missing or is not ready, CVO stalls the workload-cluster upgrade. Publish the missing package with the command above, then continue observing the existing request. CVO detects the newly ready package and resumes automatically; you do not need to submit the upgrade request again. Packages for Aligned operators that are not installed on this workload cluster do not block its upgrade.
 
@@ -133,7 +133,7 @@ ac adm upgrade status
 
 For detailed semantics of `ac adm upgrade status` output (preflight and stage interpretation), see [Upgrading Clusters](/ui/cli_tools/ac/upgrading-clusters.md).
 
-If an installed Aligned operator does not advance toward its target version, verify that its target package was pushed to this workload cluster as described in [Ensure Aligned operator packages are available](#operator-push-fallback). If a `Stalled` condition names a missing or not-ready `ModulePluginConfig`, the missing component is a cluster plugin; publish its package once to the global tier as described in [Upgrade the global cluster](./upgrade_global_cluster.mdx#recover-missing-aligned-package).
+If an installed Aligned operator does not advance toward its target version, verify that its target package was pushed to this workload cluster as described in [Ensure Aligned operator packages are available](#operator-push-fallback). If a `Stalled` condition names a missing or not-ready `ModulePluginConfig`, the missing component is a cluster plugin; use the package-specific recovery path in [Upgrade the global cluster](./upgrade_global_cluster.mdx#recover-missing-aligned-package).
 
 The commands above track the cluster-level (Core and Aligned) upgrade. To observe an individual plugin or operator module — for example while upgrading an Agnostic plugin — read its `ModuleInfo`:
 


### PR DESCRIPTION
## Summary

- Clarify that the ACP Core Package contains Core artifacts only and that required Aligned Extension packages are downloaded separately.
- Document the ACP 4.5 installation flow with Common ACP Extensions and the eight required application packages staged in plugins/.
- Document the ACP 4.5 upgrade flow with ACP Upgrade to v4.5, eleven staged application packages, upgrade.sh --only-sync-image, and violet for other Extensions.
- Add Violet CLI and Customer Portal download paths while preserving the existing ACP 4.5 upgrade-path and Kubernetes guidance.

## Validation

- git diff --check
- yarn lint (0 errors, 0 warnings)
- yarn build

Jira: https://jira.alauda.cn/browse/AIT-73311