### PR TITLE
ACP-55026: add Agent Sandbox documentation site

### DIFF
--- a/docs/en/agent_sandbox/agent_sandbox.mdx
+++ b/docs/en/agent_sandbox/agent_sandbox.mdx
@@ -1,0 +1,6 @@
+
+# About Alauda Build of Agent Sandbox
+
+Alauda Build of Agent Sandbox provides a Kubernetes-native way to manage isolated, stateful, singleton workloads with stable identities for AI agents, development environments, notebooks, and similar use cases.
+
+<ExternalSite name="agent_sandbox" />

--- a/docs/en/agent_sandbox/index.mdx
+++ b/docs/en/agent_sandbox/index.mdx
@@ -1,0 +1,11 @@
+---
+weight: 74
+i18n:
+  title:
+    en: Alauda Build of Agent Sandbox
+    zh: Alauda Build of Agent Sandbox
+---
+
+# Alauda Build of Agent Sandbox
+
+<Overview />

--- a/sites.yaml
+++ b/sites.yaml
@@ -26,6 +26,13 @@
   base: /ai
   version: "2.7"
   repo: https://github.com/alauda/aml-docs
+- name: agent_sandbox
+  displayName:
+    en: Alauda Build of Agent Sandbox
+    zh: Alauda Build of Agent Sandbox
+  base: /agent_sandbox
+  version: "0.5.4"
+  repo: https://github.com/alauda/agent-sandbox-docs
 - name: hyperflux
   displayName:
     en: Alauda Hyperflux


### PR DESCRIPTION
## Summary

- register the Agent Sandbox documentation site in `sites.yaml`
- use `/agent_sandbox` as the site base
- track Agent Sandbox product version `0.5.4`
- link to `https://github.com/alauda/agent-sandbox-docs`

## Verification

- `yarn install --immutable`
- `yarn lint` — 0 errors and 0 warnings
- `yarn build`

Tracking: ACP-55026