### PR TITLE
[release-4.4] ACP-55018: document Ceph disruption protection

### DIFF
--- a/docs/en/storage/storagesystem_ceph/how_to/dedicated_cluster.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/dedicated_cluster.mdx
@@ -2,68 +2,66 @@
 weight: 61
 ---
 
-# Configure a Dedicated Cluster for Distributed Storage  
+# Configure a Dedicated Cluster for Distributed Storage
 
 Dedicated cluster deployment refers to using an independent cluster to deploy the platform's distributed storage, where other business clusters within the platform access and utilize the storage services it provides through integration.  
 To ensure the performance and stability of the platform's distributed storage, only the platform's core components and distributed storage components are deployed in the dedicated storage cluster, avoiding the co-location of other business workloads. This separated deployment approach is the recommended best practice for the platform's distributed storage.
 
-## Architecture  
+## Architecture
 
 Storage-Compute Separation Architecture
 
-![](../assets/dedicated_cluster_architecture.png)  
-
+![](../assets/dedicated_cluster_architecture.png)
 
 ## Infrastructure requirements
 
-### Platform requirements  
+### Platform requirements
 
 Supported in version 3.18 and later.
 
-### Cluster requirements  
+### Cluster requirements
 
 It is recommended to use bare-metal clusters as dedicated storage clusters.
 
-### Resource requirements  
+### Resource requirements
 
 Please refer to the [Core Concepts](../concepts/concept.mdx) for the components of distributed storage deployment.
 
 Each component has distinct CPU and memory requirements. The recommended configurations are as follows:
 
-|Process|CPU|Memory|
-|:---|:---:|:---:|
-|MON|2c|3Gi|
-|MGR|3c|4Gi|
-|MDS|3c|8Gi|
-|RGW|2c|4Gi|
-|OSD|4c|8Gi|
+| Process | CPU | Memory |
+| :------ | :-: | :----: |
+| MON     | 2c  |  3Gi   |
+| MGR     | 3c  |  4Gi   |
+| MDS     | 3c  |  8Gi   |
+| RGW     | 2c  |  4Gi   |
+| OSD     | 4c  |  8Gi   |
 
+A cluster typically runs:
 
-A cluster typically runs:  
 - 3 MON
-- 2 MGR  
+- 2 MGR
 - multiple OSD
 - 2 MDS (if using CephFS)
-- 2 RGW (if using CephObjectStorage) 
+- 2 RGW (if using CephObjectStorage)
 
+Based on the component distribution, the following per-node resource recommendations apply:
 
-Based on the component distribution, the following per-node resource recommendations apply:  
+| CPU                        | Memory                       |
+| :------------------------- | :--------------------------- |
+| 16c + (4c \* OSD per node) | 20Gi + (8Gi \* OSD per node) |
 
-|CPU|Memory|
-|:---|:---|
-|16c + (4c * OSD per node)|20Gi + (8Gi * OSD per node)|  
-
-### Storage device requirements  
+### Storage device requirements
 
 It is recommended to deploy 12 or fewer storage devices per node. This helps restrict the recovery time following a node failure.
 
-#### Storage device type requirements  
+#### Storage device type requirements
 
 It is recommended to use enterprise SSDs with a capacity of 10TiB or smaller per device, and ensure all disks are identical in size and type.
 
-#### Capacity planning  
+#### Capacity planning
 
-Before deployment, storage capacity must be planned according to specific business requirements. By default, the distributed storage system employs a 3-replica redundancy strategy. Therefore, the usable capacity is calculated by dividing the total raw storage capacity (from all storage devices) by 3.  
+Before deployment, storage capacity must be planned according to specific business requirements. By default, the distributed storage system employs a 3-replica redundancy strategy. Therefore, the usable capacity is calculated by dividing the total raw storage capacity (from all storage devices) by 3.
 
 Example for 30(N) nodes (replica count = 3), The usable capacity scenario is as follows:  
 |Storage device size(D)|Storage device per node(M)|Total Capacity(D*M*N)|Usable Capacity(D*M*N/3)|
@@ -72,32 +70,30 @@ Example for 30(N) nodes (replica count = 3), The usable capacity scenario is as 
 |2 TiB|6|360 TiB|120 TiB|
 |4 TiB|9|1080 TiB|360 TiB|
 
-#### Capacity monitoring and expansion    
+#### Capacity monitoring and expansion
 
-1. **Proactive Capacity Planning**  
+1. **Proactive Capacity Planning**
 
-    Always ensure usable storage capacity exceeds consumption. If storage is fully exhausted, recovery requires manual intervention and cannot be resolved by simply deleting or migrating data.
+   Always ensure usable storage capacity exceeds consumption. If storage is fully exhausted, recovery requires manual intervention and cannot be resolved by simply deleting or migrating data.
 
-2. **Capacity Alerts**  
+2. **Capacity Alerts**
 
-    The cluster triggers alerts at two thresholds:  
+   The cluster triggers alerts at two thresholds:
+   - **80% utilization** ("near full"): Proactively **free up space** or scale out the cluster.
+   - **95% utilization** ("full"): Storage is fully exhausted, and standard commands cannot free space. Contact platform support immediately.
 
