### PR TITLE
docs: add NFD v0.18.3 guidance for ACP 4.3

### DIFF
--- a/docs/en/configure/specialized_hardware_and_driver_enablement/index.mdx
+++ b/docs/en/configure/specialized_hardware_and_driver_enablement/index.mdx
@@ -1,0 +1,11 @@
+---
+weight: 85
+title: Specialized hardware and driver enablement
+---
+
+# Specialized hardware and driver enablement
+
+Use this section to discover node capabilities and configure shared components
+that support specialized hardware and driver enablement.
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/configure/specialized_hardware_and_driver_enablement/index.mdx
+++ b/docs/en/configure/specialized_hardware_and_driver_enablement/index.mdx
@@ -5,7 +5,12 @@ title: Specialized hardware and driver enablement
 
 # Specialized hardware and driver enablement
 
-Use this section to discover node capabilities and configure shared components
-that support specialized hardware and driver enablement.
+Use this section to prepare nodes for specialized workloads. Node discovery
+identifies hardware and system capabilities, while hardware enablement and
+driver lifecycle components use that information to make supported devices
+available to the cluster.
+
+Complete the shared platform prerequisites here before installing or using a
+GPU, NPU, or other specialized hardware product.
 
 <Overview overviewHeaders={[]} />

--- a/docs/en/configure/specialized_hardware_and_driver_enablement/node_feature_discovery/index.mdx
+++ b/docs/en/configure/specialized_hardware_and_driver_enablement/node_feature_discovery/index.mdx
@@ -26,8 +26,9 @@ NFD discovers and labels node capabilities. It does not:
 Install the plugin once in each target cluster that requires these node labels.
 Other Cluster Plugins and workloads can consume NFD labels, while drivers and
 resource-management components remain independently installed and managed.
-Vendor-specific feature discovery components are configured through their
-respective product documentation rather than this shared NFD workflow.
+GPU Feature Discovery (GFD) and NPU Feature Discovery are vendor-specific
+components. Configure them through their respective NVIDIA GPU or NPU Operator
+product documentation rather than this shared NFD workflow.
 
 For versions validated with the ACP release documented here, see
 [Validated NFD versions](./validated_versions.mdx).

