### PR TITLE
docs: restructure install and upgrade guides

### DIFF
--- a/docs/en/install/global_dr.mdx
+++ b/docs/en/install/global_dr.mdx
@@ -1,5 +1,5 @@
 ---
-weight: 60
+weight: 18
 ---
 
 # Global Cluster Disaster Recovery

--- a/docs/en/install/installer-parameters.mdx
+++ b/docs/en/install/installer-parameters.mdx
@@ -1,0 +1,119 @@
+---
+weight: 35
+---
+
+# Installer Parameters
+
+Use this reference while configuring the `global` cluster in the installer Web UI. Confirm the network, access, image source, and node decisions before you submit the installation.
+
+<table>
+  <tr>
+    <th style={{ whiteSpace: 'nowrap' }}>Parameter</th>
+    <th style={{ whiteSpace: 'nowrap' }}>Description</th>
+  </tr>
+  <tr>
+    <td><b>Kubernetes Version</b></td>
+    <td>
+      All optional versions are rigorously tested for stability and compatibility.<br />
+      <b>Recommendation:</b> Choose the latest version for optimal features and support.
+    </td>
+  </tr>
+  <tr>
+    <td><b>Cluster Network Protocol</b></td>
+    <td>
+      Supports three modes: IPv4 single stack, IPv6 single stack, IPv4/IPv6 dual stack.<br />
+      <b>Note:</b> If you select dual stack mode, ensure all nodes have correctly configured IPv6 addresses; the network protocol cannot be changed after setting.
+    </td>
+  </tr>
+  <tr>
+    <td><b>Cluster Endpoint</b></td>
+    <td>
+      <ul>
+        Enter the pre-prepared domain name.<br />
+        If no domain name is available, enter the pre-prepared <code>`global` VIP</code>.<br />
+        <code>Self-built VIP</code> is disabled by default, only enable it if you have not provided a LoadBalancer.<br /><br />
+        The following conditions must be met when using <code>Self-built VIP</code> :<br />
+        - A usable VRID is available;<br />
+        - The host network supports the VRRP protocol;<br />
+        - All control plane nodes and the VIP must be on the same subnet.<br />
+      </ul>
+      <ul>
+        <b>Tip:</b> For single-node deployments in feature experience scenarios, you can directly enter the node IP. There is no need to enable <code>Self-built VIP</code> or prepare network resources such as <code>`global` VIP</code>.
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td><b>Platform Access Address</b></td>
+    <td>
+      <ul>
+        If you do not need to distinguish between <b>Cluster Endpoint</b> and <b>Platform Access Address</b>, enter the same address as the <b>Cluster Endpoint</b>.<br />
+        If you need to distinguish, for example, if the `global` cluster is only for internal network access and the platform needs to provide external network access, enter the pre-prepared domain name or <code>External IP</code>.<br />
+        The platform uses HTTPS access by default and does not enable HTTP. If you need to enable HTTP access, enable it in <b>Advanced Settings</b> (not recommended).<br />
+        <b>Note:</b> A domain name must be entered in the following cases,<br />
+        - A disaster recovery plan for the `global` cluster is planned;<br />
+        - The platform needs to support IPv6 access.<br />
+      </ul>
+      <ul>
+        <b>Tip:</b> If you need to configure more platform access addresses, you can add them in <b>Other Settings > Other Platform Access Addresses</b> in the next step. Or, after installation, add them in platform management according to the user manual.<br />
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td><b>Certificate</b></td>
+    <td>
+      The platform provides self-signed certificates to support HTTPS access by default.<br />
+      If you need to use a custom certificate, you can upload an existing certificate.
+    </td>
+  </tr>
+  <tr>
+    <td><b>Image Repository</b></td>
+    <td>
+      <code>Platform Deployment</code> uses the Registry deployed with the <code>global</code> cluster.<br />
+      <code>External</code> uses a customer-managed platform image registry. Its address and pull credentials must match the values passed to <code>setup.sh</code>, and the registry must already contain the complete target-version Core and Extension payload.
+    </td>
+  </tr>
+  <tr>
+    <td><b>Container Network</b></td>
+    <td>
+      The default subnet and Service network segment of the cluster cannot overlap.<br />
+      When using the Kube-OVN Overlay network, ensure that the container network and the host network are not in the same network segment, otherwise it may cause network exceptions.
+    </td>
+  </tr>
+  <tr>
+    <td><b>Node Name</b></td>
+    <td>
+      If you select <code>Host Name as Node Name</code>, ensure that the host names of all nodes are unique.
+    </td>
+  </tr>
+  <tr>
+    <td><b>`global` Cluster Platform Node Isolation</b></td>
+    <td>
+      Enable only when you plan to run application workloads in the `global` cluster.<br />
+      <b>After enabling:</b><br />
+      - Nodes can be set to <code>Platform Exclusive</code>, i.e., only run platform components, ensuring platform and application workloads are isolated;<br />
+      - Workloads of the DaemonSet type are excluded.
+    </td>
+  </tr>
+  <tr>
+    <td><b>Add Node</b></td>
+    <td>
+      <b>Control Plane Node:</b>
+      <ul>
+        - Supports adding 1 or 3 control plane nodes (3 for high availability configuration);<br />
+        - If <code>Platform Exclusive</code> is enabled, <code>Deployable Applications</code> is forced to be disabled, and control plane nodes only run platform components;<br />
+        - If <code>Platform Exclusive</code> is disabled, you can choose whether to enable <code>Deployable Applications</code>, allowing control plane nodes to run application workloads.<br />
+      </ul>
+
+      <b>Worker Node:</b>
+      <ul>
+        - If <code>Platform Exclusive</code> is enabled, <code>Deployable Applications</code> is forced to be disabled;<br />
+        - If <code>Platform Exclusive</code> is disabled, <code>Deployable Applications</code> is forced to be enabled.<br />
+      </ul>
+
+      <p>When using Kube-OVN, you can specify the node network card by entering the gateway name.</p>
+      <p>If the node availability check fails, adjust it according to the page prompt and add it again.</p>
+    </td>
+  </tr>
+</table>
+
+After reviewing the parameters, return to [Installing](./installing.mdx) to submit the installation.

--- a/docs/en/install/installing.mdx
+++ b/docs/en/install/installing.mdx
@@ -98,9 +98,7 @@ If you plan to create a `global` cluster with Single-stack Network IPv6, you mus
 
 ### Parameter Configuration
 