-    - **80% utilization** ("near full"): Proactively **free up space** or scale out the cluster.
-    - **95% utilization** ("full"): Storage is fully exhausted, and standard commands cannot free space. Contact platform support immediately.  
+   Always address alerts promptly and monitor storage usage regularly to avoid outages.
 
-    Always address alerts promptly and monitor storage usage regularly to avoid outages.
+3. **Scaling Recommendations**
+   - **Avoid**: Adding storage devices to existing nodes.
+   - **Recommended**: Scale out by adding new storage nodes.
+   - **Requirement**: New nodes must use storage devices identical in size, type, and quantity to existing nodes.
 
-3. **Scaling Recommendations**  
+### Network requirements
 
-    - **Avoid**: Adding storage devices to existing nodes.
-    - **Recommended**: Scale out by adding new storage nodes.
-    - **Requirement**: New nodes must use storage devices identical in size, type, and quantity to existing nodes.
+Distributed storage must utilize **HostNetwork**.
 
-### Network requirements  
-
-Distributed storage must utilize **HostNetwork**.   
-
-#### Network Isolation  
+#### Network Isolation
 
 The network is categorized into two types:
 
@@ -107,44 +103,41 @@ The network is categorized into two types:
 To ensure service quality and performance stability:
 
 1. For Dedicated Storage Clusters:  
-    Reserve two network interfaces on each host:
-        - Public Network: For client and component communication.
-        - Cluster Network: For internal replication and rebalancing traffic.
+   Reserve two network interfaces on each host: - Public Network: For client and component communication. - Cluster Network: For internal replication and rebalancing traffic.
 2. For Business Clusters:  
-    Reserve one network interface on each host to access the storage Public Network.
+   Reserve one network interface on each host to access the storage Public Network.
 
-Example Network Isolation Configuration  
+Example Network Isolation Configuration
 
-![](../assets/dedicated_cluster_network_architecture.png)  
+![](../assets/dedicated_cluster_network_architecture.png)
 
-#### Network interface speed requirements  
+#### Network interface speed requirements
 
-1. **Storage Nodes**  
-    - **Public Network** and **Cluster Network** require 10GbE or higher network interfaces.  
+1. **Storage Nodes**
+   - **Public Network** and **Cluster Network** require 10GbE or higher network interfaces.
 
-2. **Business Cluster Nodes**  
-    - The network interface used to access the storage **Public Network** must be 10GbE or higher.
+2. **Business Cluster Nodes**
+   - The network interface used to access the storage **Public Network** must be 10GbE or higher.
 
-
-## Procedure  
+## Procedure
 
 <Steps>
-### Deploy Operator  
+### Deploy Operator
 
-1. Access **Administrator**.  
+1. Access **Administrator**.
 
-2. In the left sidebar, click **Storage Management** > **Distributed Storage**.  
+2. In the left sidebar, click **Storage Management** > **Distributed Storage**.
 
-3. Click **Create Now**.  
+3. Click **Create Now**.
 
-4. In the **Deploy Operator** wizard page, click the **Deploy Operator** button at the bottom right.  
-   - When the page automatically advances to the next step, it indicates that the Operator has been deployed successfully.  
+4. In the **Deploy Operator** wizard page, click the **Deploy Operator** button at the bottom right.
+   - When the page automatically advances to the next step, it indicates that the Operator has been deployed successfully.
    - If the deployment fails, please refer to the prompt on the interface **Clean Up Deployed Information and Retry**, and redeploy the Operator; if you wish to return to the distributed storage selection page, click **Application Store**, first uninstall the resources in the already deployed **rook-operator**, and then uninstall **rook-operator**.
 
-
-### Create ceph cluster  
+### Create ceph cluster
 
 Execute commands on the **control node** of the storage cluster.
+
 <details> 
     <summary>Click to view</summary>
 
@@ -171,6 +164,8 @@ Execute commands on the **control node** of the storage cluster.
       dashboard:
         enabled: true
       dataDirHostPath: /var/lib/rook
+      disruptionManagement:
+        managePodBudgets: true
       mgr:
         count: 2
         modules:
@@ -191,8 +186,6 @@ Execute commands on the **control node** of the storage cluster.
       placement:
         all:
           tolerations:
-          - effect: NoSchedule
-            operator: Exists
           - key: "node-role.kubernetes.io/master"
             operator: "Exists"
             effect: "NoSchedule"