--- a/docs/en/configure/specialized_hardware_and_driver_enablement/node_feature_discovery/index.mdx
+++ b/docs/en/configure/specialized_hardware_and_driver_enablement/node_feature_discovery/index.mdx
@@ -1,0 +1,43 @@
+---
+weight: 10
+title: Node Feature Discovery
+---
+
+# Alauda Build of Node Feature Discovery
+
+**Alauda Build of Node Feature Discovery (NFD)** is based on the Kubernetes SIG
+[Node Feature Discovery](https://kubernetes-sigs.github.io/node-feature-discovery/)
+project. It detects hardware features and system configuration on Kubernetes
+nodes and publishes the discovered information as node labels and `NodeFeature`
+resources.
+
+NFD provides a shared node-discovery layer for components and workloads that
+select nodes by operating system, architecture, kernel, CPU, PCI, or other
+hardware characteristics.
+
+## Scope
+
+NFD discovers and labels node capabilities. It does not:
+
+- install or manage hardware drivers;
+- expose GPU or NPU resources to Kubernetes;
+- replace a vendor Device Plugin, DRA driver, or accelerator operator.
+
+Install the plugin once in each target cluster that requires these node labels.
+Other Cluster Plugins and workloads can consume NFD labels, while drivers and
+resource-management components remain independently installed and managed.
+Vendor-specific feature discovery components are configured through their
+respective product documentation rather than this shared NFD workflow.
+
+For versions validated with the ACP release documented here, see
+[Validated NFD versions](./validated_versions.mdx).
+
+For installation and upgrade instructions, see
+[Install Node Feature Discovery](./install.mdx).
+
+## Related information
+
+- [Hardware accelerators](../../../hardware_accelerator/index.mdx)
+- [Validated NFD versions](./validated_versions.mdx)
+- [Cluster Plugin](../../../extend/cluster_plugin.mdx)
+- [Upstream Node Feature Discovery documentation](https://kubernetes-sigs.github.io/node-feature-discovery/)

--- a/docs/en/configure/specialized_hardware_and_driver_enablement/node_feature_discovery/install.mdx
+++ b/docs/en/configure/specialized_hardware_and_driver_enablement/node_feature_discovery/install.mdx
@@ -1,0 +1,82 @@
+---
+weight: 20
+title: Install Node Feature Discovery
+---
+
+# Install Node Feature Discovery
+
+This page describes the common installation, verification, upgrade, and
+uninstallation workflow for **Alauda Build of Node Feature Discovery**.
+
+Before installation or upgrade, select a version and package architecture from
+[Validated NFD versions](./validated_versions.mdx). Verify that the exact
+package lists your ACP version in the **ACP compatible versions** field in the
+**<Term name="company" /> Customer Portal**.
+
+## Download the Cluster Plugin
+
+:::info
+
+The **Alauda Build of Node Feature Discovery** Cluster Plugin can be retrieved
+from the **<Term name="company" /> Customer Portal**. Contact technical support
+if you cannot access the package.
+
+:::
+
+## Upload the Cluster Plugin
+
+Upload the NFD package by following the general
+[Upload Packages](../../../extend/upload_package.mdx) procedure.
+
+## Install the Cluster Plugin
+
+1. Go to **Administrator** > **Marketplace** > **Cluster Plugins**.
+2. Switch to the target cluster and install the selected version of **Alauda
+   Build of Node Feature Discovery**.
+3. Wait until the installation finishes successfully.
+
+## Verify the installation
+
+Verify that the NFD master, worker, and garbage collector workloads are ready:
+
+```bash
+kubectl -n kube-system get deployment node-feature-discovery-master node-feature-discovery-gc
+kubectl -n kube-system get daemonset node-feature-discovery-worker
+```
+
+Verify that NFD is publishing discovered features:
+
+```bash
+kubectl get nodefeatures.nfd.k8s-sigs.io --all-namespaces
+kubectl get node <node-name> --show-labels
+```
+
+The target node should contain labels with the
+`feature.node.kubernetes.io/` prefix.
+
+## Upgrade Node Feature Discovery
+
+1. Select a target version from
+   [Validated NFD versions](./validated_versions.mdx), review its upgrade notes,
+   and confirm that the package lists your ACP version in the **ACP compatible
+   versions** field.
+2. Upload the target version package.
+3. Go to **Administrator** > **Marketplace** > **Cluster Plugins**, and select
+   the target cluster.
+4. Upgrade **Alauda Build of Node Feature Discovery** to the selected version.
+5. Repeat the installation verification commands.
+
+The NFD upgrade does not change separately managed accelerator drivers or
+Device Plugin versions. After the upgrade, verify that the node labels required
+by your workloads remain present.
+
+## Uninstall Node Feature Discovery
+
+Before uninstalling NFD, confirm that no Cluster Plugin or workload still
+depends on labels published by NFD.
+
+1. Go to **Administrator** > **Marketplace** > **Cluster Plugins**.
+2. Switch to the target cluster and uninstall **Alauda Build of Node Feature
+   Discovery**.
+3. Confirm that the NFD master, worker, and garbage collector workloads have
+   been removed.

--- a/docs/en/configure/specialized_hardware_and_driver_enablement/node_feature_discovery/install.mdx
+++ b/docs/en/configure/specialized_hardware_and_driver_enablement/node_feature_discovery/install.mdx
@@ -56,6 +56,10 @@ The target node should contain labels with the
 
 ## Upgrade Node Feature Discovery
 
+Before upgrading, record the currently installed NFD version and configuration.
+Only the upgrade paths listed in
+[Validated NFD versions](./validated_versions.mdx) have been validated.
+
 1. Select a target version from
    [Validated NFD versions](./validated_versions.mdx), review its upgrade notes,
    and confirm that the package lists your ACP version in the **ACP compatible
@@ -69,6 +73,10 @@ The target node should contain labels with the
 The NFD upgrade does not change separately managed accelerator drivers or
 Device Plugin versions. After the upgrade, verify that the node labels required
 by your workloads remain present.
+
+Downgrade is not validated. If verification fails after an upgrade, retain the
+installation status and verification output, and contact technical support
+before changing versions again.
 
 ## Uninstall Node Feature Discovery
 

--- a/docs/en/configure/specialized_hardware_and_driver_enablement/node_feature_discovery/validated_versions.mdx
+++ b/docs/en/configure/specialized_hardware_and_driver_enablement/node_feature_discovery/validated_versions.mdx
@@ -1,0 +1,37 @@
+---
+weight: 10
+title: Validated NFD versions
+---
+
+# Validated NFD versions
+
+The following NFD versions have been validated with the ACP release documented
+here. Versions not listed are outside this validation scope; absence from this
+table does not imply that they are incompatible.
+
+For formal package compatibility, verify that the exact package lists your ACP
+version in the **ACP compatible versions** field in the
+**<Term name="company" /> Customer Portal**.
+
+| NFD version | ACP validation scope | Kubernetes validation scope | Runtime architectures |
+| --- | --- | --- | --- |
+| v0.18.3 | ACP 4.3 | v1.33.7-2 | `amd64`, `arm64` |
+
+The v0.18.3 delivery includes architecture-specific packages for `amd64` and
+`arm64`, and an `ALL` package containing both runtime architectures.
+
+## Default behavior
+
+The default Cluster Plugin installation enables the NFD master, worker, and
+garbage collector and publishes generic node features. Vendor-specific feature
+discovery extensions are not enabled by this default workflow.
+
+## Upgrade notes
+
+### v0.18.3
+
+Upgrade from v0.17.3 to v0.18.3 has been validated and does not require user
+configuration migration. The release fixes an issue where node operating-system
+and kernel-module features might not be discovered correctly after an upgrade.
+Separately managed accelerator drivers and Device Plugin versions are not
+changed by the NFD upgrade.

--- a/docs/en/hardware_accelerator/index.mdx
+++ b/docs/en/hardware_accelerator/index.mdx
@@ -4,4 +4,8 @@ weight: 71
 
 # Hardware accelerators
 
+Before installing accelerator components, use
+[Node Feature Discovery](../configure/specialized_hardware_and_driver_enablement/node_feature_discovery/index.mdx)
+when a component or workload requires node feature labels.
+
 <Overview />


### PR DESCRIPTION
## Summary

- Add Specialized hardware and driver enablement as the ACP-owned home for Node Feature Discovery.
- Document the NFD v0.18.3 install, verification, upgrade, uninstall, architecture, and ACP 4.3 validation scope.
- Add a minimal NFD prerequisite link from Hardware accelerators.

## Scope

The shared ACP pages cover generic NFD only. Vendor-specific feature discovery configuration remains in the corresponding product documentation.

## Validation

- git diff --check
- yarn lint: 0 errors, 0 warnings
- yarn build: passed; only existing OpenAPI and DefinePlugin warnings
- generated routes and cross-links verified in dist