### PR TITLE
[release-4.4] docs: require Violet 4.2.13 and clarify node access

### DIFF
--- a/docs/en/extend/download_package.mdx
+++ b/docs/en/extend/download_package.mdx
@@ -54,7 +54,7 @@ mv -f violet_darwin_arm64 /usr/bin/violet && chmod +x /usr/bin/violet
 
 > **Note**: If the tool path is not added to your environment variables, you must specify the full path when running commands.
 
-The `violet ac` commands require **Violet v4.2.9 or later**. After installing the binary, verify its version:
+Use **Violet v4.2.13 or later** for the workflows documented on this page. After installing the binary, verify its version:
 
 ```bash
 violet version

--- a/docs/en/extend/upload_package.mdx
+++ b/docs/en/extend/upload_package.mdx
@@ -68,6 +68,12 @@ mv -f violet_darwin_arm64 /usr/bin/violet && chmod +x /usr/bin/violet
 
 > **Note**: If the tool path is not added to your environment variables, you must specify the full path when running commands.
 
+Use **Violet v4.2.13 or later** for the workflows documented on this page. After installing the binary, verify its version:
+
+```bash
+violet version
+```
+
 ## Prerequisites
 
 **Permission requirements**
@@ -96,6 +102,10 @@ To create or manage platform tokens, sign in to the platform Web Console, open *
 
 :::warning
 **Identity provider (IdP) users must use a platform token.** Username and password login authenticates only against the platform's local user store. If your account comes from an external identity provider (for example, LDAP or OIDC), username and password login fails — use `--platform-token` instead.
+:::
+
+:::warning Violet versions earlier than v4.2.13
+Earlier versions can fail when `--platform-token` is used and report `failed to get user info from platform server`. Upgrade to Violet v4.2.13 or later before using the token-based workflows documented on this page.
 :::
 
 #### Image Registry Parameters

--- a/docs/en/install/prepare/download.mdx
+++ b/docs/en/install/prepare/download.mdx
@@ -29,7 +29,7 @@ For customer delivery and production environments, use the package versions and 
 
 ### Download with Violet CLI (Recommended)
 
-Install **Violet v4.2.9 or later**, run `violet version` to verify the version, and use `violet ac login` to log in to the <Term name="company" /> Customer Portal. For installation and login instructions, see [Download Packages](/extend/download_package.mdx).
+Install **Violet v4.2.13 or later**, run `violet version` to verify the version, and use `violet ac login` to log in to the <Term name="company" /> Customer Portal. For installation and login instructions, see [Download Packages](/extend/download_package.mdx).
 
 Set `<target-platform-version>` to the exact ACP Distribution Version of the Core Package, such as `v4.4.0`. Set `<arch>` to `amd64`, `arm64`, or `hybrid` to match the Core Package. List the scenarios first, and then download **Common ACP Extensions**:
 

--- a/docs/en/ui/cli_tools/violet.mdx
+++ b/docs/en/ui/cli_tools/violet.mdx
@@ -6,4 +6,6 @@ weight: 20
 
 The platform provides the **`violet`** command-line tool for downloading packages from the Customer Portal and uploading packages to <Term name="productShort" />.
 
+Use **Violet v4.2.13 or later** for the documented download, inventory, and upload workflows.
+
 For details, see [Download Packages](/extend/download_package) and [Upload Packages](/extend/upload_package).

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -78,7 +78,7 @@ From the **<Term name="company" /> Customer Portal**, download the **<Term name=
 
 ### Step 2: Download ACP Upgrade to v4.4 \{#download-acp-upgrade-to-v44}
 
-Use **Violet v4.2.9 or later** to download the scenario packages directly. Run `violet version` to verify the version, and use `violet ac login` to log in to the <Term name="company" /> Customer Portal. For installation and login instructions, see [Download Packages](/extend/download_package.mdx).
+Use **Violet v4.2.13 or later** to download the scenario packages directly. Run `violet version` to verify the version, and use `violet ac login` to log in to the <Term name="company" /> Customer Portal. For installation and login instructions, see [Download Packages](/extend/download_package.mdx).
 
 Set `<target-platform-version>` to the exact ACP Distribution Version of the Core Package, such as `v4.4.0`. Set `<arch>` to `amd64`, `arm64`, or `hybrid` to match the Core Package. List the scenarios first, and then download **ACP Upgrade to v4.4**:
 
@@ -132,6 +132,8 @@ violet list \
 ```
 
 Prefer `--platform-token` over `--platform-password` to avoid exposing passwords in shell history and process listings (`ps aux`).
+
+Violet v4.2.13 or later is required for this token-based inventory workflow. Earlier versions can fail with `failed to get user info from platform server`; upgrade Violet before continuing.
 
 ### Step 4: Download the other Extension packages
 

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -46,14 +46,9 @@ Every module `PHASE` must be `Running`, and `deployStatus` must not be `Upgradin
 
 If the target release is ACP 4.4 or later, upgrades the cluster to Kubernetes 1.35 or later, and reports an administrator acknowledgement gate for node readiness, verify every production node that will run the target cluster before acknowledging the gate.
 
-Run the checks through SSH on each node, or use an approved node shell. For example:
+ACP does not provide a dedicated debug image for this procedure. Log in to each node through SSH or another administrative node access method available in your environment, and run the following checks directly on the node operating system. The account and credentials depend on how the cluster nodes were provisioned.
 
-```bash
-kubectl debug node/<node-name> -it --image=<approved-debug-image>
-chroot /host
-```
-
-On each node, verify the Linux kernel version:
+Verify the Linux kernel version:
 
 ```bash
 uname -r

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -46,7 +46,7 @@ Every module `PHASE` must be `Running`, and `deployStatus` must not be `Upgradin
 
 If the target release is ACP 4.4 or later, upgrades the cluster to Kubernetes 1.35 or later, and reports an administrator acknowledgement gate for node readiness, verify every production node that will run the target cluster before acknowledging the gate.
 
-ACP does not provide a dedicated debug image for this procedure. Log in to each node through SSH or another administrative node access method available in your environment, and run the following checks directly on the node operating system. The account and credentials depend on how the cluster nodes were provisioned.
+Log in to each node through SSH or another administrative node access method available in your environment, and run the following checks directly on the node operating system. The account and credentials depend on how the cluster nodes were provisioned.
 
 Verify the Linux kernel version:
 


### PR DESCRIPTION
## Summary

- Require Violet v4.2.13 or later across package download, inventory, and upload documentation.
- Document the token authentication failure seen with earlier Violet versions and require users to upgrade before continuing.
- Remove the undefined approved-debug-image example from node readiness checks and direct users to run the host checks through SSH or their existing administrative node access method.
- State that ACP does not provide a dedicated debug image for this procedure.

## Validation

- git diff --check
- yarn lint (0 errors, 0 warnings)
- yarn build
- confirmed no v4.2.9-v4.2.12 minimum requirement or approved-debug-image remains in docs/en

## Delivery note

This PR corrects product documentation. Publishing Violet v4.2.13 through the Customer Portal is a separate delivery action tracked by AIT-73358.

Jira: https://jira.alauda.cn/browse/AIT-73358