@@ -239,41 +232,71 @@ Execute commands on the **control node** of the storage cluster.
         <storage devices>
     EOF
     ```
+
 </details>
 
-**Parameters**:  
-- **public network cidr**: CIDR of the storage **Public Network** (e.g., ```- 10.0.1.0/24```).
-- **cluster network cidr**: CIDR of the storage **Cluster Network** (e.g., ```- 10.0.2.0/24```).
-- **storage devices**: Specify the storage devices to be utilized by the distributed storage.  
-    Example Formatting:
-    ```         
-      nodes:
-      - name: storage-node-01
-        devices:
-        - name: /dev/disk/by-id/wwn-0x5000cca01dd27d60
-        useAllDevices: false
-      - name: storage-node-02
-        devices:
-        - name: sdb
-        - name: sdc
-        useAllDevices: false
-      - name: storage-node-03
-        devices:
-        - name: sdb
-        - name: sdc
-        useAllDevices: false
-    ```  
-    <Directive type="info" title="Tip">
-    Uses the disk's World Wide Name (WWN) for stable naming, which avoids reliance on volatile device paths like ```sdb``` that may change after reboots.
-    </Directive>
+For an internal CephCluster created directly, the platform defaults
+`spec.disruptionManagement.managePodBudgets` to `true` when the field is omitted.
+Set it explicitly to `false` only when opting out of Rook-managed PDB protection.
+An internal StorageCluster does not expose this setting and always creates its
+CephCluster with the value `true`. External Ceph always uses `false`; the API
+rejects `external.enable=true` together with `managePodBudgets=true` because a
+PDB in the workload cluster cannot protect daemons in the remote Ceph cluster.
 
-### Create storage pools  
+The platform does not set `osdMaintenanceTimeout`; the installed Rook version's
+default applies. For an existing CephCluster being adopted by a StorageCluster,
+an existing value of `false` is reported as `Conflict/CephAdoptionConflict` and
+is not changed automatically. The supported resolution is to change the
+CephCluster to `true`. If retaining `false` is unavoidable, the following
+Unsupported Override is an escape hatch, not a standard StorageCluster option:
+
+```yaml
+spec:
+  unsupportedOverrides:
+    cephCluster:
+      patches:
+        - op: replace
+          path: /spec/disruptionManagement/managePodBudgets
+          value: false
+```
+
+**Parameters**:
+
+- **public network cidr**: CIDR of the storage **Public Network** (e.g., `- 10.0.1.0/24`).
+- **cluster network cidr**: CIDR of the storage **Cluster Network** (e.g., `- 10.0.2.0/24`).
+- **storage devices**: Specify the storage devices to be utilized by the distributed storage.  
+   Example Formatting:
+  ```
+    nodes:
+    - name: storage-node-01
+      devices:
+      - name: /dev/disk/by-id/wwn-0x5000cca01dd27d60
+      useAllDevices: false
+    - name: storage-node-02
+      devices:
+      - name: sdb
+      - name: sdc
+      useAllDevices: false
+    - name: storage-node-03
+      devices:
+      - name: sdb
+      - name: sdc
+      useAllDevices: false
+  ```
+  <Directive type="info" title="Tip">
+    Uses the disk's World Wide Name (WWN) for stable naming, which avoids
+    reliance on volatile device paths like ```sdb``` that may change after
+    reboots.
+  </Directive>
+
+### Create storage pools
 
 Three storage pool types are available. Select and create the appropriate ones based on your business requirements.
 
-#### Create file pool  
+#### Create file pool
 
 Execute commands on the **control node** of the storage cluster.
+
 <details> 
     <summary>Click to view</summary>
 
@@ -310,19 +333,28 @@ Execute commands on the **control node** of the storage cluster.
                   - rook-ceph-mds
               topologyKey: kubernetes.io/hostname
           tolerations:
-          - effect: NoSchedule
-            operator: Exists
+          - key: "node-role.kubernetes.io/master"
+            operator: "Exists"
+            effect: "NoSchedule"
+          - key: "node-role.kubernetes.io/control-plane"
+            operator: "Exists"
+            effect: "NoSchedule"
+          - key: "node-role.kubernetes.io/cpaas-system"
+            operator: "Exists"
+            effect: "NoSchedule"
         resources:
           requests:
             cpu: "3"
             memory: 8Gi
     EOF
     ```
-</details>  
 
-#### Create block pool  
+</details>
+
+#### Create block pool
 
 Execute commands on the **control node** of the storage cluster.
+
 <details> 
     <summary>Click to view</summary>
 
@@ -339,11 +371,13 @@ Execute commands on the **control node** of the storage cluster.
         size: 3
     EOF
     ```
+
 </details>
 
-#### Create object pool  
+#### Create object pool
 
 Execute commands on the **control node** of the storage cluster.
+
 <details> 
     <summary>Click to view</summary>
 
@@ -379,8 +413,15 @@ Execute commands on the **control node** of the storage cluster.
                   - rook-ceph-rgw
               topologyKey: kubernetes.io/hostname
           tolerations:
-          - effect: NoSchedule
-            operator: Exists
+          - key: "node-role.kubernetes.io/master"
+            operator: "Exists"
+            effect: "NoSchedule"
+          - key: "node-role.kubernetes.io/control-plane"
+            operator: "Exists"
+            effect: "NoSchedule"
+          - key: "node-role.kubernetes.io/cpaas-system"
+            operator: "Exists"
+            effect: "NoSchedule"
         port: 7480
         resources:
           requests:
@@ -388,11 +429,12 @@ Execute commands on the **control node** of the storage cluster.
             memory: 4Gi
     EOF
     ```
+
 </details>
 
 </Steps>
 
-## Follow-up Actions  
+## Follow-up Actions
 
 When other clusters need to utilize the distributed storage service, refer to the following guidelines.  
 [Deploying in External Mode](/storage/storagesystem_ceph/installation/access_storage_service.mdx)

--- a/docs/en/storage/storagesystem_ceph/how_to/dedicated_cluster.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/dedicated_cluster.mdx
@@ -238,27 +238,8 @@ Execute commands on the **control node** of the storage cluster.
 For an internal CephCluster created directly, the platform defaults
 `spec.disruptionManagement.managePodBudgets` to `true` when the field is omitted.
 Set it explicitly to `false` only when opting out of Rook-managed PDB protection.