-After completing the installation parameter configuration according to the page guide, confirm the installation.
-
-[Parameter Description](#parameters) provides detailed descriptions of key parameters. Please read carefully and configure according to actual needs.
+Configure the installation in the Web UI, review every value, and then confirm the installation. Use [Installer Parameters](./installer-parameters.mdx) for the field-by-field reference.
 
 </Steps>
 
@@ -108,146 +106,18 @@ After completing the installation parameter configuration according to the page 
 
 After the installer reports that the installation is complete, validate Core and the required Aligned Extensions before continuing with post-install tasks. For the checklist and commands, see [Validation](./validation.mdx).
 
-## Parameter Description \{#parameters}
+## Installer Parameter Reference \{#parameters}
 
-<table>
-  <tr>
-    <th style={{ whiteSpace: 'nowrap' }}>Parameter</th>
-    <th style={{ whiteSpace: 'nowrap' }}>Description</th>
-  </tr>
-  <tr>
-    <td><b>Kubernetes Version</b></td>
-    <td>
-      All optional versions are rigorously tested for stability and compatibility.<br />
-      <b>Recommendation:</b> Choose the latest version for optimal features and support.
-    </td>
-  </tr>
-  <tr>
-    <td><b>Cluster Network Protocol</b></td>
-    <td>
-      Supports three modes: IPv4 single stack, IPv6 single stack, IPv4/IPv6 dual stack.<br />
-      <b>Note:</b> If you select dual stack mode, ensure all nodes have correctly configured IPv6 addresses; the network protocol cannot be changed after setting.
-    </td>
-  </tr>
-  <tr>
-    <td><b>Cluster Endpoint</b></td>
-    <td>
-      <ul>
-        Enter the pre-prepared domain name.<br />
-        If no domain name is available, enter the pre-prepared <code>`global` VIP</code>.<br />
-        <code>Self-built VIP</code> is disabled by default, only enable it if you have not provided a LoadBalancer.<br /><br />
-        The following conditions must be met when using <code>Self-built VIP</code> :<br />
-        - A usable VRID is available;<br />
-        - The host network supports the VRRP protocol;<br />
-        - All control plane nodes and the VIP must be on the same subnet.<br />
-      </ul>
-      <ul>
-        <b>Tip:</b> For single-node deployments in feature experience scenarios, you can directly enter the node IP. There is no need to enable <code>Self-built VIP</code> or prepare network resources such as <code>`global` VIP</code>.
-      </ul>
-    </td>
-  </tr>
-  <tr>
-    <td><b>Platform Access Address</b></td>
-    <td>
-      <ul>
-        If you do not need to distinguish between <b>Cluster Endpoint</b> and <b>Platform Access Address</b>, enter the same address as the <b>Cluster Endpoint</b>.<br />
-        If you need to distinguish, for example, if the `global` cluster is only for internal network access and the platform needs to provide external network access, enter the pre-prepared domain name or <code>External IP</code>.<br />
-        The platform uses HTTPS access by default and does not enable HTTP. If you need to enable HTTP access, enable it in <b>Advanced Settings</b> (not recommended).<br />
-        <b>Note:</b> A domain name must be entered in the following cases,<br />
-        - A disaster recovery plan for the `global` cluster is planned;<br />
-        - The platform needs to support IPv6 access.<br />
-      </ul>
-      <ul>
-        <b>Tip:</b> If you need to configure more platform access addresses, you can add them in <b>Other Settings > Other Platform Access Addresses</b> in the next step. Or, after installation, add them in platform management according to the user manual.<br />
-      </ul>
-    </td>
-  </tr>
-  <tr>
-    <td><b>Certificate</b></td>
-    <td>
-      The platform provides self-signed certificates to support HTTPS access by default.<br />
-      If you need to use a custom certificate, you can upload an existing certificate.
-    </td>
-  </tr>
-  <tr>
-    <td><b>Image Repository</b></td>
-    <td>
-      <code>Platform Deployment</code> uses the Registry deployed with the <code>global</code> cluster.<br />
-      <code>External</code> uses a customer-managed platform image registry. Its address and pull credentials must match the values passed to <code>setup.sh</code>, and the registry must already contain the complete target-version Core and Extension payload.
-    </td>
-  </tr>
-  <tr>
-    <td><b>Container Network</b></td>
-    <td>
-      The default subnet and Service network segment of the cluster cannot overlap.<br />
-      When using the Kube-OVN Overlay network, ensure that the container network and the host network are not in the same network segment, otherwise it may cause network exceptions.
-    </td>
-  </tr>
-  <tr>
-    <td><b>Node Name</b></td>
-    <td>
-      If you select <code>Host Name as Node Name</code>, ensure that the host names of all nodes are unique.
-    </td>
-  </tr>
-  <tr>
-    <td><b>`global` Cluster Platform Node Isolation</b></td>
-    <td>
-      Enable only when you plan to run application workloads in the `global` cluster.<br />
-      <b>After enabling:</b><br />
-      - Nodes can be set to <code>Platform Exclusive</code>, i.e., only run platform components, ensuring platform and application workloads are isolated;<br />
-      - Workloads of the DaemonSet type are excluded.
-    </td>
-  </tr>
-  <tr>
-    <td><b>Add Node</b></td>
-    <td>
-      <b>Control Plane Node:</b>
-      <ul>
-        - Supports adding 1 or 3 control plane nodes (3 for high availability configuration);<br />
-        - If <code>Platform Exclusive</code> is enabled, <code>Deployable Applications</code> is forced to be disabled, and control plane nodes only run platform components;<br />
-        - If <code>Platform Exclusive</code> is disabled, you can choose whether to enable <code>Deployable Applications</code>, allowing control plane nodes to run application workloads.<br />
-      </ul>
+For the detailed field reference, see [Installer Parameters](./installer-parameters.mdx).
 
-      <b>Worker Node:</b>
-      <ul>
-        - If <code>Platform Exclusive</code> is enabled, <code>Deployable Applications</code> is forced to be disabled;<br />
-        - If <code>Platform Exclusive</code> is disabled, <code>Deployable Applications</code> is forced to be enabled.<br />
-      </ul>
+## Installation Troubleshooting \{#common-stalls}
 
-      <p>When using Kube-OVN, you can specify the node network card by entering the gateway name.</p>
-      <p>If the node availability check fails, please adjust it according to the page prompt and add it again.</p>
-    </td>
-  </tr>
-</table>
-
-## Common Stalls and Where to Look \{#common-stalls}
-
-If the installer reports an error or appears to make no progress, start with the symptom in the table below. The signals listed are the first place to look; collect that output before opening a ticket so support can act on the same data.
-
-| Symptom | First place to look | What you are looking for |
-|---|---|---|
-| Web UI does not load | Terminal output of `setup.sh` and `nerdctl ps` on the installation node | The `minialauda-control-plane` container is Running and port `8080` is reachable from the browser. |
-| Installer log stops advancing | `tail -f /var/cpaas/data/installer.log` | The last log line tells you which phase the installer is in. If the same phase repeats for more than a few minutes, the cause is usually one of the rows below. |
-| Stuck on control plane provisioning | `kubectl get machines -A` and `kubectl describe` on a machine that is not `Ready` | `Bootstrap` and `Infrastructure` conditions on the machine; the node can usually be reached at the IP from `status.addresses`. |
-| Stuck on network and core add-ons | `kubectl -n kube-system get pods` on the new cluster | Kube-OVN, CoreDNS, and kube-proxy pods are `Running`. Image-pull failures usually point to a registry reachability problem. |
-| AppRelease shows `Failed` | `kubectl describe apprelease <name> -n <namespace>` | The `Status` conditions and recent `Events` describe the underlying chart error. |
-| Pod is `ImagePullBackOff` or `ErrImagePull` | `kubectl describe pod <pod> -n <namespace>` | Confirm that the platform image source is reachable from the failing node and that DNS, routing, firewall rules, CA trust, pull credentials, and the referenced manifest are available. |
-| Artifact reports `Absent` | `kubectl get productbase base -o yaml` and the registry administration interface | Confirm that the matching target-version package was uploaded to the configured registry and was not removed by retention, then republish the missing package. |
-| A recovered or replacement node cannot pull an installed-version image | `kubectl describe pod <pod> -n <namespace>` on the affected workload and registry retention records | Restore the referenced digest and correct registry availability, backup, or retention policies before retrying node recovery. |
-| `ClusterModule/global` does not reach a healthy phase | `kubectl describe clustermodule global` | The `Status.conditions` describe which module is blocking the cluster from completing. |
-
-Issues that are not listed here usually point to environment-specific causes. Capture the installer log and the relevant `kubectl describe` output, then escalate.
-
-## Installer Cleanup
-
-Normally, the installer will be automatically deleted after installation. If the installer is not automatically deleted after 30 minutes of installation, please execute the following command on the node where the installer is located to force delete the installer container:
-
-```bash
-nerdctl rm -f minialauda-control-plane
-```
+For installer stalls, failed resources, image-pull failures, missing artifacts, and cleanup, see [Installation Troubleshooting](./troubleshooting.mdx).
 
 ## Additional Resources
 
 - [Upload and Install Extensions](../extend/index.mdx)
+- [Installer Parameters](./installer-parameters.mdx)
 - [Validation](./validation.mdx)
+- [Installation Troubleshooting](./troubleshooting.mdx)
 - [Next Steps](./next_steps.mdx)

--- a/docs/en/install/next_steps.mdx
+++ b/docs/en/install/next_steps.mdx
@@ -1,5 +1,5 @@
 ---
-weight: 50
+weight: 60
 ---
 
 # Next Steps

--- a/docs/en/install/overview.mdx
+++ b/docs/en/install/overview.mdx
@@ -34,12 +34,16 @@ The following work is outside this installation flow:
 
 The installation follows this high-level path:
 
-1. [Plan](./planning.mdx). Choose the deployment architecture and confirm install-time decisions.
-2. [Prepare for installation](./prepare/index.mdx). Prepare resources, network access, storage, and nodes.
-3. [Download](./prepare/download.mdx). Download the Core Package and the `Common ACP Extensions` package set separately from the <Term name="company" /> Customer Portal.
-4. [Installing](./installing.mdx). Extract the Core Package, copy the eight required Aligned Extension packages into `plugins/`, start the installer, and configure installation parameters.
-5. [Validation](./validation.mdx). Confirm that the platform Web UI, Core, required Aligned Extensions, and Pods are healthy.
-6. [Next Steps](./next_steps.mdx). Install the Product Docs plugin and follow scenario-based next steps.
+1. [Plan](./planning.mdx). Choose the deployment architecture and confirm decisions that cannot be changed safely after installation.
+2. If required, read [Global Cluster Disaster Recovery](./global_dr.mdx) before preparing resources. DR affects addresses, certificates, load balancing, registry selection, and the consistency of both installations.
+3. [Prepare for installation](./prepare/index.mdx). Meet the hardware, storage, network, and node requirements.
+4. [Download](./prepare/download.mdx). Download the matching Core Package and the required Aligned Extension packages.
+5. If selected, [prepare the external platform image registry](./prepare/external-platform-image-registry.mdx) and upload the complete target-version payload.
+6. [Installing](./installing.mdx). Extract the Core Package, stage the required packages, start the installer, and complete the Web UI workflow.
+7. Use [Installer Parameters](./installer-parameters.mdx) while reviewing the values entered in the installer.
+8. [Validation](./validation.mdx). Accept the installation only after the Web UI, Core, required Aligned Extensions, image source, artifacts, and Pods are healthy.
+9. If the installer stalls or validation fails, use [Installation Troubleshooting](./troubleshooting.mdx).
+10. [Next Steps](./next_steps.mdx). Install the Product Docs plugin and continue with scenario-specific configuration.
 
 The Customer Portal is the official source for <Term name="productShort" /> installation packages. For download requirements and package architecture options, see [Download](./prepare/download.mdx).
 

--- a/docs/en/install/planning.mdx
+++ b/docs/en/install/planning.mdx
@@ -30,11 +30,11 @@ Confirm the following decisions before running the installer:
 | --- | --- | --- |
 | Installation packages | Choose an x86, ARM, or hybrid Core Package and download the required Aligned Extension packages for the same <Term name="productShort" /> version and architecture. | [Download](./prepare/download.mdx) |
 | Cluster network protocol | Choose IPv4, IPv6, or dual stack before starting the installer. | [Installing](./installing.mdx#start_installer) |
-| Cluster Endpoint and Platform Access Address | Prepare the access addresses that cluster components, administrators, and users will use. | [Prerequisites](./prepare/prerequisites.mdx#network-resources) and [Parameter Description](./installing.mdx#parameters) |
+| Cluster Endpoint and Platform Access Address | Prepare the access addresses that cluster components, administrators, and users will use. | [Prerequisites](./prepare/prerequisites.mdx#network-resources) and [Installer Parameters](./installer-parameters.mdx) |
 | Load balancing | Decide whether to use an external load balancer or Self-built VIP. | [Prerequisites](./prepare/prerequisites.mdx#network-resources) and [LoadBalancer Forwarding Rules](./prepare/prerequisites.mdx#port-forward) |
-| Certificates | Decide whether to use installer-generated self-signed certificates or trusted certificates that you provide. | [Prerequisites](./prepare/prerequisites.mdx#network-resources) and [Parameter Description](./installing.mdx#parameters) |
-| Platform image source | Decide whether to use the platform built-in Registry or a customer-managed external platform image registry. For new production deployments, use an external registry when it meets the documented availability and lifecycle requirements. | [Prepare an External Platform Image Registry](./prepare/external-platform-image-registry.mdx) and [Parameter Description](./installing.mdx#parameters) |
-| Nodes | Confirm node names, node roles, and whether platform node isolation is required. | [Node Preprocessing](./prepare/node_preprocessing.mdx) and [Parameter Description](./installing.mdx#parameters) |
+| Certificates | Decide whether to use installer-generated self-signed certificates or trusted certificates that you provide. | [Prerequisites](./prepare/prerequisites.mdx#network-resources) and [Installer Parameters](./installer-parameters.mdx) |
+| Platform image source | Decide whether to use the platform built-in Registry or a customer-managed external platform image registry. For new production deployments, use an external registry when it meets the documented availability and lifecycle requirements. | [Prepare an External Platform Image Registry](./prepare/external-platform-image-registry.mdx) and [Installer Parameters](./installer-parameters.mdx) |
+| Nodes | Confirm node names, node roles, and whether platform node isolation is required. | [Node Preprocessing](./prepare/node_preprocessing.mdx) and [Installer Parameters](./installer-parameters.mdx) |
 | Global Cluster Disaster Recovery | Decide whether your environment requires primary and standby `global` clusters. | [Global Cluster Disaster Recovery](./global_dr.mdx) |
 
 If you plan to use Global Cluster Disaster Recovery, read [Global Cluster Disaster Recovery](./global_dr.mdx) before installing <Term name="productShort" /> Core. Disaster recovery planning affects domain names, VIPs, certificates, load balancer rules, image registry choices, package architecture, and installation parameter consistency.
@@ -49,4 +49,5 @@ Use the following pages as the source of truth before running the installer:
 - [Download](./prepare/download.mdx): Download the Core Package and `Common ACP Extensions` separately, and verify that their version and architecture match.
 - [Prepare an External Platform Image Registry](./prepare/external-platform-image-registry.mdx): If selected, upload the complete target-version Core and Extension payload before starting the installer.
 - [Global Cluster Disaster Recovery](./global_dr.mdx): Plan primary and standby `global` clusters if disaster recovery is required.
-- [Installing](./installing.mdx): Upload the Core Package, start the installer, and configure parameters.
+- [Installing](./installing.mdx): Upload the Core Package, stage required packages, and start the installer.
+- [Installer Parameters](./installer-parameters.mdx): Configure the installation choices in the Web UI.

--- a/docs/en/install/prepare/external-platform-image-registry.mdx
+++ b/docs/en/install/prepare/external-platform-image-registry.mdx
@@ -1,5 +1,5 @@
 ---
-weight: 25
+weight: 40
 ---
 
 # Prepare an External Platform Image Registry
@@ -84,7 +84,7 @@ Use the Core Package that exactly matches the <Term name="productShort" /> Distr
 
 5. In the registry administration interface or API, confirm that the newly uploaded repositories and manifests are present and are not immediately eligible for cleanup.
 
-## Troubleshooting
+## Troubleshooting \{#troubleshooting}
 
 | Symptom | Likely cause | Action |
 | --- | --- | --- |

--- a/docs/en/install/troubleshooting.mdx
+++ b/docs/en/install/troubleshooting.mdx
@@ -19,12 +19,12 @@ Collect the signal in the second column before changing the environment or openi
 | AppRelease shows `Failed` | `kubectl describe apprelease <name> -n <namespace>` | Status conditions and recent Events that identify the chart or dependency failure. |
 | `ClusterModule/global` does not become healthy | `kubectl describe clustermodule global` | The status condition that identifies the blocking Core or Aligned module. |
 
-## Image Pull and Artifact Failures
+## Image Pull and Artifact Failures \{#image-pull-and-artifact-failures}
 
 | Symptom | Checks | Recovery |
 | --- | --- | --- |
 | Pod is `ImagePullBackOff` or `ErrImagePull` | Run `kubectl describe pod <pod> -n <namespace>` and test the configured registry from the failing node. | Correct the reported DNS, route, firewall, CA trust, pull credential, registry availability, or missing-manifest problem. |
-| Artifact reports `Absent` | Inspect `kubectl get productbase base -o yaml` and the registry administration interface. | Republish the matching package from the exact target-version payload to the configured registry. |
+| A required Core or Aligned application is unavailable after installation | Inspect the corresponding `AppRelease`, `ModuleInfo`, `ModulePlugin`, and Pod Events. If package availability is still unclear, inspect the matching entry in `kubectl get productbase base -o yaml` and the exact `repository:tag` in the registry. | If the registry confirms that the required manifest is missing, upload the matching installation-version package. For authorization, CA, DNS, routing, or connectivity errors, correct the reported registry problem instead of republishing the package. Ignore unrelated `Absent` entries for optional or uninstalled catalog packages. |
 | A recovered or replacement node cannot pull an installed-version image | Inspect the failing Pod and registry retention records. | Restore the referenced digest, then correct registry availability, backup, or retention policy before retrying recovery. |
 
 For upload-command failures that occur before the installer starts, use [External Platform Image Registry Troubleshooting](./prepare/external-platform-image-registry.mdx#troubleshooting).

--- a/docs/en/install/troubleshooting.mdx
+++ b/docs/en/install/troubleshooting.mdx
@@ -1,0 +1,42 @@
+---
+weight: 50
+---
+
+# Installation Troubleshooting
+
+Use this page when the installer does not progress, an installation resource fails, or post-install validation reports an image or artifact problem.
+
+## Common Stalls and Where to Look
+
+Collect the signal in the second column before changing the environment or opening a support ticket.
+
+| Symptom | First place to look | What you are looking for |
+|---|---|---|
+| Web UI does not load | Terminal output of `setup.sh` and `nerdctl ps` on the installation node | The `minialauda-control-plane` container is Running and port `8080` is reachable from the browser. |
+| Installer log stops advancing | `tail -f /var/cpaas/data/installer.log` | The last completed phase and the first repeated or failed operation. |
+| Stuck on control plane provisioning | `kubectl get machines -A` and `kubectl describe` on a machine that is not `Ready` | The `Bootstrap` and `Infrastructure` conditions and the node address in `status.addresses`. |
+| Stuck on network and Core add-ons | `kubectl -n kube-system get pods` on the new cluster | Kube-OVN, CoreDNS, and kube-proxy Pods are `Running`; image-pull failures usually identify a registry path problem. |
+| AppRelease shows `Failed` | `kubectl describe apprelease <name> -n <namespace>` | Status conditions and recent Events that identify the chart or dependency failure. |
+| `ClusterModule/global` does not become healthy | `kubectl describe clustermodule global` | The status condition that identifies the blocking Core or Aligned module. |
+
+## Image Pull and Artifact Failures
+
+| Symptom | Checks | Recovery |
+| --- | --- | --- |
+| Pod is `ImagePullBackOff` or `ErrImagePull` | Run `kubectl describe pod <pod> -n <namespace>` and test the configured registry from the failing node. | Correct the reported DNS, route, firewall, CA trust, pull credential, registry availability, or missing-manifest problem. |
+| Artifact reports `Absent` | Inspect `kubectl get productbase base -o yaml` and the registry administration interface. | Republish the matching package from the exact target-version payload to the configured registry. |
+| A recovered or replacement node cannot pull an installed-version image | Inspect the failing Pod and registry retention records. | Restore the referenced digest, then correct registry availability, backup, or retention policy before retrying recovery. |
+
+For upload-command failures that occur before the installer starts, use [External Platform Image Registry Troubleshooting](./prepare/external-platform-image-registry.mdx#troubleshooting).
+
+## Installer Cleanup
+
+The installer normally removes itself after installation. If the installer container remains 30 minutes after installation completes, run this command on the installation node:
+
+```bash
+nerdctl rm -f minialauda-control-plane
+```
+
+## Collect Evidence Before Escalation
+
+Capture `/var/cpaas/data/installer.log`, the relevant `kubectl describe` output, failing resource conditions, and the exact Core Package version and architecture. Do not include registry passwords or Secret contents.

--- a/docs/en/install/validation.mdx
+++ b/docs/en/install/validation.mdx
@@ -1,5 +1,5 @@
 ---
-weight: 35
+weight: 40
 ---
 
 # Validation

--- a/docs/en/install/validation.mdx
+++ b/docs/en/install/validation.mdx
@@ -84,18 +84,9 @@ kubectl get cluster global -o json \
 
 For a registry that permits anonymous pull, the password annotation does not need to exist.
 
-Confirm that no discovered artifact is missing:
+`ProductBase` also contains catalog entries for optional or uninstalled Extensions. Do not require every entry in `ProductBase.status.artifacts` to be `Ready`; an unrelated `Absent` entry does not by itself indicate an installation failure.
 
-```bash
-kubectl get productbase base -o json | jq -r '
-  .status.artifacts[] as $artifact
-  | $artifact.channels[]
-  | select(.artifactStatus != "Ready")
-  | [$artifact.name, .channel, .tag, .artifactStatus]
-  | @tsv'
-```
-
-No output is expected. Confirm that the Extension catalog exists and that Pods are not blocked by image pulls:
+Confirm that the required Extension catalog entries exist and that Pods are not blocked by image pulls:
 
 ```bash
 kubectl get moduleplugins
@@ -104,7 +95,7 @@ kubectl get pods --all-namespaces \
   | awk '$4 ~ /ImagePullBackOff|ErrImagePull/'
 ```
 
-The Pod command must produce no output. If an artifact reports `Absent`, republish the matching Core or Extension package from the exact target-version payload. If a Pod cannot pull an image, use `kubectl describe pod <pod> -n <namespace>` to identify whether DNS, routing, firewall rules, CA trust, pull credentials, registry availability, or a missing manifest caused the failure.
+The Pod command must produce no output. Installation acceptance is based on the required applications, their `ModuleInfo` and `AppRelease` state, and their running Pods. If a required installed application is unavailable, follow [Installation Troubleshooting](./troubleshooting.mdx#image-pull-and-artifact-failures) to distinguish a missing manifest from DNS, routing, firewall, CA trust, pull credential, or registry availability problems.
 
 ## Next Step
 

--- a/docs/en/upgrade/overview.mdx
+++ b/docs/en/upgrade/overview.mdx
@@ -14,13 +14,33 @@ When moving the platform to a new ACP Distribution Version, the upgrade normally
 
 A workload cluster can be upgraded only to a Distribution Version that the global tier has already reached. In environments with **global disaster recovery (DR)**, this means both the standby and primary global clusters must reach the target Distribution Version before workload clusters are upgraded to that Distribution Version. Before upgrading the global tier, verify that every workload cluster is within the target Distribution Version's **Compatible Versions** in the [Kubernetes Support Matrix](../overview/kubernetes-support-matrix.mdx#version-support-matrix). This prerequisite is separate from the sequencing rule.
 
+## Upgrade Workflow
+
+Follow the pages in this order:
+
+1. [Pre-Upgrade Preparation](./pre-upgrade.mdx): confirm the supported path, cluster readiness, and complete target-version package set.
+2. [Upgrade the global cluster](./upgrade_global_cluster.mdx), or [Upgrade Global Clusters in a DR Environment](./upgrade_global_dr.mdx) when global DR is enabled.
+3. [Upgrade Workload Clusters](./upgrade_workload_cluster.mdx) after the global tier reaches the target Distribution Version.
+4. [Upgrade Validation](./validation.mdx): accept the Distribution Version, Kubernetes, Core, Aligned plugins, Pods, artifacts, CVO history, and Web UI.
+5. [Upgrade Troubleshooting](./troubleshooting.mdx): use this only when preflight or execution reports a block or stall.
+
+Plan the maintenance timeline so preparation finishes before the change window:
+
+| Phase | Recommended timing | State change |
+| --- | --- | --- |
+| Download and publish artifacts | Before the maintenance window | No running component is upgraded. |
+| Run preflight and resolve blocks | 1–2 weeks before the window | Read-only checks; remediation can change the environment separately. |
+| Upgrade the global tier | First maintenance window | Core, Kubernetes, and installed Aligned plugins move to the target. |
+| Upgrade workload clusters | After the global tier | Each selected workload cluster moves in its own controlled window. |
+| Validate and complete follow-up work | Before closing each window | Confirms acceptance and completes required post-upgrade actions. |
+
 ## Key Concepts
 
 - **ClusterVersionShadow (`cvsh`)**: The upgrade resource used to track current version, desired version, preflight results, execution stages, and history.
 - **Distribution Version**: The ACP version currently reached by a cluster. A workload cluster can be upgraded only to a Distribution Version that the global tier has already reached.
 - **Preflight**: Validation checks that run before the upgrade starts applying the target version. For workload clusters, review preflight results from the upgrade status output after the upgrade request is submitted.
 - **Available upgrade targets**: The upgrade versions that are currently offered for a cluster. In the Web Console, the target version for the current upgrade flow is determined by the platform.
-- **upgrade.sh**: The preparation script for global cluster upgrades. It synchronizes Core artifacts and any required Aligned Extension packages that you manually place in the extracted Core Package's `plugins/` directory. Artifact synchronization and preflight checks can be run ahead of the maintenance window; the cluster version operator is deployed inside the window, just before the upgrade is requested.
+- **upgrade.sh**: The preparation script for global cluster upgrades. With the platform built-in Registry, it synchronizes Core artifacts and packages staged in `plugins/`. With an external Registry, synchronization is skipped and the target payload is uploaded separately. The script also runs preflight and deploys CVO at the appropriate stages.
 - **Global DR environment**: An environment with both a primary global cluster and a standby global cluster.
 - **Primary global cluster**: The global cluster that the platform access domain currently resolves to.
 - **Standby global cluster**: The other global cluster in the DR pair. After a failover, the roles of the two clusters are swapped.
@@ -33,16 +53,16 @@ A single cluster upgrade window covers four kinds of work:
 
 | Work item | Required? | How it is upgraded | If you run immutable OS |
 |---|---|---|---|
-| <Term name="productShort" /> Core (the platform itself) | Required | CVO, driven by `upgrade.sh`-prepared artifacts | Same control flow; the Kubernetes step is handled separately, see below |
-| Aligned plugins (cluster plugins and operators released together with the matching ACP version) | Required for each installed plugin | For the Aligned applications provided through **ACP Upgrade to v4.5**, manually copy their separately downloaded packages into the extracted Core Package's `plugins/` directory and synchronize them with `upgrade.sh`. Publish other installed Aligned packages with `violet`. CVO then upgrades each installed Aligned plugin as part of the cluster upgrade. | Same |
+| <Term name="productShort" /> Core (the platform itself) | Required | CVO, driven by artifacts prepared through [Sync upgrade artifacts](./upgrade_global_cluster.mdx#sync-upgrade-artifacts) | Same control flow; the Kubernetes step is handled separately, see below |
+| Aligned plugins (cluster plugins and operators released together with the matching ACP version) | Required for each installed plugin | For the Aligned applications provided through **ACP Upgrade to v4.5**, manually copy their packages into `plugins/` and publish them through [Sync upgrade artifacts](./upgrade_global_cluster.mdx#sync-upgrade-artifacts). Publish other installed Aligned packages with `violet`. CVO then upgrades each installed Aligned plugin as part of the cluster upgrade. | Same |
 | Kubernetes | Required in the same window | On traditional-OS clusters, CVO upgrades Kubernetes in place on the existing nodes as part of the same cluster upgrade; nodes are not replaced. | Kubernetes is rolled out by replacing nodes from a new Alauda OS-based image through Cluster API rolling updates, not upgraded in place. The procedure lives in the immutable infrastructure documentation; see <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/huawei-dcs.html" children="Upgrading Clusters on Huawei DCS" />, <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/vmware-vsphere.html" children="Upgrading Clusters on VMware vSphere" />, or <ExternalSiteLink name="immutable-infra" href="/upgrade-cluster/huawei-cloud-stack.html" children="Upgrading Clusters on Huawei Cloud Stack" /> |
 | Agnostic plugins (independently released cluster plugins and operators) | Optional, per plugin | Upgrade each cluster plugin or operator from **Marketplace > Cluster Plugins** or the operator's own workflow after the cluster reaches the target Distribution Version | Same |
 
 A few rules govern when each piece moves:
 
 - The platform requires that a cluster's Kubernetes version is upgraded together with its Core and Aligned versions; mixing a new Core release with an old Kubernetes minor version is not validated.
-- Before requesting an upgrade, make the target-version package available for every Aligned plugin already installed on that cluster. Use `upgrade.sh` for the packages from **ACP Upgrade to v4.5**, and use `violet` for other Aligned packages. A missing package for an installed Aligned plugin stalls the CVO upgrade. Packages for Aligned plugins that are not installed on the cluster do not cause those plugins to be installed.
-- Cluster plugins are global resources. A package made available through the global-tier `upgrade.sh` or `violet` workflow can be used by every cluster in the platform; you do not publish the same cluster plugin again per workload cluster.
+- Before requesting an upgrade, make the target-version package available for every Aligned plugin already installed on that cluster. Use the `plugins/` publication path in [Sync upgrade artifacts](./upgrade_global_cluster.mdx#sync-upgrade-artifacts) for packages from **ACP Upgrade to v4.5**, and use `violet` for other Aligned packages. A missing package for an installed Aligned plugin stalls the CVO upgrade. Packages for Aligned plugins that are not installed on the cluster do not cause those plugins to be installed.
+- Cluster plugins are global resources. A package made available through the global-tier artifact publication or `violet` workflow can be used by every cluster in the platform; you do not publish the same cluster plugin again per workload cluster.
 - Operators are scoped to each cluster. Pushing operators to the global tier is recommended but not sufficient on its own; the same operator must be available on each workload cluster before the workload upgrade. If you forgot to push an operator during the global window, you can push it again before the workload upgrade as a fallback.
 - Workload-cluster upgrades are only required when a workload cluster falls outside the target ACP release's [Kubernetes Support Matrix](../overview/kubernetes-support-matrix.html). Workload clusters that stay within the supported range can keep their existing Kubernetes version after the global tier moves; the platform will continue to manage them.
 
@@ -52,7 +72,7 @@ The Cluster Version Operator (CVO) decides which kinds of upgrades it drives end
 
 | Lifecycle type | Driven by CVO? | Notes |
 |---|---|---|
-| Core | Yes, CVO is the only supported path | Core upgrades require the artifacts that `upgrade.sh` prepares; CVO consumes those artifacts. |
+| Core | Yes, CVO is the only supported path | Core upgrades require the artifacts prepared through the global-cluster sync workflow; CVO consumes those artifacts. |
 | Aligned plugins | Yes by default | The cluster plugin or operator workflow can also upgrade an individual Aligned plugin out of band — for example, to apply a critical security fix without moving the cluster to a new Distribution Version. |
 | Agnostic plugins | No | CVO does not manage these. Upgrade each cluster plugin from **Marketplace > Cluster Plugins** and each operator from its own workflow after the cluster reaches the target Distribution Version. |
 
@@ -71,15 +91,12 @@ On **Immutable Infrastructure** clusters (DCS, vSphere, HCS), Kube-OVN is driven
 - **Global clusters**: Follow the validated `upgrade.sh`-based procedure. After the preparation phase completes, request the upgrade from the Web Console through the two-step RPCH review flow, use ACP CLI, or update `ClusterVersionShadow.spec.desiredUpdate` directly.
 - **Workload clusters**: Use the Web Console through the two-step RPCH review flow or use ACP CLI after the target Distribution Version becomes available for the workload cluster.
 
-## Post-upgrade Security Hardening
-
-If the environment is upgrading from a release earlier than ACP 4.3 and has not completed PKCE security hardening, complete [Disabling the PKCE Plain Method](/security/platform_security_configurations/disable_pkce_plain_method.mdx) after the global cluster and all workload clusters reach the target Distribution Version.
-
-If the environment is upgrading from a release earlier than ACP 4.3, complete the required Agnostic plugin compatibility upgrades in [Upgrade the global cluster](./upgrade_global_cluster.mdx).
-
 ## Related Documentation
 
 - [Pre-upgrade](./pre-upgrade.mdx)
 - [Upgrade the global cluster](./upgrade_global_cluster.mdx)
+- [Upgrade global clusters in a DR environment](./upgrade_global_dr.mdx)
 - [Upgrade workload clusters](./upgrade_workload_cluster.mdx)
+- [Upgrade validation](./validation.mdx)
+- [Upgrade troubleshooting](./troubleshooting.mdx)
 - [Global Cluster Disaster Recovery](/install/global_dr.mdx)

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -105,7 +105,7 @@ This package set provides the target-version packages for the following Aligned 
 - **Alauda Language Pack for Chinese**
 - **Alauda Container Platform Networking for Calico**
 
-Before running `upgrade.sh`, manually copy all eleven packages into the `plugins/` directory of the extracted Core Package. [Upgrade the global cluster](./upgrade_global_cluster.mdx#sync-upgrade-artifacts) describes the copy and synchronization steps.
+Before publishing upgrade artifacts, manually copy all eleven packages into the `plugins/` directory of the extracted Core Package. [Sync upgrade artifacts](./upgrade_global_cluster.mdx#sync-upgrade-artifacts) describes the built-in and external Registry publication branches.
 
 ### Step 3: Inventory other Extensions on every cluster in scope
 
@@ -135,12 +135,12 @@ Import the exported `apps.yaml` file into the **<Term name="company" /> Customer
 
 If the result includes one of the eleven applications from **ACP Upgrade to v4.5**, do not publish that duplicate with `violet`. Use the package from **ACP Upgrade to v4.5** through the Core Package's `plugins/` directory instead. Use `violet push` only for the remaining Extension packages.
 
-Download every package you will need so they are all available locally before the upgrade window starts. The next page, [Upgrade the global cluster](./upgrade_global_cluster.mdx), describes how `upgrade.sh` synchronizes Core and the eleven manually staged packages, and how `violet` publishes the other Extensions. Artifact synchronization and package publication do not upgrade any already-running plugin, so complete them before the maintenance window.
+Download every package you will need so they are all available locally before the upgrade window starts. The next page, [Upgrade the global cluster](./upgrade_global_cluster.mdx), describes how the selected Registry path publishes Core and the eleven manually staged packages, and how `violet` publishes the other Extensions. Artifact publication does not upgrade any already-running plugin, so complete it before the maintenance window.
 
 :::warning Required Aligned Plugin Packages
 Every Aligned plugin installed on a cluster being upgraded must have its target-version package available before the upgrade request. CVO does not require target packages for Aligned plugins that are not installed, and synchronizing a package does not install an absent plugin.
 
-If a required package is missing or is not ready, CVO stalls the cluster upgrade. Add packages from **ACP Upgrade to v4.5** through the `plugins/` directory and `upgrade.sh`; publish other packages with `violet`. CVO detects newly available packages and continues the existing upgrade request automatically.
+If a required package is missing or is not ready, CVO stalls the cluster upgrade. Add packages from **ACP Upgrade to v4.5** through the `plugins/` publication path in [Sync upgrade artifacts](./upgrade_global_cluster.mdx#sync-upgrade-artifacts); publish other packages with `violet`. CVO detects newly available packages and continues the existing upgrade request automatically.
 :::
 
 :::warning

--- a/docs/en/upgrade/pre-upgrade.mdx
+++ b/docs/en/upgrade/pre-upgrade.mdx
@@ -138,9 +138,9 @@ If the result includes one of the eleven applications from **ACP Upgrade to v4.5
 Download every package you will need so they are all available locally before the upgrade window starts. The next page, [Upgrade the global cluster](./upgrade_global_cluster.mdx), describes how the selected Registry path publishes Core and the eleven manually staged packages, and how `violet` publishes the other Extensions. Artifact publication does not upgrade any already-running plugin, so complete it before the maintenance window.
 
 :::warning Required Aligned Plugin Packages
-Every Aligned plugin installed on a cluster being upgraded must have its target-version package available before the upgrade request. CVO does not require target packages for Aligned plugins that are not installed, and synchronizing a package does not install an absent plugin.
+Every Aligned plugin installed on a cluster being upgraded must have its target-version package available before the upgrade request. CVO does not require target packages for Aligned applications that are not installed, and synchronizing a package does not install an application that is not currently installed.
 
-If a required package is missing or is not ready, CVO stalls the cluster upgrade. Add packages from **ACP Upgrade to v4.5** through the `plugins/` publication path in [Sync upgrade artifacts](./upgrade_global_cluster.mdx#sync-upgrade-artifacts); publish other packages with `violet`. CVO detects newly available packages and continues the existing upgrade request automatically.
+If a required package is unavailable, CVO blocks progress and keeps retrying the existing request. For an installed Aligned cluster plugin, the `ClusterVersionShadow` condition reports a missing or non-Ready target `ModulePluginConfig`. For an installed Aligned operator, inspect its target catalog, `Subscription`, `InstallPlan`, and `ModuleInfo`. Add packages from **ACP Upgrade to v4.5** through the `plugins/` publication path in [Sync upgrade artifacts](./upgrade_global_cluster.mdx#sync-upgrade-artifacts); publish other packages with `violet`.
 :::
 
 :::warning

--- a/docs/en/upgrade/troubleshooting.mdx
+++ b/docs/en/upgrade/troubleshooting.mdx
@@ -1,0 +1,96 @@
+---
+weight: 60
+---
+
+# Upgrade Troubleshooting
+
+Use this page when preflight reports a blocking check, CVO reports `Stalled=True`, or a Core or Aligned module does not reach its target version.
+
+## Inspect Upgrade State
+
+Replace `<cluster>` with `global` or the workload cluster name:
+
+```bash
+kubectl -n cpaas-system get cvsh <cluster> \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+
+kubectl -n cpaas-system get cvsh <cluster> \
+  -o jsonpath='{.status.preflight.observedAt}{"\n"}{range .status.preflight.checks[*]}{.name}{"\t"}{.policy}{"\t"}{.state}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+
+kubectl -n cpaas-system get cvsh <cluster> \
+  -o jsonpath='{range .status.history[*]}{.version}{"\t"}{.state}{"\t"}{.startedTime}{"\t"}{.completionTime}{"\n"}{end}'
+```
+
+Resolve the first failing preflight check or the reason in the `Stalled` condition before changing the upgrade request.
+
+## Handle Preflight Blocks \{#handle-preflight-blocks-when-needed}
+
+If `ResourcePatchUpgradeable` fails with `reason=UnexemptResourcePatches`, inspect the named `ResourcePatch` and add the required target-version exemption only after reviewing the patch:
+
+```bash
+kubectl -n cpaas-system get cvsh <cluster> \
+  -o jsonpath='{range .status.preflight.checks[?(@.name=="ResourcePatchUpgradeable")]}{.state}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+
+kubectl get resourcepatches <rp-name> -o yaml
+kubectl annotate resourcepatches <rp-name> \
+  config.cpaas.io/exempt-for-ver=<target-version> \
+  --overwrite
+```
+
+Common preflight blocks:
+
+| Check | What it validates | Resolution |
+| --- | --- | --- |
+| `KubernetesVersionSupported` | The cluster's Kubernetes version is within the target release's supported range. | Follow the [Kubernetes Support Matrix](/overview/kubernetes-support-matrix.html); do not disable the check. |
+| `VersionUpgradePath` | The current patch can reach the requested target through a supported edge. | Use a target in `availableUpdates` or follow an offered intermediate target. |
+| `ClusterRunning` | The cluster is healthy and reconciled. | Inspect `kubectl get clusterview <cluster>` and resolve unhealthy nodes or components. |
+| `DockerRuntimeUnsupported` | No node uses the unsupported Docker runtime. | Migrate affected nodes to `containerd`. |
+| `ClusterModuleStable`, `ModuleInfoStable` | Core and installed Aligned modules are stable. | Follow [Verify Module Stability Before You Upgrade](./pre-upgrade.mdx#module-stability-self-check). |
+
+Do not disable `VersionUpgradePath`, `KubernetesVersionSupported`, or `AdminAckRequired` to force an unsupported upgrade. If technical support instructs you to disable another check temporarily, disable only the named check in `cpaas-system/cvo-config`.
+
+## Handle Administrator Acknowledgement Gates
+
+If `AdminAckRequired` fails, inspect the keys supplied by the target release:
+
+```bash
+kubectl -n cpaas-system get configmap admin-gates -o yaml
+```
+
+Complete the action described by the applicable gate. For a Kubernetes 1.35 or later node-readiness gate, complete [Kubernetes 1.35 or Later Node Readiness](./pre-upgrade.mdx#kubernetes-135-node-readiness) on every production node.
+
+Copy the applicable key from `admin-gates`, record the acknowledgement, and rerun preflight:
+
+```bash
+ACK_KEY='<key-from-admin-gates>'
+kubectl -n cpaas-system patch configmap admin-acks --type merge \
+  -p "{\"data\":{\"${ACK_KEY}\":\"true\"}}"
+
+bash upgrade.sh --preflight
+```
+
+## Recover a Missing Aligned Package \{#recover-missing-aligned-package}
+
+If `Stalled=True` names a missing or not-ready `ModulePluginConfig`, identify the application and required version from the condition.
+
+- For an application in **ACP Upgrade to v4.5**, copy its package into the target Core Package's `plugins/` directory. With the platform built-in Registry, rerun `upgrade.sh --only-sync-image`. With an external registry, rerun both modes in [Prepare the Target-Version Payload](../install/prepare/external-platform-image-registry.mdx#prepare-the-target-version-payload).
+- For another Aligned cluster plugin, publish the target package to the global tier with `violet push`.
+- For an Aligned operator, publish the target package to every cluster where that operator is installed. If only one workload cluster is missing it, push to that cluster with `--clusters "<workload-cluster-name>"`.
+
+Continue observing the existing request. CVO resumes after the package becomes ready; do not clear or resubmit `desiredUpdate`.
+
+## Diagnose a Module That Does Not Advance
+
+```bash
+kubectl get moduleinfo -l cpaas.io/cluster-name=<cluster> \
+  -o custom-columns='MODULE:.metadata.labels.cpaas\.io/module-name,CURRENT:.status.version,TARGET:.spec.version,NEW:.status.availableVersions[0].version,PHASE:.status.phase'
+
+kubectl get moduleinfo <name> \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+```
+
+Inspect the named resource and related Events. For image-pull failures, verify registry reachability, CA trust, pull credentials, and the referenced manifest from the affected node.
+
+## Collect Evidence Before Escalation
+
+Capture the `cvsh` conditions, preflight checks, stages and history, the affected `ModuleInfo` or `ModulePluginConfig`, related Events, and the exact source and target versions. Do not include platform tokens, registry passwords, or Secret contents.

--- a/docs/en/upgrade/troubleshooting.mdx
+++ b/docs/en/upgrade/troubleshooting.mdx
@@ -4,7 +4,7 @@ weight: 60
 
 # Upgrade Troubleshooting
 
-Use this page when preflight reports a blocking check, CVO reports `Stalled=True`, or a Core or Aligned module does not reach its target version.
+Use this page when preflight reports a blocking check, CVO reports `Ready=False`, `Reconciling=True`, or `Stalled=True`, or a Core or Aligned module does not reach its target version.
 
 ## Inspect Upgrade State
 
@@ -21,7 +21,7 @@ kubectl -n cpaas-system get cvsh <cluster> \
   -o jsonpath='{range .status.history[*]}{.version}{"\t"}{.state}{"\t"}{.startedTime}{"\t"}{.completionTime}{"\n"}{end}'
 ```
 
-Resolve the first failing preflight check or the reason in the `Stalled` condition before changing the upgrade request.
+Resolve the first failing preflight check or the relevant `Ready`, `Reconciling`, or `Stalled` condition before changing the upgrade request.
 
 ## Handle Preflight Blocks \{#handle-preflight-blocks-when-needed}
 
@@ -71,13 +71,48 @@ bash upgrade.sh --preflight
 
 ## Recover a Missing Aligned Package \{#recover-missing-aligned-package}
 
-If `Stalled=True` names a missing or not-ready `ModulePluginConfig`, identify the application and required version from the condition.
+An unavailable Aligned package does not change the application's current installed state. Depending on the package type and reconciliation stage, CVO can report the problem through `Ready=False` or `Reconciling=True` rather than `Stalled=True`.
+
+### Aligned Cluster Plugins
+
+If a `ClusterVersionShadow` condition contains `required ready ModulePluginConfig for installed platform-aligned component`, identify the target `ProductManifest` and the named `ModulePluginConfig`:
+
+```bash
+kubectl get productmanifest v<target-version> -o yaml
+
+kubectl get modulepluginconfig <modulepluginconfig-name> \
+  -o jsonpath='{.spec.image}{"\n"}{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+```
+
+For a ModulePlugin channel, `artifactStatus: Absent` in the target `ProductManifest` means that the matching target `ModulePluginConfig` is not fully Ready. It does not mean that the currently installed application became absent, and it does not by itself prove that the image is missing from the registry.
+
+Use the `ModulePluginConfig` condition and the exact image in `.spec.image` to select the recovery:
+
+| Evidence | Recovery |
+| --- | --- |
+| The named `ModulePluginConfig` does not exist | Inspect the target `ProductManifest` conditions and controller reconciliation. A missing object does not by itself prove that the package image is absent. |
+| `ResolveDigestFailed` reports `manifest unknown` or `not found`, or the registry confirms that `.spec.image` is absent | Republish the exact target package by using the applicable method below. |
+| The condition reports `unauthorized`, `denied`, or another authentication error | Correct the registry credentials or repository permissions, then let the existing request retry. |
+| The condition reports an `x509` or certificate trust error | Correct the registry certificate chain or node trust configuration. |
+| The condition reports DNS, routing, timeout, or connection errors | Restore registry reachability from the component that performs the resolution. |
+| `LoadModulePluginFailed` | Inspect the package contents and `module-plugin.yaml`; publish a corrected package only after confirming the package is invalid. |
 
 - For an application in **ACP Upgrade to v4.5**, copy its package into the target Core Package's `plugins/` directory. With the platform built-in Registry, rerun `upgrade.sh --only-sync-image`. With an external registry, rerun both modes in [Prepare the Target-Version Payload](../install/prepare/external-platform-image-registry.mdx#prepare-the-target-version-payload).
 - For another Aligned cluster plugin, publish the target package to the global tier with `violet push`.
-- For an Aligned operator, publish the target package to every cluster where that operator is installed. If only one workload cluster is missing it, push to that cluster with `--clusters "<workload-cluster-name>"`.
 
-Continue observing the existing request. CVO resumes after the package becomes ready; do not clear or resubmit `desiredUpdate`.
+### Aligned Operators
+
+Aligned operators do not use `ModulePluginConfig`. If an installed operator does not advance, inspect its `Subscription`, target `InstallPlan`, catalog, and `ModuleInfo` on the affected cluster:
+
+```bash
+kubectl get subscription -A
+kubectl get installplan -A
+kubectl get moduleinfo -l cpaas.io/cluster-name=<cluster>
+```
+
+If the target operator package is missing, publish it to every cluster where that operator is installed. If only one workload cluster is missing it, push to that cluster with `--clusters "<workload-cluster-name>"`. If the package exists, resolve the `Subscription`, `InstallPlan`, catalog, or `ModuleInfo` condition actually reported by CVO.
+
+Continue observing the existing request after correcting the problem. CVO retries automatically; do not clear or resubmit `desiredUpdate`.
 
 ## Diagnose a Module That Does Not Advance
 

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -108,7 +108,7 @@ violet push <path-to-other-operator-package> \
 Pushing every operator package to every <Term name="productShort" /> cluster from the global window is the recommended pattern. If the global window has already passed and you discover a workload cluster missing an operator package, you can still push to that workload cluster before the workload upgrade — see [Upgrade workload clusters](./upgrade_workload_cluster.mdx#operator-push-fallback).
 
 :::warning
-Before requesting the upgrade, make the target package available for every Aligned plugin installed on the cluster. Use `upgrade.sh` for applications from **ACP Upgrade to v4.5**, and `violet` for the other Aligned packages. CVO does not install an absent plugin merely because its package was synchronized. If an installed Aligned cluster plugin's package is missing or has not become ready, CVO stalls the upgrade and reports a missing or not-ready `ModulePluginConfig`.
+Before requesting the upgrade, make the target package available for every Aligned plugin installed on the cluster. Use `upgrade.sh` for applications from **ACP Upgrade to v4.5**, and `violet` for the other Aligned packages. Synchronizing a package does not install an application that is not currently installed. For an installed Aligned cluster plugin, CVO requires the matching target `ModulePluginConfig` to be Ready; otherwise, CVO cannot build the upgrade plan, reports the error through `ClusterVersionShadow`, and retries the existing request. An installed Aligned operator requires a matching target `InstallPlan` from its catalog.
 :::
 
 Registry behavior depends on how the environment is configured:
@@ -134,21 +134,14 @@ To bypass artifact validation when it is known to be redundant, add `--skip-chec
 Do not open the maintenance window until image and plugin synchronization is complete.
 :::
 
-Before running preflight, confirm that the registry configuration is still correct and that no discovered target artifact is missing:
+Before running preflight, confirm that the registry configuration is still correct:
 
 ```bash
 kubectl get productbase base \
   -o jsonpath='{.spec.registry.address}{"\t"}{.spec.registry.external}{"\n"}'
-
-kubectl get productbase base -o json | jq -r '
-  .status.artifacts[] as $artifact
-  | $artifact.channels[]
-  | select(.artifactStatus != "Ready")
-  | [$artifact.name, .channel, .tag, .artifactStatus]
-  | @tsv'
 ```
 
-The artifact command must produce no output. For an external registry, also confirm the newly uploaded manifests in the registry administration interface or API; automatic synchronization is intentionally skipped.
+Use successful completion of the selected publication commands and the registry administration interface or API as the Phase 1 evidence. Confirm that the expected target repositories and tags exist, and compare the published Extension set with the installed inventory exported to `apps.yaml`. Do not use `ProductBase.status.artifacts` as a zero-output target-version gate: it represents the current catalog and can legitimately contain `Absent` entries for optional or uninstalled packages.
 
 ### Run preflight checks
 
@@ -198,6 +191,28 @@ bash upgrade.sh --skip-sync-image
 ```
 
 This deploys or updates the cluster version operator (CVO) and completes the remaining preparation. The CVO drives the Core and Aligned plugin upgrade once the upgrade is requested in the next step.
+
+After the command completes, inspect the target `ProductManifest` before requesting the upgrade:
+
+```bash
+kubectl get productmanifest v<target-version> \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+
+kubectl get productmanifest v<target-version> -o json | jq -r '
+  .status.artifacts[] as $artifact
+  | $artifact.channels[]
+  | select(.artifactStatus != "Ready")
+  | [$artifact.name, .channel, .tag, .artifactStatus]
+  | @tsv'
+```
+
+The per-artifact output is diagnostic and is not required to be empty. The target manifest can include optional, Agnostic, or uninstalled entries that are legitimately not Ready. Compare the output with the installed Core and Aligned inventory. For an installed Aligned `ModulePlugin`, inspect the matching target `ModulePluginConfig` when its channel is not Ready:
+
+```bash
+kubectl get modulepluginconfig <modulepluginconfig-name> -o yaml
+```
+
+Use the component name and channel tag from the target `ProductManifest`, or the name reported in the `ClusterVersionShadow` error, to identify the `ModulePluginConfig`. The component version in this name is not necessarily the ACP Distribution Version. Do not treat `artifactStatus: Absent` alone as proof that the registry manifest is missing; use the `ModulePluginConfig` condition and its `.spec.image` to distinguish a missing manifest from authentication, CA, network, or package-content failures.
 
 ### Request the upgrade
 

--- a/docs/en/upgrade/upgrade_global_cluster.mdx
+++ b/docs/en/upgrade/upgrade_global_cluster.mdx
@@ -21,7 +21,7 @@ This Compatible Versions prerequisite applies whether or not the environment use
 
 Global cluster upgrades follow the validated `upgrade.sh`-based procedure documented on this page. You can request the global-cluster upgrade from the Web Console, by updating `ClusterVersionShadow.spec.desiredUpdate`, or by using ACP CLI with `--cluster=global`. For the complete AC CLI workflow and output interpretation, see [Upgrading Clusters](/ui/cli_tools/ac/upgrading-clusters.md). For full command and flag syntax, see [AC CLI Administrator Command Reference](/ui/cli_tools/ac/administrator-command-reference.md).
 
-If the environment uses **global DR**, follow the [Global DR Procedure](#global-dr-procedure). Otherwise, follow the standard workflow below.
+If the environment uses **global DR**, follow [Upgrade Global Clusters in a DR Environment](./upgrade_global_dr.mdx). Otherwise, follow the standard workflow below.
 
 ## Standard Workflow
 
@@ -185,96 +185,7 @@ The default check set includes:
 - `ModuleInfoStable`
 - `PlatformLicense`
 
-### Handle preflight blocks when needed \{#handle-preflight-blocks-when-needed}
-
-**When:** before the maintenance window. Resolve every blocking item discovered by preflight so the window is not spent troubleshooting.
-
-If `ResourcePatchUpgradeable` fails with `reason=UnexemptResourcePatches`, inspect the blocking `ResourcePatch` and add the required exemption annotation:
-
-```bash
-kubectl -n cpaas-system get cvsh global \
-  -o jsonpath='{range .status.preflight.checks[?(@.name=="ResourcePatchUpgradeable")]}{.state}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
-
-kubectl get resourcepatches <rp-name> -o yaml
-```
-
-The default annotation key is `config.cpaas.io/exempt-for-ver`.
-
-```bash
-kubectl annotate resourcepatches <rp-name> \
-  config.cpaas.io/exempt-for-ver=<target-version> \
-  --overwrite
-```
-
-### Resolve other common preflight blocks \{#resolve-other-preflight-blocks}
-
-The default check set validates several more conditions. List every check that is not `Passed`, then resolve each with the table below:
-
-```bash
-kubectl -n cpaas-system get cvsh global \
-  -o jsonpath='{range .status.preflight.checks[*]}{.name}{"\t"}{.state}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
-```
-
-| Check | What it validates | How to resolve |
-| --- | --- | --- |
-| `KubernetesVersionSupported` | The cluster's Kubernetes version is within the target release's supported range. | If it is below the supported range, upgrade the cluster's Kubernetes into that range first — see [Kubernetes Support Matrix](/overview/kubernetes-support-matrix.html). |
-| `VersionUpgradePath` | The current patch can reach the requested target patch through a supported upgrade edge. | Use only a target listed in `availableUpdates`. If no suitable target is offered, choose a later target that includes the current source patch or first follow an intermediate target offered by the platform. Do not disable this check to force the upgrade. |
-| `ClusterRunning` | The cluster is healthy and reconciled. | Check the cluster with `kubectl get clusterview global` and resolve any unhealthy node or component before retrying. |
-| `DockerRuntimeUnsupported` | No node still uses the unsupported Docker runtime. | Migrate the affected nodes to `containerd` before upgrading. |
-| `ClusterModuleStable`, `ModuleInfoStable` | Installed Core and Aligned modules are stable (`Running`), not mid-deploy or mid-upgrade. | See [Verify Module Stability Before You Upgrade](./pre-upgrade.mdx#module-stability-self-check). |
-
-### Handle administrator acknowledgement gates \{#handle-administrator-acknowledgement-gates}
-
-If `AdminAckRequired` fails, the target release contains an administrator acknowledgement gate that applies to the current cluster version. The release provides gate definitions in `cpaas-system/admin-gates`. Administrators record completed acknowledgements in `cpaas-system/admin-acks`.
-
-Inspect the current gates:
-
-```bash
-kubectl -n cpaas-system get configmap admin-gates -o yaml
-```
-
-If the target release is ACP 4.4 or later, upgrades the cluster to Kubernetes 1.35 or later, and `admin-gates` reports a node-readiness acknowledgement key, complete the [Kubernetes 1.35 or later node readiness checks](./pre-upgrade.mdx#kubernetes-135-node-readiness) on every production node.
-
-Use the acknowledgement key provided by the target release. The first gate introduced for this requirement, for the ACP 4.4 and Kubernetes 1.35 target, is:
-
-```text
-ack-4.4-kubernetes-1.35-kernel-update
-```
-
-Treat this key as an example; a later target release can provide a different key. After the node checks pass, copy the applicable key from `admin-gates` and write it to `admin-acks`:
-
-```bash
-ACK_KEY='<key-from-admin-gates>'
-kubectl -n cpaas-system patch configmap admin-acks --type merge \
-  -p "{\"data\":{\"${ACK_KEY}\":\"true\"}}"
-```
-
-Run preflight again:
-
-```bash
-bash upgrade.sh --preflight
-```
-
-Confirm that `AdminAckRequired` passes:
-
-```bash
-kubectl -n cpaas-system get cvsh global \
-  -o jsonpath='{range .status.preflight.checks[?(@.name=="AdminAckRequired")]}{.state}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
-```
-
-Do not disable `VersionUpgradePath`, `KubernetesVersionSupported`, or `AdminAckRequired` to force an unsupported upgrade. If technical support instructs you to disable a non-version check temporarily, configure only the specified check in `cpaas-system/cvo-config`. For example:
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cvo-config
-  namespace: cpaas-system
-data:
-  preflight: |
-    disabled:
-      - ResourcePatchUpgradeable
-```
+If any check does not pass, stop before the maintenance window and follow [Upgrade Troubleshooting](./troubleshooting.mdx#handle-preflight-blocks-when-needed). Do not disable version, Kubernetes support, or administrator acknowledgement checks to force an unsupported upgrade.
 
 ### Deploy the cluster version operator \{#deploy-the-cluster-version-operator}
 
@@ -386,29 +297,7 @@ Focus on these conditions first:
 | `Reconciling`    | `True` means the upgrade is still running.                     |
 | `Stalled`        | `True` means the upgrade is blocked and requires intervention. |
 
-Useful diagnostics:
-
-```bash
-kubectl -n cpaas-system get cvsh global \
-  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
-
-kubectl -n cpaas-system get cvsh global \
-  -o jsonpath='{.status.preflight.observedAt}{"\n"}{range .status.preflight.checks[*]}{.name}{"\t"}{.policy}{"\t"}{.state}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
-
-kubectl -n cpaas-system get cvsh global \
-  -o jsonpath='{range .status.history[*]}{.version}{"\t"}{.state}{"\t"}{.startedTime}{"\t"}{.completionTime}{"\n"}{end}'
-```
-
-#### Recover from a missing Aligned cluster plugin package \{#recover-missing-aligned-package}
-
-If `Stalled=True` and the condition message names a missing or not-ready `ModulePluginConfig`, an installed Aligned cluster plugin does not yet have its target package available:
-
-1. Identify the application and required version from the `Stalled` condition and the Customer Portal.
-2. If the application is listed in **ACP Upgrade to v4.5**, download its package and copy it into the extracted Core Package's `plugins/` directory. For the platform built-in Registry, rerun `upgrade.sh --only-sync-image`. For an external registry, rerun both modes in [Prepare the Target-Version Payload](../install/prepare/external-platform-image-registry.mdx#prepare-the-target-version-payload).
-3. For another Aligned cluster plugin, publish the package to the global tier with `violet push` as described in [Sync upgrade artifacts](#sync-upgrade-artifacts).
-4. Continue observing the existing upgrade request. CVO watches package readiness and resumes automatically after the package becomes ready; do not clear or resubmit `desiredUpdate`.
-
-The commands above track the cluster-level (Core and Aligned) upgrade. To observe an individual plugin or operator module — for example while upgrading an Agnostic plugin — read its `ModuleInfo` instead:
+If `Stalled=True`, follow [Upgrade Troubleshooting](./troubleshooting.mdx). To observe an individual plugin or operator module, read its `ModuleInfo`:
 
 ```bash
 # Current version, target, next available version, and phase per installed module on this cluster
@@ -436,185 +325,17 @@ If you skipped pushing an Agnostic plugin during pre-upgrade and the Marketplace
 
 </Steps>
 
-## Post-upgrade
+## Validate the Upgrade
 
-- <ExternalSiteLink
-    name="ai"
-    href="/upgrade/upgrade-from-aml-1.2.html"
-    children="Upgrade Alauda AI"
-  />
-
-- <ExternalSiteLink
-    name="devops"
-    href="/upgrade/index.html"
-    children="Upgrade Alauda DevOps"
-  />
-
-- If the source release is earlier than ACP 4.3 and PKCE hardening has not already been completed, wait until all workload clusters reach the target Distribution Version, then follow [Disabling the PKCE Plain Method](/security/platform_security_configurations/disable_pkce_plain_method.mdx).
-
-- When upgrading from a release earlier than ACP 4.3, an API authentication change introduced in ACP 4.3 requires the following Agnostic plugins to be upgraded to versions compatible with the target ACP release. Otherwise, their UI pages may fail to open:
-  - `Alauda DevOps v3`
-  - `Alauda AI Essentials`
-  - `Alauda Hyperflux`
-  - `Alauda Container Platform Data Services Essentials`
-- After upgrading the plugins, verify that each listed plugin UI page opens successfully.
-
-## Global DR Procedure \{#global-dr-procedure}
-
-Use this procedure when the environment includes both a primary global cluster and a standby global cluster. The DR-specific steps below are in addition to the standard CVO workflow.
-
-<Steps>
-
-### Verify the DR environment before upgrading
-
-Follow your regular global DR inspection procedures to ensure that data in the **standby global cluster** is consistent with the **primary global cluster**. For background on the DR topology and synchronization workflow, see [Global Cluster Disaster Recovery](/install/global_dr.mdx).
-
-If inconsistencies are detected, do not uninstall the etcd synchronization plugin in the next step, and contact technical support before proceeding. Uninstalling the plugin while the standby global cluster is missing data that the primary holds can cause owner references to resolve incorrectly, and workload-cluster node `Machine` objects — including immutable-OS clusters, where this destroys the backing virtual machine — may be deleted.
-
-On **both** global clusters, run the following command to ensure no `Machine` nodes are in a non-running state:
-
-```bash
-kubectl get machines.platform.tkestack.io
-```
-
-If any such nodes exist, resolve them before continuing.
-
-### Uninstall the etcd synchronization plugin from the standby global cluster
-
-1. Access the Web Console of the **standby global cluster** through its IP or VIP.
-2. Switch to **Administrator** view.
-3. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.
-4. Find **<Term name="product" /> etcd Synchronizer** and uninstall it.
-5. Wait for the uninstallation to complete before proceeding.
-
-### Sync upgrade artifacts on both global clusters
-
-Complete **Sync upgrade artifacts** in the standard workflow on **both** the standby global cluster and the primary global cluster.
-
-Use the same synchronization mode on both clusters.
-
-### Upgrade the standby global cluster
-
-If you will use the Web Console on the standby global cluster, verify that the standby cluster `ProductBase` includes the standby VIP in `spec.alternativeURLs`:
-
-```yaml
-apiVersion: product.alauda.io/v1alpha2
-kind: ProductBase
-metadata:
-  name: base
-spec:
-  alternativeURLs:
-    - https://<standby-cluster-vip>
-```
-
-After synchronization completes, run the remaining steps from the standard workflow on the **standby global cluster**:
-
-1. **Run preflight checks**
-2. **Deploy the cluster version operator**
-3. **Request the upgrade**
-4. **Observe execution** until the standby global cluster reaches the desired version
-
-### Upgrade the primary global cluster
-
-After the standby global cluster has reached the desired version, run the remaining steps from the standard workflow on the **primary global cluster**:
-
-1. **Run preflight checks**
-2. **Deploy the cluster version operator**
-3. **Request the upgrade**
-4. **Observe execution** until the primary global cluster reaches the desired version
-
-### Reinstall the etcd synchronization plugin and verify sync status
-
-Before reinstalling the plugin, verify that port `2379` is forwarded correctly from both global-cluster VIPs to their control plane nodes when that forwarding mode is used. Port forwarding through a load balancer is not required if the standby global cluster can access the active global cluster directly.
-
-Before reinstalling the plugin, get the bearer token for accessing the active global cluster API server from the active global cluster. Copy the command output and use it when creating or updating the `etcd-sync-active-cluster-token` Secret in `cpaas-system`. The Secret stores the token under the data key `token`. Use this Secret through **Active Global Cluster Token Secret**. Legacy plain-token configuration remains only as a compatibility fallback and is not the recommended operational path.
-
-```bash
-# Run this command on the active cluster.
-kubectl -n cpaas-system get secret k8sadmin -o jsonpath='{.data.token}' | base64 -d
-```
-
-Copy the output value, then run this command on the standby cluster:
-
-```bash
-ACTIVE_CLUSTER_TOKEN='<paste-the-token-from-the-active-cluster>'
-kubectl -n cpaas-system create secret generic etcd-sync-active-cluster-token \
-  --from-literal=token="${ACTIVE_CLUSTER_TOKEN}" \
-  --dry-run=client -o yaml | kubectl apply -f -
-```
-
-To reinstall the plugin:
-
-1. Access the **standby global cluster** Web Console through its VIP and switch to **Administrator** view.
-2. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.
-3. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, and configure the required parameters.
-
-When you configure the plugin:
-
-- Set **Active Global Cluster VIP** to the VIP of the active global cluster.
-- When port `2379` is not forwarded through a load balancer, set **Active Global Cluster ETCD Endpoints** correctly.
-- Set **Standby Cluster ETCD Endpoints** to the standby cluster etcd address. Use the default value unless the local etcd service is exposed through a different endpoint.
-- Set **Active Global Cluster Token Secret** to `etcd-sync-active-cluster-token`.
-- Use the default value of **Data Check Interval**.
-- Leave **Print detail logs** disabled unless you are troubleshooting.
-
-During reinstallation, the system runs the `etcd-sync-bootstrap` Job before the `etcd-sync` Deployment starts. The release continues only after the Job prepares `remote-etcd-ca`, `remote-etcd-issuer`, and `remote-etcd-client`.
-
-Verify the bootstrap Job and runtime resources:
-
-```bash
-kubectl get job -n cpaas-system etcd-sync-bootstrap
-kubectl logs -n cpaas-system job/etcd-sync-bootstrap
-kubectl get secret -n cpaas-system remote-etcd-ca
-kubectl get issuer -n cpaas-system remote-etcd-issuer
-kubectl get certificate -n cpaas-system remote-etcd-client
-kubectl get secret -n cpaas-system remote-etcd-client
-```
-
-Verify the sync Pods are running on the standby global cluster and identify the current leader:
-
-```bash
-kubectl get po -n cpaas-system -l app=etcd-sync
-kubectl get lease -n cpaas-system etcd-sync-mirror
-leader_pod=$(kubectl get lease -n cpaas-system etcd-sync-mirror -o jsonpath='{.spec.holderIdentity}')
-kubectl logs -n cpaas-system "$leader_pod" | grep -E "Acquired leader lease|Start Sync update"
-```
-
-If resources with `ownerReference` dependencies need to be resynchronized, recreate the current leader Pod after `Start Sync update` appears:
-
-```bash
-leader_pod=$(kubectl get lease -n cpaas-system etcd-sync-mirror -o jsonpath='{.spec.holderIdentity}')
-kubectl delete po -n cpaas-system "$leader_pod"
-```
-
-Check sync status:
-
-```bash
-mirror_svc=$(kubectl get svc -n cpaas-system etcd-sync-monitor -o jsonpath='{.spec.clusterIP}')
-ipv6_regex="^[0-9a-fA-F:]+$"
-if [[ $mirror_svc =~ $ipv6_regex ]]; then
-  mirror_host="[$mirror_svc]"
-else
-  mirror_host="$mirror_svc"
-fi
-curl -g "http://${mirror_host}/check"
-```
-
-Output interpretation:
-
-- `LOCAL ETCD missed keys`: Keys exist in the primary global cluster but are missing from the standby. This often resolves after restarting the current `etcd-sync` leader Pod.
-- `LOCAL ETCD surplus keys`: Keys exist in the standby global cluster but not in the primary. Review these with your operations team before deleting them.
-
-After verification succeeds, remove any remaining legacy plain-token configuration from the plugin settings or release values.
-
-If the active-cluster token or the remote `etcd-ca` changes later, run the plugin upgrade or reinstall workflow again so that the `etcd-sync-bootstrap` hook refreshes the runtime credentials and certificates.
-
-</Steps>
+After the cluster reaches the desired version and the in-use Agnostic plugins are handled, complete [Upgrade Validation](./validation.mdx).
 
 ## Related Documentation
 
 - [Overview](./overview.mdx)
 - [Pre-upgrade](./pre-upgrade.mdx)
+- [Upgrade global clusters in a DR environment](./upgrade_global_dr.mdx)
 - [Upgrade workload clusters](./upgrade_workload_cluster.mdx)
+- [Upgrade validation](./validation.mdx)
+- [Upgrade troubleshooting](./troubleshooting.mdx)
 - [Upgrading Clusters](/ui/cli_tools/ac/upgrading-clusters.md)
 - [Global Cluster Disaster Recovery](/install/global_dr.mdx)

--- a/docs/en/upgrade/upgrade_global_dr.mdx
+++ b/docs/en/upgrade/upgrade_global_dr.mdx
@@ -1,0 +1,151 @@
+---
+weight: 35
+---
+
+# Upgrade Global Clusters in a DR Environment
+
+Use this procedure when the environment includes both a primary global cluster and a standby global cluster. The DR-specific steps are in addition to the standard CVO workflow in [Upgrade the global cluster](./upgrade_global_cluster.mdx).
+
+<Steps>
+
+## Verify the DR environment before upgrading
+
+Follow your regular global DR inspection procedures to ensure that data in the **standby global cluster** is consistent with the **primary global cluster**. For background on the DR topology and synchronization workflow, see [Global Cluster Disaster Recovery](/install/global_dr.mdx).
+
+If inconsistencies are detected, do not uninstall the etcd synchronization plugin in the next step, and contact technical support before proceeding. Uninstalling the plugin while the standby global cluster is missing data that the primary holds can cause owner references to resolve incorrectly, and workload-cluster node `Machine` objects — including immutable-OS clusters, where this destroys the backing virtual machine — may be deleted.
+
+On **both** global clusters, run the following command to ensure no `Machine` nodes are in a non-running state:
+
+```bash
+kubectl get machines.platform.tkestack.io
+```
+
+If any such nodes exist, resolve them before continuing.
+
+## Uninstall the etcd synchronization plugin from the standby global cluster
+
+1. Access the Web Console of the **standby global cluster** through its IP or VIP.
+2. Switch to **Administrator** view.
+3. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.
+4. Find **<Term name="product" /> etcd Synchronizer** and uninstall it.
+5. Wait for the uninstallation to complete before proceeding.
+
+## Sync upgrade artifacts on both global clusters
+
+Complete [Sync upgrade artifacts](./upgrade_global_cluster.mdx#sync-upgrade-artifacts) on both the standby global cluster and the primary global cluster. Use the same registry type and exact target-version payload on both clusters. For an external registry, complete both upload modes for each registry endpoint that the two global clusters use.
+
+## Upgrade the standby global cluster
+
+If you will use the Web Console on the standby global cluster, verify that the standby cluster `ProductBase` includes the standby VIP in `spec.alternativeURLs`:
+
+```yaml
+apiVersion: product.alauda.io/v1alpha2
+kind: ProductBase
+metadata:
+  name: base
+spec:
+  alternativeURLs:
+    - https://<standby-cluster-vip>
+```
+
+After synchronization completes, run the remaining standard workflow steps on the **standby global cluster**:
+
+1. Run preflight checks.
+2. Deploy the cluster version operator.
+3. Request the upgrade.
+4. Observe execution until the standby global cluster reaches the desired version.
+
+## Upgrade the primary global cluster
+
+After the standby global cluster reaches the desired version, run the remaining standard workflow steps on the **primary global cluster**:
+
+1. Run preflight checks.
+2. Deploy the cluster version operator.
+3. Request the upgrade.
+4. Observe execution until the primary global cluster reaches the desired version.
+
+## Reinstall the etcd synchronization plugin and verify sync status
+
+Before reinstalling the plugin, verify that port `2379` is forwarded correctly from both global-cluster VIPs to their control plane nodes when that forwarding mode is used. Port forwarding through a load balancer is not required if the standby global cluster can access the active global cluster directly.
+
+Get the bearer token for the active global cluster API server from the active cluster, then use it to create or update the `etcd-sync-active-cluster-token` Secret on the standby cluster. Keep the token in the current shell only and clear it after the Secret is created.
+
+```bash
+# Run on the active cluster and copy the output without storing it in a document.
+kubectl -n cpaas-system get secret k8sadmin -o jsonpath='{.data.token}' | base64 -d
+```
+
+Run on the standby cluster:
+
+```bash
+read -rsp "Active global cluster token: " ACTIVE_CLUSTER_TOKEN
+printf '\n'
+kubectl -n cpaas-system create secret generic etcd-sync-active-cluster-token \
+  --from-literal=token="${ACTIVE_CLUSTER_TOKEN}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+unset ACTIVE_CLUSTER_TOKEN
+```
+
+To reinstall the plugin:
+
+1. Access the **standby global cluster** Web Console through its VIP and switch to **Administrator** view.
+2. Navigate to **Marketplace > Cluster Plugins** and select the `global` cluster.
+3. Find **<Term name="product" /> etcd Synchronizer**, click **Install**, and configure the required parameters.
+
+When you configure the plugin:
+
+- Set **Active Global Cluster VIP** to the VIP of the active global cluster.
+- When port `2379` is not forwarded through a load balancer, set **Active Global Cluster ETCD Endpoints** correctly.
+- Set **Standby Cluster ETCD Endpoints** to the standby cluster etcd address. Use the default value unless the local etcd service is exposed through a different endpoint.
+- Set **Active Global Cluster Token Secret** to `etcd-sync-active-cluster-token`.
+- Use the default value of **Data Check Interval**.
+- Leave **Print detail logs** disabled unless you are troubleshooting.
+
+During reinstallation, the system runs the `etcd-sync-bootstrap` Job before the `etcd-sync` Deployment starts. Verify the bootstrap Job and runtime resources:
+
+```bash
+kubectl get job -n cpaas-system etcd-sync-bootstrap
+kubectl logs -n cpaas-system job/etcd-sync-bootstrap
+kubectl get secret -n cpaas-system remote-etcd-ca
+kubectl get issuer -n cpaas-system remote-etcd-issuer
+kubectl get certificate -n cpaas-system remote-etcd-client
+kubectl get secret -n cpaas-system remote-etcd-client
+```
+
+Verify the sync Pods and current leader on the standby global cluster:
+
+```bash
+kubectl get po -n cpaas-system -l app=etcd-sync
+kubectl get lease -n cpaas-system etcd-sync-mirror
+leader_pod=$(kubectl get lease -n cpaas-system etcd-sync-mirror -o jsonpath='{.spec.holderIdentity}')
+kubectl logs -n cpaas-system "$leader_pod" | grep -E "Acquired leader lease|Start Sync update"
+```
+
+If resources with `ownerReference` dependencies need to be resynchronized, recreate the current leader Pod after `Start Sync update` appears:
+
+```bash
+leader_pod=$(kubectl get lease -n cpaas-system etcd-sync-mirror -o jsonpath='{.spec.holderIdentity}')
+kubectl delete po -n cpaas-system "$leader_pod"
+```
+
+Check sync status:
+
+```bash
+mirror_svc=$(kubectl get svc -n cpaas-system etcd-sync-monitor -o jsonpath='{.spec.clusterIP}')
+ipv6_regex="^[0-9a-fA-F:]+$"
+if [[ $mirror_svc =~ $ipv6_regex ]]; then
+  mirror_host="[$mirror_svc]"
+else
+  mirror_host="$mirror_svc"
+fi
+curl -g "http://${mirror_host}/check"
+```
+
+- `LOCAL ETCD missed keys`: Keys exist in the primary global cluster but are missing from the standby. This often resolves after restarting the current `etcd-sync` leader Pod.
+- `LOCAL ETCD surplus keys`: Keys exist in the standby global cluster but not in the primary. Review these with your operations team before deleting them.
+
+After verification succeeds, remove any remaining legacy plain-token configuration from the plugin settings or release values. If the active-cluster token or remote `etcd-ca` changes later, run the plugin upgrade or reinstall workflow again so `etcd-sync-bootstrap` refreshes the runtime credentials and certificates.
+
+</Steps>
+
+After both global clusters are healthy at the target version and synchronization is restored, continue with [Upgrade Workload Clusters](./upgrade_workload_cluster.mdx) or [Upgrade Validation](./validation.mdx).

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -1,5 +1,5 @@
 ---
-weight: 30
+weight: 40
 ---
 
 # Upgrade Workload Clusters
@@ -74,7 +74,7 @@ Preflight returns two parts:
 
 If preflight does not pass, do not submit the upgrade request until all blocking items are resolved.
 
-For preflight block handling patterns, see [Handle preflight blocks when needed](./upgrade_global_cluster.mdx#handle-preflight-blocks-when-needed).
+For preflight block handling patterns, see [Upgrade Troubleshooting](./troubleshooting.mdx#handle-preflight-blocks-when-needed).
 
 ### Request the upgrade
 
@@ -133,7 +133,7 @@ ac adm upgrade status
 
 For detailed semantics of `ac adm upgrade status` output (preflight and stage interpretation), see [Upgrading Clusters](/ui/cli_tools/ac/upgrading-clusters.md).
 
-If an installed Aligned operator does not advance toward its target version, verify that its target package was pushed to this workload cluster as described in [Ensure Aligned operator packages are available](#operator-push-fallback). If a `Stalled` condition names a missing or not-ready `ModulePluginConfig`, the missing component is a cluster plugin; use the package-specific recovery path in [Upgrade the global cluster](./upgrade_global_cluster.mdx#recover-missing-aligned-package).
+If the upgrade reports `Stalled=True`, use [Upgrade Troubleshooting](./troubleshooting.mdx). Missing Aligned operator and cluster-plugin packages have different recovery paths.
 
 The commands above track the cluster-level (Core and Aligned) upgrade. To observe an individual plugin or operator module — for example while upgrading an Agnostic plugin — read its `ModuleInfo`:
 
@@ -158,27 +158,16 @@ Whether each Agnostic plugin needs to be upgraded in this window depends on its 
 
 If the Marketplace does not offer the target version of an operator on this workload cluster, follow [Ensure Aligned operator packages are available](#operator-push-fallback) for that operator first and then retry the Marketplace upgrade.
 
-When troubleshooting, inspect conditions, preflight details, and history first:
-
-```bash
-kubectl -n cpaas-system get cvsh <cluster> \
-  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
-
-kubectl -n cpaas-system get cvsh <cluster> \
-  -o jsonpath='{.status.preflight.observedAt}{"\n"}{range .status.preflight.checks[*]}{.name}{"\t"}{.policy}{"\t"}{.state}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
-
-kubectl -n cpaas-system get cvsh <cluster> \
-  -o jsonpath='{range .status.history[*]}{.version}{"\t"}{.state}{"\t"}{.startedTime}{"\t"}{.completionTime}{"\n"}{end}'
-```
-
 </Steps>
 
-## Complete Security Hardening When Upgrading From Before ACP 4.3
+## Validate the Upgrade
 
-If the source release is earlier than ACP 4.3 and PKCE hardening has not already been completed, wait until all workload clusters reach the target Distribution Version, then follow [Disabling the PKCE Plain Method](/security/platform_security_configurations/disable_pkce_plain_method.mdx).
+After the workload cluster and its in-use Agnostic plugins reach their targets, complete [Upgrade Validation](./validation.mdx).
 
 ## Related Documentation
 
 - [Overview](./overview.mdx)
 - [Upgrade the global cluster](./upgrade_global_cluster.mdx)
+- [Upgrade validation](./validation.mdx)
+- [Upgrade troubleshooting](./troubleshooting.mdx)
 - [Upgrading Clusters](/ui/cli_tools/ac/upgrading-clusters.md)

--- a/docs/en/upgrade/upgrade_workload_cluster.mdx
+++ b/docs/en/upgrade/upgrade_workload_cluster.mdx
@@ -51,7 +51,7 @@ violet push <path/to/operator-package> \
 
 You only need to push packages for Aligned operators actually installed on the workload cluster. Aligned cluster plugin packages made available to the global tier are available to all workload clusters and do not need per-cluster publication.
 
-If an installed Aligned operator's target package is missing or is not ready, CVO stalls the workload-cluster upgrade. Publish the missing package with the command above, then continue observing the existing request. CVO detects the newly ready package and resumes automatically; you do not need to submit the upgrade request again. Packages for Aligned operators that are not installed on this workload cluster do not block its upgrade.
+If an installed Aligned operator's target package is unavailable, CVO can wait for a matching target `InstallPlan` and then report an error while retrying the existing request. Inspect the operator's catalog, `Subscription`, `InstallPlan`, and `ModuleInfo`; publish a missing package with the command above, or correct the reported catalog or registry problem. Continue observing the existing request; you do not need to submit it again. Packages for Aligned operators that are not installed on this workload cluster do not block its upgrade.
 
 ### Run preflight checks
 

--- a/docs/en/upgrade/validation.mdx
+++ b/docs/en/upgrade/validation.mdx
@@ -41,22 +41,17 @@ kubectl get pods --all-namespaces \
 
 All nodes must be `Ready`; Core and installed Aligned modules must report the target version in a healthy phase; critical Pods must be `Running` or `Completed`.
 
-## Validate Artifacts and Extension Availability
+## Validate Installed Extension Availability
 
-Run the artifact check from the global cluster:
+From the global cluster, review the cluster plugin catalog when you need to confirm that an upgraded application remains discoverable:
 
 ```bash
-kubectl get productbase base -o json | jq -r '
-  .status.artifacts[] as $artifact
-  | $artifact.channels[]
-  | select(.artifactStatus != "Ready")
-  | [$artifact.name, .channel, .tag, .artifactStatus]
-  | @tsv'
-
 kubectl get moduleplugins
 ```
 
-The artifact command must produce no output. Confirm that required target versions are available for the installed Extensions and that no Pod reports `ImagePullBackOff` or `ErrImagePull`.
+Upgrade acceptance applies to the Core and Aligned applications actually installed on the upgraded cluster. Use the `ClusterVersionShadow` completion state and the `ModuleInfo` versions from the previous sections as the authoritative result, and confirm that no related Pod reports `ImagePullBackOff` or `ErrImagePull`.
+
+Do not require every entry in `ProductBase.status.artifacts` to be `Ready`. `ProductBase` includes optional or uninstalled catalog packages, including Agnostic applications, which can legitimately remain `Absent` after a successful cluster upgrade.
 
 ## Validate the Web UI and In-Use Agnostic Plugins
 

--- a/docs/en/upgrade/validation.mdx
+++ b/docs/en/upgrade/validation.mdx
@@ -1,0 +1,79 @@
+---
+weight: 50
+---
+
+# Upgrade Validation
+
+Validate each upgraded cluster before closing its maintenance window. In a global DR environment, validate the standby and primary global clusters separately before upgrading workload clusters.
+
+## Confirm Distribution Version and CVO Completion
+
+From the global cluster, inspect the target cluster's `ClusterVersionShadow`:
+
+```bash
+kubectl -n cpaas-system get cvsh <cluster> \
+  -o jsonpath='{.status.current.version}{"\t"}{.status.desired.version}{"\n"}{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+
+kubectl -n cpaas-system get cvsh <cluster> \
+  -o jsonpath='{range .status.history[*]}{.version}{"\t"}{.state}{"\t"}{.startedTime}{"\t"}{.completionTime}{"\n"}{end}'
+```
+
+The current and desired Distribution Versions must match the target. `Ready` must be `True`, `Reconciling` must no longer be `True`, and `Stalled` must not be `True`. The newest history entry must show the target version completed successfully.
+
+## Validate Kubernetes, Nodes, Core, and Aligned Plugins
+
+From the global-cluster management context, confirm the Core and installed Aligned module state:
+
+```bash
+kubectl get clustermodule <cluster> -o yaml
+kubectl get moduleinfo -l cpaas.io/cluster-name=<cluster>
+```
+
+Then use a `kubectl` context for the upgraded cluster to confirm the Kubernetes server version, node readiness, and Pods:
+
+```bash
+kubectl version
+kubectl get nodes
+kubectl get pods --all-namespaces \
+  | awk '{if ($4 != "Running" && $4 != "Completed")print}' \
+  | awk -F'[/ ]+' '{if ($3 != $4)print}'
+```
+
+All nodes must be `Ready`; Core and installed Aligned modules must report the target version in a healthy phase; critical Pods must be `Running` or `Completed`.
+
+## Validate Artifacts and Extension Availability
+
+Run the artifact check from the global cluster:
+
+```bash
+kubectl get productbase base -o json | jq -r '
+  .status.artifacts[] as $artifact
+  | $artifact.channels[]
+  | select(.artifactStatus != "Ready")
+  | [$artifact.name, .channel, .tag, .artifactStatus]
+  | @tsv'
+
+kubectl get moduleplugins
+```
+
+The artifact command must produce no output. Confirm that required target versions are available for the installed Extensions and that no Pod reports `ImagePullBackOff` or `ErrImagePull`.
+
+## Validate the Web UI and In-Use Agnostic Plugins
+
+Open the platform Web UI and confirm that login, cluster pages, and Marketplace pages load. Upgrade each in-use Agnostic plugin required for the target Kubernetes version, then verify its UI and primary function.
+
+When upgrading from a release earlier than ACP 4.3, use target-compatible versions of these Agnostic plugins or their pages can fail to open:
+
+- `Alauda DevOps v3`
+- `Alauda AI Essentials`
+- `Alauda Hyperflux`
+- `Alauda Container Platform Data Services Essentials`
+
+Complete any product-specific procedures that apply:
+
+- <ExternalSiteLink name="ai" href="/upgrade/upgrade-from-aml-1.2.html" children="Upgrade Alauda AI" />
+- <ExternalSiteLink name="devops" href="/upgrade/index.html" children="Upgrade Alauda DevOps" />
+
+If the source release is earlier than ACP 4.3 and PKCE hardening has not already been completed, wait until the global tier and all workload clusters reach the target Distribution Version, then follow [Disabling the PKCE Plain Method](/security/platform_security_configurations/disable_pkce_plain_method.mdx).
+
+If any acceptance check fails, keep the maintenance window open and use [Upgrade Troubleshooting](./troubleshooting.mdx).


### PR DESCRIPTION
## Summary

- split installer parameter reference and installation troubleshooting from the installation happy path
- keep installation validation as the single post-install acceptance page
- split global DR upgrade, upgrade validation, and upgrade troubleshooting from the global-cluster happy path
- keep external Registry detection and payload publication in Sync upgrade artifacts

## Stack

Depends on #1014. Retarget to master after the base PR is merged.

## Validation

- yarn lint docs
- git diff --check
- full local build was not awaited; review CI separately