### PR TITLE
docs: fix Gateway API reference links

### DIFF
--- a/docs/en/networking/functions/configure_gatewayapi_route.mdx
+++ b/docs/en/networking/functions/configure_gatewayapi_route.mdx
@@ -268,11 +268,11 @@ spec:
 
 Each route is a CR defined by the `GatewayAPI` specification. For detailed information about the fields and configuration options for each route type, please refer to the official documentation:
 
-- [HTTPRoute specification](https://gateway-api.sigs.k8s.io/reference/spec/#httproute)
-- [TCPRoute specification](https://gateway-api.sigs.k8s.io/reference/spec/#tcproute)
-- [UDPRoute specification](https://gateway-api.sigs.k8s.io/reference/spec/#udproute)
-- [GRPCRoute specification](https://gateway-api.sigs.k8s.io/reference/spec/#grpcroute)
-- [TLSRoute specification](https://gateway-api.sigs.k8s.io/reference/spec/#tlsroute)
+- [HTTPRoute specification](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httproute)
+- [TCPRoute specification](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tcproute)
+- [UDPRoute specification](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#udproute)
+- [GRPCRoute specification](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#grpcroute)
+- [TLSRoute specification](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tlsroute)
 
 #### Publish to Listener \{#publish_to_listener}
 
@@ -356,10 +356,10 @@ The following match conditions, filter types, and advanced options are used by `
 
 | Condition Type | Official Documentation                                                                     |
 | -------------- | ------------------------------------------------------------------------------------------ |
-| Path           | [HTTPPathMatch](https://gateway-api.sigs.k8s.io/reference/spec/#httppathmatch)             |
-| Headers        | [HTTPHeaderMatch](https://gateway-api.sigs.k8s.io/reference/spec/#httpheadermatch)         |
-| QueryParams    | [HTTPQueryParamMatch](https://gateway-api.sigs.k8s.io/reference/spec/#httpqueryparammatch) |
-| Method         | [HTTPMethod](https://gateway-api.sigs.k8s.io/reference/spec/#httpmethod)                   |
+| Path           | [HTTPPathMatch](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httppathmatch)             |
+| Headers        | [HTTPHeaderMatch](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpheadermatch)         |
+| QueryParams    | [HTTPQueryParamMatch](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpqueryparammatch) |
+| Method         | [HTTPMethod](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpmethod)                   |
 
 ##### Filter Types
 
@@ -398,13 +398,13 @@ The following match conditions, filter types, and advanced options are used by `
 
 | Filter Type            | Official Documentation                                                                                 |
 | ---------------------- | ------------------------------------------------------------------------------------------------------ |
-| RequestHeaderModifier  | [HTTPHeaderFilter](https://gateway-api.sigs.k8s.io/reference/spec/#httpheaderfilter)                   |
-| ResponseHeaderModifier | [HTTPHeaderFilter](https://gateway-api.sigs.k8s.io/reference/spec/#httpheaderfilter)                   |
-| RequestRedirect        | [HTTPRequestRedirectFilter](https://gateway-api.sigs.k8s.io/reference/spec/#httprequestredirectfilter) |
-| URLRewrite             | [HTTPURLRewriteFilter](https://gateway-api.sigs.k8s.io/reference/spec/#httpurlrewritefilter)           |
-| CORS                   | [HTTPCORSFilter](https://gateway-api.sigs.k8s.io/reference/spec/#httpcorsfilter)                       |
-| RequestMirror          | [HTTPRequestMirrorFilter](https://gateway-api.sigs.k8s.io/reference/spec/#httprequestmirrorfilter)     |
-| HTTPExternalAuthFilter | [HTTPExternalAuthFilter](https://gateway-api.sigs.k8s.io/reference/spec/#httpexternalauthfilter)       |
+| RequestHeaderModifier  | [HTTPHeaderFilter](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpheaderfilter)                   |
+| ResponseHeaderModifier | [HTTPHeaderFilter](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpheaderfilter)                   |
+| RequestRedirect        | [HTTPRequestRedirectFilter](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprequestredirectfilter) |
+| URLRewrite             | [HTTPURLRewriteFilter](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpurlrewritefilter)           |
+| CORS                   | [HTTPCORSFilter](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpcorsfilter)                       |
+| RequestMirror          | [HTTPRequestMirrorFilter](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprequestmirrorfilter)     |
+| HTTPExternalAuthFilter | [HTTPExternalAuthFilter](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpexternalauthfilter)       |
 
 ##### Options \{#rule_options}
 
@@ -428,7 +428,7 @@ session persistence settings.
 
 | Field                    | Specification                                                                          |
 | ------------------------ | -------------------------------------------------------------------------------------- |
-| `.spec.rules[].timeouts` | [HTTPRouteTimeouts](https://gateway-api.sigs.k8s.io/reference/spec/#httproutetimeouts) |
+| `.spec.rules[].timeouts` | [HTTPRouteTimeouts](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httproutetimeouts) |
 
 ##### Retry \{#rule_retry}
 
@@ -448,7 +448,7 @@ session persistence settings.
 
 | Field                 | Specification                                                                    |
 | --------------------- | -------------------------------------------------------------------------------- |
-| `.spec.rules[].retry` | [HTTPRouteRetry](https://gateway-api.sigs.k8s.io/reference/spec/#httprouteretry) |
+| `.spec.rules[].retry` | [HTTPRouteRetry](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouteretry) |
 
 ##### Session Persistence \{#rule_session}
 
@@ -461,7 +461,7 @@ Configures session affinity settings to ensure requests from the same client are
 
 | Field                              | Specification                                                                            |
 | ---------------------------------- | ---------------------------------------------------------------------------------------- |
-| `.spec.rules[].sessionPersistence` | [SessionPersistence](https://gateway-api.sigs.k8s.io/reference/spec/#sessionpersistence) |
+| `.spec.rules[].sessionPersistence` | [SessionPersistence](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#sessionpersistence) |
 
 #### GRPCRoute Match and Filter Reference
 


### PR DESCRIPTION
## Summary

- update obsolete Gateway API reference paths to the current API reference
- preserve the existing anchors for route, match, filter, timeout, retry, and session persistence documentation

## Tests

- `yarn lint`
- verified all 19 linked anchors exist on the current Gateway API reference page