-An internal StorageCluster does not expose this setting and always creates its
-CephCluster with the value `true`. External Ceph always uses `false`; the API
-rejects `external.enable=true` together with `managePodBudgets=true` because a
-PDB in the workload cluster cannot protect daemons in the remote Ceph cluster.
-
 The platform does not set `osdMaintenanceTimeout`; the installed Rook version's
-default applies. For an existing CephCluster being adopted by a StorageCluster,
-an existing value of `false` is reported as `Conflict/CephAdoptionConflict` and
-is not changed automatically. The supported resolution is to change the
-CephCluster to `true`. If retaining `false` is unavoidable, the following
-Unsupported Override is an escape hatch, not a standard StorageCluster option:
-
-```yaml
-spec:
-  unsupportedOverrides:
-    cephCluster:
-      patches:
-        - op: replace
-          path: /spec/disruptionManagement/managePodBudgets
-          value: false
-```
+default applies.
 
 **Parameters**:
 

--- a/docs/en/storage/storagesystem_ceph/how_to/dedicated_cluster.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/dedicated_cluster.mdx
@@ -2,66 +2,68 @@
 weight: 61
 ---
 
-# Configure a Dedicated Cluster for Distributed Storage
+# Configure a Dedicated Cluster for Distributed Storage  
 
 Dedicated cluster deployment refers to using an independent cluster to deploy the platform's distributed storage, where other business clusters within the platform access and utilize the storage services it provides through integration.  
 To ensure the performance and stability of the platform's distributed storage, only the platform's core components and distributed storage components are deployed in the dedicated storage cluster, avoiding the co-location of other business workloads. This separated deployment approach is the recommended best practice for the platform's distributed storage.
 
-## Architecture
+## Architecture  
 
 Storage-Compute Separation Architecture
 
-![](../assets/dedicated_cluster_architecture.png)
+![](../assets/dedicated_cluster_architecture.png)  
+
 
 ## Infrastructure requirements
 
-### Platform requirements
+### Platform requirements  
 
 Supported in version 3.18 and later.
 
-### Cluster requirements
+### Cluster requirements  
 
 It is recommended to use bare-metal clusters as dedicated storage clusters.
 
-### Resource requirements
+### Resource requirements  
 
 Please refer to the [Core Concepts](../concepts/concept.mdx) for the components of distributed storage deployment.
 
 Each component has distinct CPU and memory requirements. The recommended configurations are as follows:
 
-| Process | CPU | Memory |
-| :------ | :-: | :----: |
-| MON     | 2c  |  3Gi   |
-| MGR     | 3c  |  4Gi   |
-| MDS     | 3c  |  8Gi   |
-| RGW     | 2c  |  4Gi   |
-| OSD     | 4c  |  8Gi   |
+|Process|CPU|Memory|
+|:---|:---:|:---:|
+|MON|2c|3Gi|
+|MGR|3c|4Gi|
+|MDS|3c|8Gi|
+|RGW|2c|4Gi|
+|OSD|4c|8Gi|
 
-A cluster typically runs:
 
+A cluster typically runs:  
 - 3 MON
-- 2 MGR
+- 2 MGR  
 - multiple OSD
 - 2 MDS (if using CephFS)
-- 2 RGW (if using CephObjectStorage)
+- 2 RGW (if using CephObjectStorage) 
 
-Based on the component distribution, the following per-node resource recommendations apply:
 
-| CPU                        | Memory                       |
-| :------------------------- | :--------------------------- |
-| 16c + (4c \* OSD per node) | 20Gi + (8Gi \* OSD per node) |
+Based on the component distribution, the following per-node resource recommendations apply:  
 
-### Storage device requirements
+|CPU|Memory|
+|:---|:---|
+|16c + (4c * OSD per node)|20Gi + (8Gi * OSD per node)|  
+
+### Storage device requirements  
 
 It is recommended to deploy 12 or fewer storage devices per node. This helps restrict the recovery time following a node failure.
 
-#### Storage device type requirements
+#### Storage device type requirements  
 
 It is recommended to use enterprise SSDs with a capacity of 10TiB or smaller per device, and ensure all disks are identical in size and type.
 
-#### Capacity planning
+#### Capacity planning  
 
-Before deployment, storage capacity must be planned according to specific business requirements. By default, the distributed storage system employs a 3-replica redundancy strategy. Therefore, the usable capacity is calculated by dividing the total raw storage capacity (from all storage devices) by 3.
+Before deployment, storage capacity must be planned according to specific business requirements. By default, the distributed storage system employs a 3-replica redundancy strategy. Therefore, the usable capacity is calculated by dividing the total raw storage capacity (from all storage devices) by 3.  
 
 Example for 30(N) nodes (replica count = 3), The usable capacity scenario is as follows:  
 |Storage device size(D)|Storage device per node(M)|Total Capacity(D*M*N)|Usable Capacity(D*M*N/3)|
@@ -70,30 +72,32 @@ Example for 30(N) nodes (replica count = 3), The usable capacity scenario is as 
 |2 TiB|6|360 TiB|120 TiB|
 |4 TiB|9|1080 TiB|360 TiB|
 
-#### Capacity monitoring and expansion
+#### Capacity monitoring and expansion    
 
-1. **Proactive Capacity Planning**
+1. **Proactive Capacity Planning**  
 
-   Always ensure usable storage capacity exceeds consumption. If storage is fully exhausted, recovery requires manual intervention and cannot be resolved by simply deleting or migrating data.
+    Always ensure usable storage capacity exceeds consumption. If storage is fully exhausted, recovery requires manual intervention and cannot be resolved by simply deleting or migrating data.
 
-2. **Capacity Alerts**
+2. **Capacity Alerts**  
 
-   The cluster triggers alerts at two thresholds:
-   - **80% utilization** ("near full"): Proactively **free up space** or scale out the cluster.
-   - **95% utilization** ("full"): Storage is fully exhausted, and standard commands cannot free space. Contact platform support immediately.
+    The cluster triggers alerts at two thresholds:  
 
-   Always address alerts promptly and monitor storage usage regularly to avoid outages.
+    - **80% utilization** ("near full"): Proactively **free up space** or scale out the cluster.
+    - **95% utilization** ("full"): Storage is fully exhausted, and standard commands cannot free space. Contact platform support immediately.  
 
-3. **Scaling Recommendations**
-   - **Avoid**: Adding storage devices to existing nodes.
-   - **Recommended**: Scale out by adding new storage nodes.
-   - **Requirement**: New nodes must use storage devices identical in size, type, and quantity to existing nodes.
+    Always address alerts promptly and monitor storage usage regularly to avoid outages.
 
-### Network requirements
+3. **Scaling Recommendations**  
 
-Distributed storage must utilize **HostNetwork**.
+    - **Avoid**: Adding storage devices to existing nodes.
+    - **Recommended**: Scale out by adding new storage nodes.
+    - **Requirement**: New nodes must use storage devices identical in size, type, and quantity to existing nodes.
 
-#### Network Isolation
+### Network requirements  
+
+Distributed storage must utilize **HostNetwork**.   
+
+#### Network Isolation  
 
 The network is categorized into two types:
 
@@ -103,41 +107,44 @@ The network is categorized into two types:
 To ensure service quality and performance stability:
 
 1. For Dedicated Storage Clusters:  
-   Reserve two network interfaces on each host: - Public Network: For client and component communication. - Cluster Network: For internal replication and rebalancing traffic.
+    Reserve two network interfaces on each host:
+        - Public Network: For client and component communication.
+        - Cluster Network: For internal replication and rebalancing traffic.
 2. For Business Clusters:  
-   Reserve one network interface on each host to access the storage Public Network.
+    Reserve one network interface on each host to access the storage Public Network.
 
-Example Network Isolation Configuration
+Example Network Isolation Configuration  
 
-![](../assets/dedicated_cluster_network_architecture.png)
+![](../assets/dedicated_cluster_network_architecture.png)  
 
-#### Network interface speed requirements
+#### Network interface speed requirements  
 
-1. **Storage Nodes**
-   - **Public Network** and **Cluster Network** require 10GbE or higher network interfaces.
+1. **Storage Nodes**  
+    - **Public Network** and **Cluster Network** require 10GbE or higher network interfaces.  
 
-2. **Business Cluster Nodes**
-   - The network interface used to access the storage **Public Network** must be 10GbE or higher.
+2. **Business Cluster Nodes**  
+    - The network interface used to access the storage **Public Network** must be 10GbE or higher.
 
-## Procedure
+
+## Procedure  
 
 <Steps>
-### Deploy Operator
+### Deploy Operator  
 
-1. Access **Administrator**.
+1. Access **Administrator**.  
 
-2. In the left sidebar, click **Storage Management** > **Distributed Storage**.
+2. In the left sidebar, click **Storage Management** > **Distributed Storage**.  
 
-3. Click **Create Now**.
+3. Click **Create Now**.  
 
-4. In the **Deploy Operator** wizard page, click the **Deploy Operator** button at the bottom right.
-   - When the page automatically advances to the next step, it indicates that the Operator has been deployed successfully.
+4. In the **Deploy Operator** wizard page, click the **Deploy Operator** button at the bottom right.  
+   - When the page automatically advances to the next step, it indicates that the Operator has been deployed successfully.  
    - If the deployment fails, please refer to the prompt on the interface **Clean Up Deployed Information and Retry**, and redeploy the Operator; if you wish to return to the distributed storage selection page, click **Application Store**, first uninstall the resources in the already deployed **rook-operator**, and then uninstall **rook-operator**.
 
-### Create ceph cluster
+
+### Create ceph cluster  
 
 Execute commands on the **control node** of the storage cluster.
-
 <details> 
     <summary>Click to view</summary>
 
@@ -232,7 +239,6 @@ Execute commands on the **control node** of the storage cluster.
         <storage devices>
     EOF
     ```
-
 </details>
 
 For an internal CephCluster created directly, the platform defaults
@@ -241,43 +247,39 @@ Set it explicitly to `false` only when opting out of Rook-managed PDB protection
 The platform does not set `osdMaintenanceTimeout`; the installed Rook version's
 default applies.
 
-**Parameters**:
-
-- **public network cidr**: CIDR of the storage **Public Network** (e.g., `- 10.0.1.0/24`).
-- **cluster network cidr**: CIDR of the storage **Cluster Network** (e.g., `- 10.0.2.0/24`).
+**Parameters**:  
+- **public network cidr**: CIDR of the storage **Public Network** (e.g., ```- 10.0.1.0/24```).
+- **cluster network cidr**: CIDR of the storage **Cluster Network** (e.g., ```- 10.0.2.0/24```).
 - **storage devices**: Specify the storage devices to be utilized by the distributed storage.  
-   Example Formatting:
-  ```
-    nodes:
-    - name: storage-node-01
-      devices:
-      - name: /dev/disk/by-id/wwn-0x5000cca01dd27d60
-      useAllDevices: false
-    - name: storage-node-02
-      devices:
-      - name: sdb
-      - name: sdc
-      useAllDevices: false
-    - name: storage-node-03
-      devices:
-      - name: sdb
-      - name: sdc
-      useAllDevices: false
-  ```
-  <Directive type="info" title="Tip">
-    Uses the disk's World Wide Name (WWN) for stable naming, which avoids
-    reliance on volatile device paths like ```sdb``` that may change after
-    reboots.
-  </Directive>
+    Example Formatting:
+    ```         
+      nodes:
+      - name: storage-node-01
+        devices:
+        - name: /dev/disk/by-id/wwn-0x5000cca01dd27d60
+        useAllDevices: false
+      - name: storage-node-02
+        devices:
+        - name: sdb
+        - name: sdc
+        useAllDevices: false
+      - name: storage-node-03
+        devices:
+        - name: sdb
+        - name: sdc
+        useAllDevices: false
+    ```  
+    <Directive type="info" title="Tip">
+    Uses the disk's World Wide Name (WWN) for stable naming, which avoids reliance on volatile device paths like ```sdb``` that may change after reboots.
+    </Directive>
 
-### Create storage pools
+### Create storage pools  
 
 Three storage pool types are available. Select and create the appropriate ones based on your business requirements.
 
-#### Create file pool
+#### Create file pool  
 
 Execute commands on the **control node** of the storage cluster.
-
 <details> 
     <summary>Click to view</summary>
 
@@ -329,13 +331,11 @@ Execute commands on the **control node** of the storage cluster.
             memory: 8Gi
     EOF
     ```
+</details>  
 
-</details>
-
-#### Create block pool
+#### Create block pool  
 
 Execute commands on the **control node** of the storage cluster.
-
 <details> 
     <summary>Click to view</summary>
 
@@ -352,13 +352,11 @@ Execute commands on the **control node** of the storage cluster.
         size: 3
     EOF
     ```
-
 </details>
 
-#### Create object pool
+#### Create object pool  
 
 Execute commands on the **control node** of the storage cluster.
-
 <details> 
     <summary>Click to view</summary>
 
@@ -410,12 +408,11 @@ Execute commands on the **control node** of the storage cluster.
             memory: 4Gi
     EOF
     ```
-
 </details>
 
 </Steps>
 
-## Follow-up Actions
+## Follow-up Actions  
 
 When other clusters need to utilize the distributed storage service, refer to the following guidelines.  
 [Deploying in External Mode](/storage/storagesystem_ceph/installation/access_storage_service.mdx)

--- a/docs/en/storage/storagesystem_ceph/how_to/disaster_recovery/dr_filesystem.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/disaster_recovery/dr_filesystem.mdx
@@ -7,16 +7,17 @@ weight: 64
 CephFS Mirror is a feature of the Ceph file system designed to enable asynchronous data replication between different Ceph clusters, thereby providing cross-cluster disaster recovery. Its core functionality is to synchronize data in a primary-backup mode, ensuring that the backup cluster can rapidly take over services if the primary cluster experiences a failure.
 
 :::warning
+
 - CephFS Mirror performs incremental synchronization based on snapshots, with the default snapshot interval set to once per hour (configurable). The differential data between the primary and backup clusters typically consists of the amount of data written within one snapshot cycle.
 - CephFS Mirror solely provides the backup of underlying storage data and is incapable of handling the backup of Kubernetes resources. Please utilize the platform's **Backup and Restore** feature to back up PVC and PV resources in conjunction.
-:::
+  :::
 
 ## Terminology
 
-|Term|Explanation|
-|:---|:---|
-|**Primary Cluster**|The cluster currently providing storage services.|
-|**Secondary Cluster**|Cluster for backup.|
+| Term                  | Explanation                                       |
+| :-------------------- | :------------------------------------------------ |
+| **Primary Cluster**   | The cluster currently providing storage services. |
+| **Secondary Cluster** | Cluster for backup.                               |
 
 ## Backup Configuration
 
@@ -31,7 +32,7 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
 
 <Steps>
 
-  ### Enable the Mirror for the file storage pool in the Secondary cluster
+### Enable the Mirror for the file storage pool in the Secondary cluster
 
     Execute the following commands on the Control node of the Secondary cluster:
 
@@ -52,7 +53,7 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
     **Parameters**:
     - `<fs-name>`: Name of the file storage pool.
 
-  ### Obtain the Peer Token \{#token}
+### Obtain the Peer Token \{#token}
 
     This token is the key credential for establishing a mirroring connection between the two clusters.
 
@@ -77,7 +78,7 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
     **Parameters**:
     - `<fs-name>`: Name of the file storage pool.
 
-  ### Create Peer Secret in the Primary cluster
+### Create Peer Secret in the Primary cluster
 
     After obtaining the Peer Token from the Secondary cluster, it is necessary to create a Peer Secret in the Primary cluster.
 
@@ -102,7 +103,7 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
     - `<token>`: The token obtained in [step 2](#token).
     - `<fs-name>`:Name of the file storage pool.
 
-  ### Enable the Mirror for the file storage pool in the Primary cluster
+### Enable the Mirror for the file storage pool in the Primary cluster
 
     Execute the following commands on the Control node of the Primary cluster:
 
@@ -177,8 +178,7 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
     - `<schedule-interval>`:Snapshot execution cycle. For details, please refer to the [official documentation](https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-schedules).
     - `<retention-policy>`: Snapshot retention policy. details, please refer to the [official documentation](https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-retention-policies).
 
-
-  ### Deploy the Mirror Daemon in the Primary cluster
+### Deploy the Mirror Daemon in the Primary cluster
 
     The Mirror Daemon continuously monitors data changes in the file storage pool (with Mirror enabled). It periodically creates snapshots and pushes the snapshot differences to the Secondary cluster over the network.
 
@@ -196,8 +196,15 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
     spec:
       placement:
         tolerations:
-        - key: NoSchedule
+        - key: node-role.kubernetes.io/master
           operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/cpaas-system
+          operator: Exists
+          effect: NoSchedule
       resources:
         limits:
           cpu: "500m"
@@ -217,7 +224,6 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
     </Tabs>
 
 </Steps>
-
 
 ## Failover
 

--- a/docs/en/storage/storagesystem_ceph/how_to/disaster_recovery/dr_filesystem.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/disaster_recovery/dr_filesystem.mdx
@@ -7,17 +7,16 @@ weight: 64
 CephFS Mirror is a feature of the Ceph file system designed to enable asynchronous data replication between different Ceph clusters, thereby providing cross-cluster disaster recovery. Its core functionality is to synchronize data in a primary-backup mode, ensuring that the backup cluster can rapidly take over services if the primary cluster experiences a failure.
 
 :::warning
-
 - CephFS Mirror performs incremental synchronization based on snapshots, with the default snapshot interval set to once per hour (configurable). The differential data between the primary and backup clusters typically consists of the amount of data written within one snapshot cycle.
 - CephFS Mirror solely provides the backup of underlying storage data and is incapable of handling the backup of Kubernetes resources. Please utilize the platform's **Backup and Restore** feature to back up PVC and PV resources in conjunction.
-  :::
+:::
 
 ## Terminology
 
-| Term                  | Explanation                                       |
-| :-------------------- | :------------------------------------------------ |
-| **Primary Cluster**   | The cluster currently providing storage services. |
-| **Secondary Cluster** | Cluster for backup.                               |
+|Term|Explanation|
+|:---|:---|
+|**Primary Cluster**|The cluster currently providing storage services.|
+|**Secondary Cluster**|Cluster for backup.|
 
 ## Backup Configuration
 
@@ -32,7 +31,7 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
 
 <Steps>
 
-### Enable the Mirror for the file storage pool in the Secondary cluster
+  ### Enable the Mirror for the file storage pool in the Secondary cluster
 
     Execute the following commands on the Control node of the Secondary cluster:
 
@@ -53,7 +52,7 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
     **Parameters**:
     - `<fs-name>`: Name of the file storage pool.
 
-### Obtain the Peer Token \{#token}
+  ### Obtain the Peer Token \{#token}
 
     This token is the key credential for establishing a mirroring connection between the two clusters.
 
@@ -78,7 +77,7 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
     **Parameters**:
     - `<fs-name>`: Name of the file storage pool.
 
-### Create Peer Secret in the Primary cluster
+  ### Create Peer Secret in the Primary cluster
 
     After obtaining the Peer Token from the Secondary cluster, it is necessary to create a Peer Secret in the Primary cluster.
 
@@ -103,7 +102,7 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
     - `<token>`: The token obtained in [step 2](#token).
     - `<fs-name>`:Name of the file storage pool.
 
-### Enable the Mirror for the file storage pool in the Primary cluster
+  ### Enable the Mirror for the file storage pool in the Primary cluster
 
     Execute the following commands on the Control node of the Primary cluster:
 
@@ -178,7 +177,8 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
     - `<schedule-interval>`:Snapshot execution cycle. For details, please refer to the [official documentation](https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-schedules).
     - `<retention-policy>`: Snapshot retention policy. details, please refer to the [official documentation](https://docs.ceph.com/en/latest/cephfs/snap-schedule/#add-and-remove-retention-policies).
 
-### Deploy the Mirror Daemon in the Primary cluster
+
+  ### Deploy the Mirror Daemon in the Primary cluster
 
     The Mirror Daemon continuously monitors data changes in the file storage pool (with Mirror enabled). It periodically creates snapshots and pushes the snapshot differences to the Secondary cluster over the network.
 
@@ -224,6 +224,7 @@ CephFS Mirror is a feature of the Ceph file system designed to enable asynchrono
     </Tabs>
 
 </Steps>
+
 
 ## Failover
 

--- a/docs/en/storage/storagesystem_ceph/how_to/replacing-or-removing-nodes.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/replacing-or-removing-nodes.mdx
@@ -6,6 +6,27 @@ weight: 20
 
 This document describes how to remove a storage node from a Rook-Ceph cluster managed by the Container Platform. Depending on whether the remaining OSDs have sufficient capacity to absorb the data from the node being removed, you may need to add a replacement node first.
 
+## Choose the Correct Workflow
+
+Use the procedure in this document only when permanently removing a node or its
+OSDs from the Ceph topology.
+
+For an immutable-OS rollout that recreates the same machine slot and reattaches
+the same disks, do **not** mark the OSDs out, purge them, or remove the node from
+`spec.storage.nodes`. Use the platform's serial CAPI rollout with
+`maxSurge=0` and `maxUnavailable=1`. CAPI drains through the Kubernetes
+Eviction API, Kubernetes PDBs gate voluntary disruption, and the Rook
+disruption controller adjusts those PDBs according to Ceph health. CAPI itself
+does not inspect Ceph health.
+
+Before replacing the next node, verify that the previous node has returned,
+its expected disks and OSD IDs match the recorded by-id/WWN identity, all target
+OSDs are `up/in`, Ceph health and PG state meet the maintenance criteria, and
+continuous application I/O is healthy. If a PDB blocks eviction, investigate
+Ceph health and daemon redundancy; do not force-delete pods or bypass eviction.
+PDBs protect only voluntary disruptions that use the Eviction API and do not
+protect node crashes or direct pod deletion.
+
 ## Prerequisites
 
 - All cluster components (except the failing node, if applicable) are functioning properly.
@@ -156,6 +177,7 @@ Rook-managed Ceph daemons (MON, MGR, MDS) may be scheduled on the old node. Excl
    ```
 
    The output should show `HEALTH_OK` with all PGs in the `active+clean` state.
+
 </Steps>
 
 ## References

--- a/docs/en/storage/storagesystem_ceph/how_to/replacing-or-removing-nodes.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/replacing-or-removing-nodes.mdx
@@ -6,27 +6,6 @@ weight: 20
 
 This document describes how to remove a storage node from a Rook-Ceph cluster managed by the Container Platform. Depending on whether the remaining OSDs have sufficient capacity to absorb the data from the node being removed, you may need to add a replacement node first.
 
-## Choose the Correct Workflow
-
-Use the procedure in this document only when permanently removing a node or its
-OSDs from the Ceph topology.
-
-For an immutable-OS rollout that recreates the same machine slot and reattaches
-the same disks, do **not** mark the OSDs out, purge them, or remove the node from
-`spec.storage.nodes`. Use the platform's serial CAPI rollout with
-`maxSurge=0` and `maxUnavailable=1`. CAPI drains through the Kubernetes
-Eviction API, Kubernetes PDBs gate voluntary disruption, and the Rook
-disruption controller adjusts those PDBs according to Ceph health. CAPI itself
-does not inspect Ceph health.
-
-Before replacing the next node, verify that the previous node has returned,
-its expected disks and OSD IDs match the recorded by-id/WWN identity, all target
-OSDs are `up/in`, Ceph health and PG state meet the maintenance criteria, and
-continuous application I/O is healthy. If a PDB blocks eviction, investigate
-Ceph health and daemon redundancy; do not force-delete pods or bypass eviction.
-PDBs protect only voluntary disruptions that use the Eviction API and do not
-protect node crashes or direct pod deletion.
-
 ## Prerequisites
 
 - All cluster components (except the failing node, if applicable) are functioning properly.

--- a/docs/en/storage/storagesystem_ceph/how_to/replacing-or-removing-nodes.mdx
+++ b/docs/en/storage/storagesystem_ceph/how_to/replacing-or-removing-nodes.mdx
@@ -156,7 +156,6 @@ Rook-managed Ceph daemons (MON, MGR, MDS) may be scheduled on the old node. Excl
    ```
 
    The output should show `HEALTH_OK` with all PGs in the `active+clean` state.
-
 </Steps>
 
 ## References


### PR DESCRIPTION
## Summary

Document the new disruption-protection defaults for the publicly exposed, directly managed `CephCluster` workflow.

## Behavior

- Explain that a new internal `CephCluster` defaults `spec.disruptionManagement.managePodBudgets` to `true` when omitted.
- Explain that users can explicitly set `managePodBudgets: false` as a supported opt-out.
- Keep `osdMaintenanceTimeout` on the installed Rook version's default.
- Remove keyless wildcard tolerations from the direct CephCluster, MDS, RGW, and CephFilesystemMirror examples.
- Keep MDS active-standby and at least two RGW instances in the examples.

## Compatibility

- Cover only the publicly exposed direct `CephCluster` management surface.
- Do not document internal StorageCluster/ASO APIs, adoption, or unsupported-patch escape hatches.
- Existing directly managed Ceph resources are not automatically converged by this change.
- The retired `acp-foundation-plugins` repository is out of scope.

## Verification

- [x] `yarn lint`
- [x] Repository pre-commit documentation lint
- [x] `git diff --check`
- [x] Final diff is limited to the direct Ceph examples and defaulting guidance

## Delivery status

- Real-cluster runtime validation is covered by the related operator/frontend delivery.
- This documentation PR introduces no runtime behavior or internal API surface.

## Related changes

- Operator: https://gitlab-ce.alauda.cn/container-platform/acp-storage-operator/-/merge_requests/96
- Legacy frontend: https://gitlab-ce.alauda.cn/frontend/acp-fe-plugins/-/merge_requests/142
- Tracking: https://jira.alauda.cn/browse/ACP-55018
